### PR TITLE
Modify interpreter to use completion values

### DIFF
--- a/server/interpreter/cval.go
+++ b/server/interpreter/cval.go
@@ -26,8 +26,7 @@ import (
 type cvalType int
 
 const (
-	PLAIN cvalType = iota
-	NORMAL
+	NORMAL cvalType = iota
 	BREAK
 	CONTINUE
 	RETURN
@@ -37,12 +36,7 @@ const (
 // The cval type implements Completion Values, as defined in §8.9
 // of the ES5.1 spec.
 //
-// .typ is the type: NORMAL, BREAK, CONTINUE, RETURN, or THROW, or one
-// of two wpecial values:
-//
-// - PLAIN, indicating that this value represents a plain JavaScript
-// object as returned by an expression, rather than a completion value
-// as returned by a statement.
+// .typ is the type: NORMAL, BREAK, CONTINUE, RETURN, or THROW
 //
 // .val is the JavaScript value being returned (if any)
 //
@@ -53,43 +47,39 @@ type cval struct {
 	targ string
 }
 
-// The pval method tests to make sure the cval is a plain JavaScript
-// value (has .typ == NONE), and returns that value.
+// The pval method tests to make sure the cval is a plain (normal)
+// JavaScript value (has .typ == NORMAL, .targ == ""), and returns
+// that value.
 func (cv cval) pval() object.Value {
-	if cv.typ != PLAIN {
-		panic("expected plain JS value, not completion value")
+	if cv.typ != NORMAL || cv.targ != "" {
+		panic("expected NORMAL JS value")
 	}
 	return cv.val
 }
 
 // The abrupt method returns true if the cval is an abrupt completion,
-// i.e. has .typ other than NORMAL.  As a check against erroneous
-// usage, .typ == PLAIN (or any other invalid value) will panic.
+// i.e. has .typ other than NORMAL.
 func (cv cval) abrupt() bool {
 	if cv.typ == NORMAL {
 		return false
 	} else if cv.typ == BREAK || cv.typ == CONTINUE ||
 		cv.typ == RETURN || cv.typ == THROW {
 		return true
-	} else if cv.typ == PLAIN {
-		panic("not actually a completion value")
 	} else {
 		panic("invalid cval type")
 	}
 }
 
-// pval takes a plain JavaScript object and returns a pointer to a
-// cval with type PLAIN containing that value.
+// pval takes an ordinary JavaScript value and returns a pointer to a
+// cval with type NORMAL containing that value.
 func pval(v object.Value) *cval {
-	return &cval{PLAIN, v, ""}
+	return &cval{NORMAL, v, ""}
 }
 
 // GoString prints a cval in a readable format
 func (cv cval) GoString() string {
 	var t string
 	switch cv.typ {
-	case PLAIN:
-		t = "PLAIN"
 	case NORMAL:
 		t = "NORMAL"
 	case BREAK:

--- a/server/interpreter/cval.go
+++ b/server/interpreter/cval.go
@@ -1,0 +1,83 @@
+/* Copyright 2017 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"CodeCity/server/interpreter/object"
+)
+
+// cvalType is an enum of completion value types.
+type cvalType int
+
+const (
+	PLAIN cvalType = iota
+	NORMAL
+	BREAK
+	CONTINUE
+	RETURN
+	THROW
+)
+
+// The cval type implements Completion Values, as defined in §8.9
+// of the ES5.1 spec.
+//
+// .typ is the type: NORMAL, BREAK, CONTINUE, RETURN, or THROW, or one
+// of two wpecial values:
+//
+// - PLAIN, indicating that this value represents a plain JavaScript
+// object as returned by an expression, rather than a completion value
+// as returned by a statement.
+//
+// .val is the JavaScript value being returned (if any)
+//
+// .targ is the target label for a BREAK or CONTINUE
+type cval struct {
+	typ  cvalType
+	val  object.Value
+	targ string
+}
+
+// The pval method tests to make sure the cval is a plain JavaScript
+// value (has .typ == NONE), and returns that value.
+func (cv cval) pval() object.Value {
+	if cv.typ != PLAIN {
+		panic("expected plain JS value, not completion value")
+	}
+	return cv.val
+}
+
+// The abrupt method returns true if the cval is an abrupt completion,
+// i.e. has .typ other than NORMAL.  As a check against erroneous
+// usage, .typ == PLAIN (or any other invalid value) will panic.
+func (cv cval) abrupt() bool {
+	if cv.typ == NORMAL {
+		return false
+	} else if cv.typ == BREAK || cv.typ == CONTINUE ||
+		cv.typ == RETURN || cv.typ == THROW {
+		return true
+	} else if cv.typ == PLAIN {
+		panic("not actually a completion value")
+	} else {
+		panic("invalid cval type")
+	}
+}
+
+// pval takes a plain JavaScript object and returns a pointer to a
+// cval with type PLAIN containing that value.
+func pval(v object.Value) *cval {
+	return &cval{PLAIN, v, ""}
+}

--- a/server/interpreter/cval.go
+++ b/server/interpreter/cval.go
@@ -17,6 +17,8 @@
 package interpreter
 
 import (
+	"fmt"
+
 	"CodeCity/server/interpreter/object"
 )
 
@@ -80,4 +82,24 @@ func (cv cval) abrupt() bool {
 // cval with type PLAIN containing that value.
 func pval(v object.Value) *cval {
 	return &cval{PLAIN, v, ""}
+}
+
+// GoString prints a cval in a readable format
+func (cv cval) GoString() string {
+	var t string
+	switch cv.typ {
+	case PLAIN:
+		t = "PLAIN"
+	case NORMAL:
+		t = "NORMAL"
+	case BREAK:
+		t = "BREAK"
+	case CONTINUE:
+		t = "CONTINUE"
+	case RETURN:
+		t = "RETURN"
+	case THROW:
+		t = "THROW"
+	}
+	return fmt.Sprintf("{%s, %#v, %#v}", t, cv.val, cv.targ)
 }

--- a/server/interpreter/interpreter.go
+++ b/server/interpreter/interpreter.go
@@ -27,7 +27,7 @@ import (
 // Interpreter implements a JavaScript interpreter.
 type Interpreter struct {
 	state   state
-	value   object.Value
+	value   *cval
 	Verbose bool
 }
 
@@ -55,9 +55,9 @@ func (intrp *Interpreter) Step() bool {
 		return false
 	}
 	if intrp.Verbose {
-		fmt.Printf("Next step is a %T\n", intrp.state)
+		fmt.Printf("Next step is %T.step(%#v)\n", intrp.state, intrp.value)
 	}
-	intrp.state = intrp.state.step()
+	intrp.state, intrp.value = intrp.state.step(intrp.value)
 	return true
 }
 
@@ -70,14 +70,8 @@ func (intrp *Interpreter) Run() {
 // Value returns the final value computed by the last statement
 // expression of the program.
 func (intrp *Interpreter) Value() object.Value {
-	return intrp.value
-}
-
-// acceptValue receives values computed by StatementExpressions; the
-// last such value accepted is the completion value of the program.
-func (intrp *Interpreter) acceptValue(v object.Value) {
-	if intrp.Verbose {
-		fmt.Printf("Interpreter just got %v.\n", v)
+	if intrp.value == nil {
+		return nil
 	}
-	intrp.value = v
+	return intrp.value.val
 }

--- a/server/interpreter/interpreter.go
+++ b/server/interpreter/interpreter.go
@@ -52,6 +52,14 @@ func New(astJSON string) *Interpreter {
 // true if a step was executed; false if the program has terminated.
 func (intrp *Interpreter) Step() bool {
 	if intrp.state == nil {
+		switch intrp.value.typ {
+		case BREAK:
+			panic(fmt.Errorf("illegal break to %s", intrp.value.targ))
+		case CONTINUE:
+			panic(fmt.Errorf("illegal continue of %s", intrp.value.targ))
+		case THROW:
+			panic(fmt.Errorf("unhandled exception %s", intrp.value.val))
+		}
 		return false
 	}
 	if intrp.Verbose {

--- a/server/interpreter/interpreter_test.go
+++ b/server/interpreter/interpreter_test.go
@@ -62,11 +62,13 @@ func TestInterpreterSimple(t *testing.T) {
 		{"foo:break foo", selfBreak, nil}, // NO completion value
 		{"var a=6;foo:{try{a*=10;break foo}finally{a--}};a",
 			breakWithFinally, object.Number(59)},
+		{"var a=0;for(var i=0;i<60;i++){try{continue;}finally{a++;}};a",
+			continueWithFinally, object.Number(60)},
 	}
 
 	for _, c := range tests {
 		i := New(c.src)
-		// if c.src == breakWithFinally {
+		// if c.src == continueWithFinally {
 		// 	i.Verbose = true
 		// }
 		i.Run()
@@ -284,6 +286,18 @@ const selfBreak = `{"type":"Program","start":0,"end":14,"body":[{"type":"Labeled
 // a
 // => 59
 const breakWithFinally = `{"type":"Program","start":0,"end":102,"body":[{"type":"VariableDeclaration","start":0,"end":9,"declarations":[{"type":"VariableDeclarator","start":4,"end":9,"id":{"type":"Identifier","start":4,"end":5,"name":"a"},"init":{"type":"Literal","start":8,"end":9,"value":6,"raw":"6"}}],"kind":"var"},{"type":"LabeledStatement","start":10,"end":100,"body":{"type":"BlockStatement","start":15,"end":100,"body":[{"type":"TryStatement","start":21,"end":98,"block":{"type":"BlockStatement","start":25,"end":66,"body":[{"type":"ExpressionStatement","start":35,"end":42,"expression":{"type":"AssignmentExpression","start":35,"end":42,"operator":"*=","left":{"type":"Identifier","start":35,"end":36,"name":"a"},"right":{"type":"Literal","start":40,"end":42,"value":10,"raw":"10"}}},{"type":"BreakStatement","start":51,"end":60,"label":{"type":"Identifier","start":57,"end":60,"name":"foo"}}]},"handler":null,"guardedHandlers":[],"finalizer":{"type":"BlockStatement","start":79,"end":98,"body":[{"type":"ExpressionStatement","start":89,"end":92,"expression":{"type":"UpdateExpression","start":89,"end":92,"operator":"--","prefix":false,"argument":{"type":"Identifier","start":89,"end":90,"name":"a"}}}]}}]},"label":{"type":"Identifier","start":10,"end":13,"name":"foo"}},{"type":"ExpressionStatement","start":101,"end":102,"expression":{"type":"Identifier","start":101,"end":102,"name":"a"}}]}`
+
+// var a = 59;
+// do {
+//   try {
+//     continue;
+//   } finally {
+//     a++;
+//   }
+// } while(false)
+// a
+// => 60
+const continueWithFinally = `{"type":"Program","start":0,"end":82,"body":[{"type":"VariableDeclaration","start":0,"end":11,"declarations":[{"type":"VariableDeclarator","start":4,"end":10,"id":{"type":"Identifier","start":4,"end":5,"name":"a"},"init":{"type":"Literal","start":8,"end":10,"value":59,"raw":"59"}}],"kind":"var"},{"type":"DoWhileStatement","start":12,"end":80,"body":{"type":"BlockStatement","start":15,"end":67,"body":[{"type":"TryStatement","start":19,"end":65,"block":{"type":"BlockStatement","start":23,"end":42,"body":[{"type":"ContinueStatement","start":29,"end":38,"label":null}]},"handler":null,"guardedHandlers":[],"finalizer":{"type":"BlockStatement","start":51,"end":65,"body":[{"type":"ExpressionStatement","start":57,"end":61,"expression":{"type":"UpdateExpression","start":57,"end":60,"operator":"++","prefix":false,"argument":{"type":"Identifier","start":57,"end":58,"name":"a"}}}]}}]},"test":{"type":"Literal","start":74,"end":79,"value":false,"raw":"false"}},{"type":"ExpressionStatement","start":81,"end":82,"expression":{"type":"Identifier","start":81,"end":82,"name":"a"}}]}`
 
 // ({foo: "bar", answer: 42})
 // => {foo: "bar", answer: 42}

--- a/server/interpreter/interpreter_test.go
+++ b/server/interpreter/interpreter_test.go
@@ -62,7 +62,7 @@ func TestInterpreterSimple(t *testing.T) {
 		{"foo:break foo", selfBreak, nil}, // NO completion value
 		{"var a=6;foo:{try{a*=10;break foo}finally{a--}};a",
 			breakWithFinally, object.Number(59)},
-		{"var a=0;for(var i=0;i<60;i++){try{continue;}finally{a++;}};a",
+		{"var a=59;do {try{continue}finally{a++}}while(false);a",
 			continueWithFinally, object.Number(60)},
 	}
 

--- a/server/interpreter/interpreter_test.go
+++ b/server/interpreter/interpreter_test.go
@@ -64,11 +64,16 @@ func TestInterpreterSimple(t *testing.T) {
 			breakWithFinally, object.Number(59)},
 		{"var a=59;do {try{continue}finally{a++}}while(false);a",
 			continueWithFinally, object.Number(60)},
+		{"var a=0;while(a++<60){try{break}finally{continue}};a",
+			breakWithFinallyContinue, object.Number(61)},
+		{"(function(){var i=0;while(i++<61){try{return 42}" +
+			"finally{continue}}return i})()",
+			returnWithFinallyContinue, object.Number(62)},
 	}
 
 	for _, c := range tests {
 		i := New(c.src)
-		// if c.src == continueWithFinally {
+		// if c.src == returnWithFinallyContinue {
 		// 	i.Verbose = true
 		// }
 		i.Run()
@@ -299,6 +304,32 @@ const breakWithFinally = `{"type":"Program","start":0,"end":102,"body":[{"type":
 // => 60
 const continueWithFinally = `{"type":"Program","start":0,"end":82,"body":[{"type":"VariableDeclaration","start":0,"end":11,"declarations":[{"type":"VariableDeclarator","start":4,"end":10,"id":{"type":"Identifier","start":4,"end":5,"name":"a"},"init":{"type":"Literal","start":8,"end":10,"value":59,"raw":"59"}}],"kind":"var"},{"type":"DoWhileStatement","start":12,"end":80,"body":{"type":"BlockStatement","start":15,"end":67,"body":[{"type":"TryStatement","start":19,"end":65,"block":{"type":"BlockStatement","start":23,"end":42,"body":[{"type":"ContinueStatement","start":29,"end":38,"label":null}]},"handler":null,"guardedHandlers":[],"finalizer":{"type":"BlockStatement","start":51,"end":65,"body":[{"type":"ExpressionStatement","start":57,"end":61,"expression":{"type":"UpdateExpression","start":57,"end":60,"operator":"++","prefix":false,"argument":{"type":"Identifier","start":57,"end":58,"name":"a"}}}]}}]},"test":{"type":"Literal","start":74,"end":79,"value":false,"raw":"false"}},{"type":"ExpressionStatement","start":81,"end":82,"expression":{"type":"Identifier","start":81,"end":82,"name":"a"}}]}`
 
-// ({foo: "bar", answer: 42})
+// var a = 0
+// while(a++ < 60) {
+//   try {
+//     break;
+//   } finally {
+//     continue;
+//   }
+// }
+// a
+// => 61
+const breakWithFinallyContinue = `{"type":"Program","start":0,"end":82,"body":[{"type":"VariableDeclaration","start":0,"end":9,"declarations":[{"type":"VariableDeclarator","start":4,"end":9,"id":{"type":"Identifier","start":4,"end":5,"name":"a"},"init":{"type":"Literal","start":8,"end":9,"value":0,"raw":"0"}}],"kind":"var"},{"type":"WhileStatement","start":10,"end":80,"test":{"type":"BinaryExpression","start":16,"end":24,"left":{"type":"UpdateExpression","start":16,"end":19,"operator":"++","prefix":false,"argument":{"type":"Identifier","start":16,"end":17,"name":"a"}},"operator":"<","right":{"type":"Literal","start":22,"end":24,"value":60,"raw":"60"}},"body":{"type":"BlockStatement","start":26,"end":80,"body":[{"type":"TryStatement","start":30,"end":78,"block":{"type":"BlockStatement","start":34,"end":50,"body":[{"type":"BreakStatement","start":40,"end":46,"label":null}]},"handler":null,"guardedHandlers":[],"finalizer":{"type":"BlockStatement","start":59,"end":78,"body":[{"type":"ContinueStatement","start":65,"end":74,"label":null}]}}]}},{"type":"ExpressionStatement","start":81,"end":82,"expression":{"type":"Identifier","start":81,"end":82,"name":"a"}}]}`
+
+// (function(){
+//   var i = 0
+//   while(i++ < 61) {
+//     try {
+//       return 42;
+//     } finally {
+//       continue;
+//     }
+//   }
+//   return i;
+// })();
+// => 62
+const returnWithFinallyContinue = `{"type":"Program","start":0,"end":131,"body":[{"type":"ExpressionStatement","start":0,"end":131,"expression":{"type":"CallExpression","start":0,"end":130,"callee":{"type":"FunctionExpression","start":0,"end":128,"id":null,"params":[],"body":{"type":"BlockStatement","start":11,"end":127,"body":[{"type":"VariableDeclaration","start":15,"end":24,"declarations":[{"type":"VariableDeclarator","start":19,"end":24,"id":{"type":"Identifier","start":19,"end":20,"name":"i"},"init":{"type":"Literal","start":23,"end":24,"value":0,"raw":"0"}}],"kind":"var"},{"type":"WhileStatement","start":27,"end":113,"test":{"type":"BinaryExpression","start":33,"end":41,"left":{"type":"UpdateExpression","start":33,"end":36,"operator":"++","prefix":false,"argument":{"type":"Identifier","start":33,"end":34,"name":"i"}},"operator":"<","right":{"type":"Literal","start":39,"end":41,"value":61,"raw":"61"}},"body":{"type":"BlockStatement","start":43,"end":113,"body":[{"type":"TryStatement","start":49,"end":109,"block":{"type":"BlockStatement","start":53,"end":77,"body":[{"type":"ReturnStatement","start":61,"end":71,"argument":{"type":"Literal","start":68,"end":70,"value":42,"raw":"42"}}]},"handler":null,"guardedHandlers":[],"finalizer":{"type":"BlockStatement","start":86,"end":109,"body":[{"type":"ContinueStatement","start":94,"end":103,"label":null}]}}]}},{"type":"ReturnStatement","start":116,"end":125,"argument":{"type":"Identifier","start":123,"end":124,"name":"i"}}]}},"arguments":[]}}]}`
+
+// ({Foo: "bar", answer: 42})
 // => {foo: "bar", answer: 42}
 const objectExpression = `{"type":"Program","start":0,"end":26,"body":[{"type":"ExpressionStatement","start":0,"end":26,"expression":{"type":"ObjectExpression","start":0,"end":26,"properties":[{"key":{"type":"Identifier","start":2,"end":5,"name":"foo"},"value":{"type":"Literal","start":7,"end":12,"value":"bar","raw":"\"bar\""},"kind":"init"},{"key":{"type":"Identifier","start":14,"end":20,"name":"answer"},"value":{"type":"Literal","start":22,"end":24,"value":42,"raw":"42"},"kind":"init"}]}}]}`

--- a/server/interpreter/scope.go
+++ b/server/interpreter/scope.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-// Package interpreter implements a JavaScript interpreter.
 package interpreter
 
 import (

--- a/server/interpreter/state.go
+++ b/server/interpreter/state.go
@@ -265,11 +265,10 @@ func (st *stateAssignmentExpression) step(cv *cval) (state, *cval) {
 		return st.parent, cv
 	}
 
-	// Do (operator)assignment:
 	var r object.Value = cv.pval()
-	if st.op == "=" {
-		// nothing extra to do
-	} else {
+
+	// Do (operator)assignment:
+	if st.op != "=" {
 		var op string
 		switch st.op {
 		case "+=":

--- a/server/interpreter/state.go
+++ b/server/interpreter/state.go
@@ -921,6 +921,7 @@ func (st *stateUpdateExpression) step(cv *cval) (state, *cval) {
 	if st.prefix {
 		r = n
 	}
+	st.arg.set(n)
 	return st.parent, pval(r)
 }
 

--- a/server/interpreter/state.go
+++ b/server/interpreter/state.go
@@ -1015,13 +1015,11 @@ type stateWhileStatement struct {
 }
 
 func (st *stateWhileStatement) init(node *ast.WhileStatement) {
-	st.addLabel("")
 	st.test = node.Test
 	st.body = node.Body
 }
 
 func (st *stateWhileStatement) initFromDoWhile(node *ast.DoWhileStatement) {
-	st.addLabel("")
 	st.test = node.Test
 	st.body = node.Body
 	st.tested = true
@@ -1045,7 +1043,7 @@ func (st *stateWhileStatement) step(cv *cval) (state, *cval) {
 	}
 	// At this point cv is cval from body.
 	st.val = cv.val
-	if cv.typ != CONTINUE || !st.hasLabel(cv.targ) {
+	if cv.typ != CONTINUE || !(cv.targ == "" || st.hasLabel(cv.targ)) {
 		if cv.typ == BREAK && (cv.targ == "" || st.hasLabel(cv.targ)) {
 			return st.parent, &cval{NORMAL, st.val, ""}
 		} else if cv.abrupt() {

--- a/server/interpreter/state.go
+++ b/server/interpreter/state.go
@@ -415,10 +415,10 @@ func (st *stateCallExpression) step(cv *cval) (state, *cval) {
 			fmt.Printf("sCE: first visit: eval function\n")
 		}
 		if st.ns != nil {
-			panic("have scope already???")
+			panic("have scope already??")
 		}
 		if st.cl != nil {
-			panic("have closure already???")
+			panic("have closure already??")
 		}
 		return newState(st, st.scope, st.callee.E), nil
 	} else if cv.abrupt() {
@@ -898,7 +898,7 @@ func (st *stateTryStatement) init(node *ast.TryStatement) {
 func (st *stateTryStatement) step(cv *cval) (state, *cval) {
 	if cv == nil {
 		if st.handled || st.finalized {
-			panic("done block or catch before begun?")
+			panic("done block or catch before begun??")
 		}
 		return newState(st, st.scope, st.block), nil
 	}


### PR DESCRIPTION
All existing tests pass.  Net change: -131 lines.

I could just merge the branch myself, but I figure you should have a look at it before I do, since this represents the biggest change yet to the architecture of the interpreter (compared to JS-interpreter).