### PR TITLE
Introduce boxed primitives

### DIFF
--- a/server/interpreter/builtin_array.go
+++ b/server/interpreter/builtin_array.go
@@ -22,12 +22,12 @@ import (
 	"encoding/json"
 )
 
-func initBuiltinArray(sc *scope) {
-	// FIXME: should be Function:
-	var Array = data.NewObject(nil, data.ObjectProto)
+func initBuiltinArray(protos *data.Protos, sc *scope) {
+	// FIXME: should be Function?:
+	var Array = data.NewObject(nil, protos.FunctionProto)
 	sc.newVar("Array", Array)
 
-	Array.Set("prototype", data.ArrayProto)
+	Array.Set("prototype", protos.ArrayProto)
 
 	var params []*ast.Identifier
 	var body *ast.BlockStatement
@@ -40,8 +40,9 @@ func initBuiltinArray(sc *scope) {
 	if e != nil {
 		panic(e)
 	}
-	var push = newClosure(nil, sc, params, body)
-	data.ArrayProto.Set("push", push)
+	// FIXME: set owner:
+	var push = newClosure(nil, protos.FunctionProto, sc, params, body)
+	protos.ArrayProto.Set("push", push)
 }
 
 const pushPolyfillParams = `[{"type":"Identifier","start":32,"end":33,"name":"e"}]`

--- a/server/interpreter/builtin_array.go
+++ b/server/interpreter/builtin_array.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 )
 
-func initArrayProto(sc *scope) {
+func initBuiltinArray(sc *scope) {
 	// FIXME: should be Function:
 	var Array = data.NewObject(nil, data.ObjectProto)
 	sc.newVar("Array", Array)

--- a/server/interpreter/builtin_array_test.go
+++ b/server/interpreter/builtin_array_test.go
@@ -31,5 +31,3 @@ func TestInitArrayProto(t *testing.T) {
 		t.Errorf("Array.prototype.push is a %T (expected *closure)", cl)
 	}
 }
-
-const emptyProg = `{"type":"Program","start":0,"end":0,"body":[]}`

--- a/server/interpreter/builtin_array_test.go
+++ b/server/interpreter/builtin_array_test.go
@@ -17,15 +17,16 @@
 package interpreter
 
 import (
-	//"CodeCity/server/interpreter/data"
 	"testing"
+
+	"CodeCity/server/interpreter/data"
 )
 
 func TestInitArrayProto(t *testing.T) {
 	i, _ := NewFromJSON(emptyProg)
-	ap, _ := i.state.(*stateBlockStatement).scope.getVar("Array").
+	ap, _ := i.state.(*stateBlockStatement).scope.getVar("Array").(data.Object).
 		Get("prototype")
-	push, _ := ap.Get("push")
+	push, _ := ap.(data.Object).Get("push")
 	cl, isClosure := push.(*closure)
 	if !isClosure {
 		t.Errorf("Array.prototype.push is a %T (expected *closure)", cl)

--- a/server/interpreter/builtin_object.go
+++ b/server/interpreter/builtin_object.go
@@ -1,0 +1,29 @@
+/* Copyright 2017 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package interpreter
+
+import (
+	"CodeCity/server/interpreter/data"
+)
+
+func initBuiltinObject(sc *scope) {
+	// FIXME: should be Function:
+	var Object = data.NewObject(nil, data.ObjectProto)
+	sc.newVar("Object", Object)
+
+	Object.Set("prototype", data.ObjectProto)
+}

--- a/server/interpreter/builtin_object.go
+++ b/server/interpreter/builtin_object.go
@@ -20,10 +20,9 @@ import (
 	"CodeCity/server/interpreter/data"
 )
 
-func initBuiltinObject(sc *scope) {
-	// FIXME: should be Function:
-	var Object = data.NewObject(nil, data.ObjectProto)
+func initBuiltinObject(protos *data.Protos, sc *scope) {
+	var Object = data.NewObject(nil, protos.ObjectProto)
 	sc.newVar("Object", Object)
 
-	Object.Set("prototype", data.ObjectProto)
+	Object.Set("prototype", protos.ObjectProto)
 }

--- a/server/interpreter/closure.go
+++ b/server/interpreter/closure.go
@@ -45,7 +45,7 @@ func (closure) ToString() data.String {
 func newClosure(owner *data.Owner, scope *scope,
 	params []*ast.Identifier, body *ast.BlockStatement) *closure {
 	var cl = new(closure)
-	cl.Object = *data.NewObject(owner, functionProto)
+	cl.Object = data.NewObject(owner, functionProto)
 	cl.scope = scope
 	cl.Set("length", data.Number(len(params)))
 	cl.params = make([]string, len(params))

--- a/server/interpreter/closure.go
+++ b/server/interpreter/closure.go
@@ -42,10 +42,10 @@ func (closure) ToString() data.String {
 
 // newClosure returns a new closure object with the specified owner,
 // scope and body, having parent functionProto.
-func newClosure(owner *data.Owner, scope *scope,
+func newClosure(owner *data.Owner, proto data.Object, scope *scope,
 	params []*ast.Identifier, body *ast.BlockStatement) *closure {
 	var cl = new(closure)
-	cl.Object = data.NewObject(owner, functionProto)
+	cl.Object = data.NewObject(owner, proto)
 	cl.scope = scope
 	cl.Set("length", data.Number(len(params)))
 	cl.params = make([]string, len(params))
@@ -55,8 +55,3 @@ func newClosure(owner *data.Owner, scope *scope,
 	cl.body = body
 	return cl
 }
-
-// functionProto is the the (plain) JavaScript object that is the
-// prototype for all closures.  (It would usually be accessed in
-// JavaScript as Function.prototype.)
-var functionProto = data.NewObject(nil, data.ObjectProto)

--- a/server/interpreter/data/array.go
+++ b/server/interpreter/data/array.go
@@ -23,18 +23,18 @@ import (
 // An Array is an object with a magic .length property and some other
 // minor special features.
 type Array struct {
-	Object
+	object
 	length uint32
 }
 
-// *Array must satisfy Value.
-var _ Value = (*Array)(nil)
+// *Array must satisfy Object.
+var _ Object = (*Array)(nil)
 
 // Get on Array implements a magic .length property itself, and passes
-// any other property lookups to its embedded Object.
+// any other property lookups to its embedded object.
 func (arr *Array) Get(name string) (Value, *ErrorMsg) {
 	if name != "length" {
-		return arr.Object.Get(name)
+		return arr.object.Get(name)
 	}
 	return Number(float64(arr.length)), nil
 }
@@ -46,7 +46,7 @@ func (arr *Array) Get(name string) (Value, *ErrorMsg) {
 //
 // Otherwise, it will:
 //
-// - Delegates setting the specified property to its embedded Object.
+// - Delegates setting the specified property to its embedded object.
 // - If this succeeds, and the property name looks like an array
 // index, then it will udpate .length appropriately.
 func (arr *Array) Set(name string, value Value) *ErrorMsg {
@@ -63,7 +63,7 @@ func (arr *Array) Set(name string, value Value) *ErrorMsg {
 		}
 		return nil
 	}
-	err := arr.Object.Set(name, value)
+	err := arr.object.Set(name, value)
 	if err == nil {
 		if i, isIndex := asIndex(name); isIndex && arr.length < i+1 {
 			arr.length = i + 1
@@ -74,12 +74,12 @@ func (arr *Array) Set(name string, value Value) *ErrorMsg {
 
 // propNames returns the list of property names (starting with
 // "length"); for efficiency this is done directly rather than by
-// calling the propNames method on the embedded Object.
+// calling the propNames method on the embedded object.
 func (arr *Array) propNames() []string {
-	names := make([]string, len(arr.Object.properties)+1)
+	names := make([]string, len(arr.object.properties)+1)
 	names[0] = "length"
 	i := 1
-	for k := range arr.Object.properties {
+	for k := range arr.object.properties {
 		names[i] = k
 		i++
 	}
@@ -87,31 +87,31 @@ func (arr *Array) propNames() []string {
 }
 
 // Delete will reject attempts to remove "length" and otherwise defers
-// to the embedded Object.
+// to the embedded object.
 func (arr *Array) Delete(name string) *ErrorMsg {
 	if name == "length" {
 		return &ErrorMsg{"TypeError",
 			"Cannot delete property 'length' of array."}
 	}
-	return arr.Object.Delete(name)
+	return arr.object.Delete(name)
 }
 
 // HasOwnProperty returns true if the property name is "length" or if
-// the embedded Object has it.
+// the embedded object has it.
 func (arr Array) HasOwnProperty(s string) bool {
 	if s == "length" {
 		return true
 	}
-	return arr.Object.HasOwnProperty(s)
+	return arr.object.HasOwnProperty(s)
 }
 
 // HasProperty returns true if the property name is "length" or if the
-// embedded Object (or its prototype(s)) has it.
+// embedded object (or its prototype(s)) has it.
 func (arr Array) HasProperty(s string) bool {
 	if s == "length" {
 		return true
 	}
-	return arr.Object.HasProperty(s)
+	return arr.object.HasProperty(s)
 }
 
 // ToString returns a string containing a comma-separated
@@ -128,19 +128,13 @@ func (arr Array) ToString() String {
 // NewArray creates a new Array with the specified owner and
 // prototype, initialises it as appropriate, and returns a pointer to
 // the newly-created object.
-func NewArray(owner *Owner, proto Value) *Array {
+func NewArray(owner *Owner, proto Object) *Array {
 	var arr = new(Array)
 	arr.init(owner, proto)
 	arr.f = true
 	arr.length = 0
 	return arr
 }
-
-// ArrayProto is the default prototype for JavaScript arrays (i.e.,
-// ones created from array literals or via Array() and not had their
-// prototype subsequently changed).  It is itself an array with
-// prototype ObjectProto.
-var ArrayProto = NewArray(nil, ObjectProto)
 
 /********************************************************************/
 

--- a/server/interpreter/data/array.go
+++ b/server/interpreter/data/array.go
@@ -32,25 +32,25 @@ var _ Object = (*Array)(nil)
 
 // Get on Array implements a magic .length property itself, and passes
 // any other property lookups to its embedded object.
-func (arr *Array) Get(name string) (Value, *ErrorMsg) {
-	if name != "length" {
-		return arr.object.Get(name)
+func (arr *Array) Get(key string) (Value, *ErrorMsg) {
+	if key != "length" {
+		return arr.object.Get(key)
 	}
 	return Number(float64(arr.length)), nil
 }
 
-// Set on Array will, if name == "length":
+// Set on Array will, if key == "length":
 //
 // - Update .length be the specified length.
-// - Delete any properties whose names are indexes and >= .length
+// - Delete any properties whose keys are indexes and >= .length
 //
 // Otherwise, it will:
 //
 // - Delegates setting the specified property to its embedded object.
-// - If this succeeds, and the property name looks like an array
+// - If this succeeds, and the property key looks like an array
 // index, then it will udpate .length appropriately.
-func (arr *Array) Set(name string, value Value) *ErrorMsg {
-	if name == "length" {
+func (arr *Array) Set(key string, value Value) *ErrorMsg {
+	if key == "length" {
 		l, ok := asLength(value)
 		if !ok {
 			return &ErrorMsg{"Range Error", "Invalid array length"}
@@ -63,40 +63,40 @@ func (arr *Array) Set(name string, value Value) *ErrorMsg {
 		}
 		return nil
 	}
-	err := arr.object.Set(name, value)
+	err := arr.object.Set(key, value)
 	if err == nil {
-		if i, isIndex := asIndex(name); isIndex && arr.length < i+1 {
+		if i, isIndex := asIndex(key); isIndex && arr.length < i+1 {
 			arr.length = i + 1
 		}
 	}
 	return err
 }
 
-// propNames returns the list of property names (starting with
+// OwnPropertyKeys returns the list of property keys (starting with
 // "length"); for efficiency this is done directly rather than by
-// calling the propNames method on the embedded object.
-func (arr *Array) propNames() []string {
-	names := make([]string, len(arr.object.properties)+1)
-	names[0] = "length"
+// calling the propKeys method on the embedded object.
+func (arr *Array) OwnPropertyKeys() []string {
+	keys := make([]string, len(arr.object.properties)+1)
+	keys[0] = "length"
 	i := 1
 	for k := range arr.object.properties {
-		names[i] = k
+		keys[i] = k
 		i++
 	}
-	return names
+	return keys
 }
 
 // Delete will reject attempts to remove "length" and otherwise defers
 // to the embedded object.
-func (arr *Array) Delete(name string) *ErrorMsg {
-	if name == "length" {
+func (arr *Array) Delete(key string) *ErrorMsg {
+	if key == "length" {
 		return &ErrorMsg{"TypeError",
 			"Cannot delete property 'length' of array."}
 	}
-	return arr.object.Delete(name)
+	return arr.object.Delete(key)
 }
 
-// HasOwnProperty returns true if the property name is "length" or if
+// HasOwnProperty returns true if the property key is "length" or if
 // the embedded object has it.
 func (arr Array) HasOwnProperty(s string) bool {
 	if s == "length" {
@@ -105,7 +105,7 @@ func (arr Array) HasOwnProperty(s string) bool {
 	return arr.object.HasOwnProperty(s)
 }
 
-// HasProperty returns true if the property name is "length" or if the
+// HasProperty returns true if the property key is "length" or if the
 // embedded object (or its prototype(s)) has it.
 func (arr Array) HasProperty(s string) bool {
 	if s == "length" {
@@ -138,7 +138,7 @@ func NewArray(owner *Owner, proto Object) *Array {
 
 /********************************************************************/
 
-// asIndex takes a property name (as a string) and checks to see if it
+// asIndex takes a property key (as a string) and checks to see if it
 // qualifies as an array index (according to the definition given in
 // §15.4 of the ES5.1 spec).  If it does, it returns the index and
 // true; if not it return 0 and false.

--- a/server/interpreter/data/array_test.go
+++ b/server/interpreter/data/array_test.go
@@ -91,8 +91,8 @@ func TestArray(t *testing.T) {
 	if !a.HasProperty("length") {
 		t.Errorf("%v.HasProperty(\"length\") == false", a)
 	}
-	if props := a.propNames(); len(props) != 1 || props[0] != "length" {
-		t.Errorf("%v.propNames == %#v (expected [\"length\"])", a, props)
+	if props := a.OwnPropertyKeys(); len(props) != 1 || props[0] != "length" {
+		t.Errorf("%v.OwnPropertyKeys == %#v (expected [\"length\"])", a, props)
 	}
 	if a.Delete("length") == nil {
 		t.Error("delete([].length) failed to report error")
@@ -183,7 +183,7 @@ func TestArrayLength(t *testing.T) {
 	check(math.MaxUint32+1, true)
 
 	// Setting length one less than maximum should remove largest
-	// index, but leave properties with names too large to be indexes:
+	// index, but leave properties with keys too large to be indexes:
 	setLen(math.MaxUint32 - 1)
 	check(math.MaxUint32-2, true)
 	check(math.MaxUint32-1, false)
@@ -192,13 +192,13 @@ func TestArrayLength(t *testing.T) {
 
 	// Setting length to zero should remove all index properties:
 	setLen(0)
-	for _, p := range a.propNames() {
+	for _, p := range a.OwnPropertyKeys() {
 		if _, isIndex := asIndex(p); isIndex {
 			t.Errorf("Setting .lengh == 0 failed to remove property %#v", p)
 		}
 	}
 	// Make sure we didn't wipe everything!
-	if len(a.propNames()) <= 1 {
+	if len(a.OwnPropertyKeys()) <= 1 {
 		t.Errorf("Setting .lengh == 0 seems to have removed some" +
 			"non-index properties")
 	}

--- a/server/interpreter/data/array_test.go
+++ b/server/interpreter/data/array_test.go
@@ -72,7 +72,7 @@ func TestAsLength(t *testing.T) {
 
 		{Null{}, 0, true},
 		{Undefined{}, 0, false},
-		{NewObject(nil, ObjectProto), 0, false},
+		{NewObject(nil, protos.ObjectProto), 0, false},
 	}
 	for _, c := range tests {
 		out, ok := asLength(c.in)
@@ -84,7 +84,7 @@ func TestAsLength(t *testing.T) {
 }
 
 func TestArray(t *testing.T) {
-	a := NewArray(nil, ArrayProto)
+	a := NewArray(nil, protos.ArrayProto)
 	if !a.HasOwnProperty("length") {
 		t.Errorf("%v.HasOwnProperty(\"length\") == false", a)
 	}
@@ -97,16 +97,16 @@ func TestArray(t *testing.T) {
 	if a.Delete("length") == nil {
 		t.Error("delete([].length) failed to report error")
 	}
-	if a.Proto() != Value(ArrayProto) {
+	if a.Proto() != Value(protos.ArrayProto) {
 		t.Errorf("%v.Proto() != ArrayProto", a)
 	}
-	if a.Proto().Proto() != Value(ObjectProto) {
+	if a.Proto().Proto() != Value(protos.ObjectProto) {
 		t.Errorf("%v.Proto().Proto() != ObjectProto", a)
 	}
 }
 
 func TestArrayLength(t *testing.T) {
-	a := NewArray(nil, ArrayProto)
+	a := NewArray(nil, protos.ArrayProto)
 
 	set := func(n int64, v Value) {
 		err := a.Set(fmt.Sprintf("%d", n), v)

--- a/server/interpreter/data/boxes.go
+++ b/server/interpreter/data/boxes.go
@@ -1,0 +1,219 @@
+/* Copyright 2017 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import (
+	"fmt"
+)
+
+/********************************************************************/
+
+// BoxedBoolean is a boxed Boolean.
+type BoxedBoolean struct {
+	object
+	value Boolean
+}
+
+// *BoxedBoolean must satisfy Object.
+var _ Object = (*BoxedBoolean)(nil)
+
+// ToBoolean has no special behaviour on BoxedBooleans: it returns
+// true, as for any other object.
+
+// ToNumber on a BoxedBoolean just returns the same value as on the
+// boxed Boolean.
+func (bbool *BoxedBoolean) ToNumber() Number {
+	return bbool.value.ToNumber()
+}
+
+// ToString returns a string representation of the boxed Boolean.
+//
+// BUG(cpcallen): ToString should call a user-code toString() method
+// if present.
+func (bbool *BoxedBoolean) ToString() String {
+	return bbool.value.ToString()
+}
+
+// ToPrimitive returns the contained Boolean on BoxedBoolean objects.
+func (bbool *BoxedBoolean) ToPrimitive() Value {
+	return bbool.value
+}
+
+// NewBoxedBoolean creates a new object with the specified owner and
+// prototype, initialises it as appropriate, and returns a pointer to
+// the newly-created object.
+func NewBoxedBoolean(owner *Owner, proto Object, value Boolean) *BoxedBoolean {
+	var bbool = new(BoxedBoolean)
+	bbool.init(owner, proto)
+	bbool.f = true
+	bbool.value = value
+	return bbool
+}
+
+/********************************************************************/
+
+// BoxedNumber is a boxed Number.
+type BoxedNumber struct {
+	object
+	value Number
+}
+
+// *BoxedNumber must satisfy Object.
+var _ Object = (*BoxedNumber)(nil)
+
+// ToBoolean has no special behaviour on BoxedNumbers: it returns
+// true, as for any other object.
+
+// ToNumber on a BoxedNumber just returns the boxed Number itself.
+func (bnum *BoxedNumber) ToNumber() Number {
+	return bnum.value
+}
+
+// ToString on a BoxedNumber just returns the same value as on the
+// boxed Number.
+func (bnum *BoxedNumber) ToString() String {
+	return bnum.value.ToString()
+}
+
+// ToPrimitive returns the contained Number on BoxedNumber objects.
+func (bnum *BoxedNumber) ToPrimitive() Value {
+	return bnum.value
+}
+
+// NewBoxedNumber creates a new object with the specified owner and
+// prototype, initialises it as appropriate, and returns a pointer to
+// the newly-created object.
+func NewBoxedNumber(owner *Owner, proto Object, value Number) *BoxedNumber {
+	var bnum = new(BoxedNumber)
+	bnum.init(owner, proto)
+	bnum.f = true
+	bnum.value = value
+	return bnum
+}
+
+/********************************************************************/
+
+// BoxedString is a boxed String.
+type BoxedString struct {
+	object
+	value String
+}
+
+// *BoxedString must satisfy Object.
+var _ Object = (*BoxedString)(nil)
+
+// Get on BoxedString implements magic .length and numeric character
+// index properties on itself, and delegates any other property
+// lookups to its embedded object.
+//
+// BUG(cpcallen): character indicides not implemented.
+func (bstr *BoxedString) Get(key string) (Value, *ErrorMsg) {
+	if key == "length" {
+		return Number(bstr.value.utf16len()), nil
+	}
+	return bstr.object.Get(key)
+}
+
+// Set on BoxedString will reject attempts to set .length or numeric
+// character indicies, and otherwise delegates to the embedded object.
+//
+// BUG(cpcallen): character indicides not implemented.
+func (bstr *BoxedString) Set(key string, value Value) *ErrorMsg {
+	if key == "length" {
+		return &ErrorMsg{"TypeError",
+			fmt.Sprintf("Cannot assign to read only property '%s' of %s",
+				key, bstr.ToString())}
+	}
+	return bstr.object.Set(key, value)
+}
+
+// Delete on BoxedString will refuse to delete "length" and numeric
+// character indicies, and otherwise defers to the embedded object.
+//
+// BUG(cpcallen): character indicides not implemented.
+func (bstr *BoxedString) Delete(key string) *ErrorMsg {
+	if key == "length" {
+		return &ErrorMsg{"TypeError",
+			fmt.Sprintf("Cannot delete property '%s' of %s",
+				key, bstr.ToString())}
+	}
+	return bstr.object.Delete(key)
+}
+
+// OwnPropertyKeys on BoxedString returns the length and numeric
+// character indicies plus any properties defined on the embedded
+// object.
+//
+// BUG(cpcallen): character indicides not implemented.
+func (bstr *BoxedString) OwnPropertyKeys() []string {
+	return append([]string{"length"}, bstr.object.OwnPropertyKeys()...)
+}
+
+// HasOwnProperty on BoxedString returns true for "length" and false for all
+// other inputs for BoxedStrings.
+//
+// BUG(cpcallen): character indicides not implemented.
+func (bstr *BoxedString) HasOwnProperty(key string) bool {
+	if key == "length" {
+		return true
+	}
+	return bstr.object.HasOwnProperty(key)
+}
+
+// HasProperty on BoxedString returns true if the specified property
+// name exists on the object or its prototype chain.
+//
+// This must be ~redundantly defined on BoxedString, because the
+// inherited definition from the embedded object would call
+// bstr.object.HasOwnProperty() instead of bstr.HasOwnProperty() and
+// thus not see length etc.
+func (bstr *BoxedString) HasProperty(key string) bool {
+	return bstr.HasOwnProperty(key) || bstr.Proto().HasProperty(key)
+}
+
+// ToBoolean has no special behaviour on BoxedStrings: it returns
+// true, as for any other object.
+
+// ToNumber on BoxedString just returns the same value as on the boxed
+// String.
+func (bstr *BoxedString) ToNumber() Number {
+	return bstr.value.ToNumber()
+}
+
+// ToString on BoxedString just returns the boxed String itself.
+//
+// BUG(cpcallen): ToString should call a user-code toString() method
+// if present.
+func (bstr *BoxedString) ToString() String {
+	return bstr.value
+}
+
+// ToPrimitive returns the contained String on BoxedString objects.
+func (bstr *BoxedString) ToPrimitive() Value {
+	return bstr.value
+}
+
+// NewBoxedString creates a new object with the specified owner and
+// prototype, initialises it as appropriate, and returns a pointer to
+// the newly-created object.
+func NewBoxedString(owner *Owner, proto Object, value String) *BoxedString {
+	var bstr = new(BoxedString)
+	bstr.init(owner, proto)
+	bstr.f = true
+	bstr.value = value
+	return bstr
+}

--- a/server/interpreter/data/boxes.go
+++ b/server/interpreter/data/boxes.go
@@ -217,3 +217,21 @@ func NewBoxedString(owner *Owner, proto Object, value String) *BoxedString {
 	bstr.value = value
 	return bstr
 }
+
+/********************************************************************/
+
+// Coerce coerces its first argument into an object.
+func Coerce(value Value, owner *Owner, protos *Protos) Object {
+	switch v := value.(type) {
+	case Object:
+		return v
+	case Boolean:
+		return NewBoxedBoolean(owner, protos.BooleanProto, v)
+	case Number:
+		return NewBoxedNumber(owner, protos.NumberProto, v)
+	case String:
+		return NewBoxedString(owner, protos.StringProto, v)
+	default:
+		panic(fmt.Errorf("Can't coerce a %T to Object", v))
+	}
+}

--- a/server/interpreter/data/boxes_test.go
+++ b/server/interpreter/data/boxes_test.go
@@ -1,0 +1,71 @@
+/* Copyright 2017 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import (
+	"testing"
+)
+
+func TestBoxedStringHasOwnProperty(t *testing.T) {
+	var s = NewBoxedString(nil, protos.StringProto, String("foo"))
+
+	if s.HasOwnProperty("foo") {
+		t.Errorf("%#v.HasOwnProperty(\"foo\") == true", s)
+	}
+	s.Set("foo", Undefined{})
+	if !s.HasOwnProperty("foo") {
+		t.Errorf("%#v.HasOwnProperty(\"foo\") == false (after set)", s)
+	}
+	if !s.HasOwnProperty("length") {
+		t.Errorf("%#v.HasOwnProperty(\"length\") == false", s)
+	}
+}
+
+func TestBoxedStringHasProperty(t *testing.T) {
+	var s = NewBoxedString(nil, protos.StringProto, String("foo"))
+
+	if s.HasProperty("foo") {
+		t.Errorf("%#v.HasProperty(\"foo\") == true", s)
+	}
+	s.Proto().Set("foo", Undefined{})
+	if !s.HasProperty("foo") {
+		t.Errorf("%#v.HasProperty(\"foo\") == false (after setting parent)", s)
+	}
+	s.Proto().Delete("foo")
+	if !s.HasProperty("length") {
+		t.Errorf("%#v.HasProperty(\"length\") == false", s)
+	}
+}
+
+func TestBoxedStringLength(t *testing.T) {
+	var tests = []struct {
+		in       string
+		expected int
+	}{
+		{"", 0},
+		{"Hello, World!", 13},
+		{"కోడ్ సిటీ", 9},
+		{"𝌆", 2},
+	}
+	for _, c := range tests {
+		bstr := NewBoxedString(nil, protos.StringProto, String(c.in))
+		if l, _ := bstr.Get("length"); l != Number(c.expected) {
+			t.Errorf("new String(%#v).length == %d (expected %d)",
+				c.in, l, c.expected)
+		}
+	}
+}

--- a/server/interpreter/data/eval.go
+++ b/server/interpreter/data/eval.go
@@ -92,12 +92,13 @@ func BinaryOp(left Value, op string, right Value) (Value, *ErrorMsg) {
 		return Number(float64(int32(float64(left.ToNumber())) &
 			int32(float64(right.ToNumber())))), nil
 	case "in":
-		if right.Type() != OBJECT {
+		obj, isObject := right.(Object)
+		if !isObject {
 			return nil, &ErrorMsg{"TypeError", fmt.Sprintf(
 				"Cannot use 'in' operator to search for '%s' in %#v",
 				left.ToString(), right)}
 		}
-		return Boolean(right.HasProperty(string(left.ToString()))), nil
+		return Boolean(obj.HasProperty(string(left.ToString()))), nil
 	case "instanceof":
 		panic("not implemented")
 	default:

--- a/server/interpreter/data/eval_extern_test.go
+++ b/server/interpreter/data/eval_extern_test.go
@@ -24,6 +24,12 @@ import (
 	tu "CodeCity/server/interpreter/data/testutil"
 )
 
+var protos *Protos
+
+func init() {
+	protos = NewProtos()
+}
+
 func TestBinaryOp(t *testing.T) {
 	var NaN = math.NaN()
 	var neg0 = math.Copysign(0, -1)
@@ -230,7 +236,7 @@ func TestBinaryOpIn(t *testing.T) {
 		t.Errorf("\"foo\" in, %#v == (%#v, %#v) (expected (true, nil))",
 			obj, v, e)
 	}
-	v, e = BinaryOp(String("length"), "in", NewArray(nil, ArrayProto))
+	v, e = BinaryOp(String("length"), "in", NewArray(nil, protos.ArrayProto))
 	if v != Boolean(true) || e != nil {
 		t.Errorf("\"foo\" in [] == (%#v, %#v) (expected true, nil)", v, e)
 	}

--- a/server/interpreter/data/eval_test.go
+++ b/server/interpreter/data/eval_test.go
@@ -93,9 +93,9 @@ func TestEquality(t *testing.T) {
 	var neg0 = math.Copysign(0, -1)
 	var inf = math.Inf(+1)
 	var negInf = math.Inf(-1)
-	var o1 = NewObject(nil, nil)
-	var o2 = NewObject(nil, nil)
-	var ow = NewOwner()
+	var o1 = NewObject(nil, protos.ObjectProto)
+	var o2 = NewObject(nil, protos.ObjectProto)
+	var ow = NewOwner(protos.OwnerProto)
 
 	var tests = []struct {
 		left     Value

--- a/server/interpreter/data/object.go
+++ b/server/interpreter/data/object.go
@@ -27,27 +27,27 @@ type Object interface {
 
 	// Get returns the current value of the given property or an
 	// ErrorMsg if that was not possible.
-	Get(name string) (Value, *ErrorMsg)
+	Get(string) (Value, *ErrorMsg)
 
 	// Set sets the given property to the specified value or returns
 	// an ErrorMsg if that was not possible.
-	Set(name string, value Value) *ErrorMsg
+	Set(string, Value) *ErrorMsg
 
 	// Delete attempts to remove the named property.  If the property
 	// exists but can't be removed for some reason an ErrorMsg is
 	// returned.  (Removing a non-existing property "succeeds"
 	// silently.)
-	Delete(name string) *ErrorMsg
+	Delete(string) *ErrorMsg
 
-	// OwnPropertyKeys returns the list of (own) property names as a
+	// OwnPropertyKeys returns the list of (own) property keys as a
 	// slice of strings.
 	OwnPropertyKeys() []string
 
-	// HasOwnProperty returns true if the specified property name
+	// HasOwnProperty returns true if the specified property key
 	// exists on the object itself.
 	HasOwnProperty(string) bool
 
-	// HasProperty returns true if the specified property name
+	// HasProperty returns true if the specified property key
 	// exists on the object or its prototype chain.
 	HasProperty(string) bool
 }

--- a/server/interpreter/data/object.go
+++ b/server/interpreter/data/object.go
@@ -76,7 +76,6 @@ func (obj Object) Get(key string) (Value, *ErrorMsg) {
 		return proto.Get(key)
 	}
 	return Undefined{}, nil
-
 }
 
 // Set sets the given property to the specified value or returns an

--- a/server/interpreter/data/object.go
+++ b/server/interpreter/data/object.go
@@ -16,11 +16,48 @@
 
 package data
 
-// Object represents typical JavaScript objects with (optional)
-// prototype, properties, etc.
-type Object struct {
+// Object represents any JavaScript value (primitive, object, etc.).
+type Object interface {
+	/// Any Object is a valid Value.
+	Value
+
+	// Proto returns the prototype (parent) object for this object.
+	// N.B. this is object.__proto__, not Constructor.prototype!
+	Proto() Object
+
+	// Get returns the current value of the given property or an
+	// ErrorMsg if that was not possible.
+	Get(name string) (Value, *ErrorMsg)
+
+	// Set sets the given property to the specified value or returns
+	// an ErrorMsg if that was not possible.
+	Set(name string, value Value) *ErrorMsg
+
+	// Delete attempts to remove the named property.  If the property
+	// exists but can't be removed for some reason an ErrorMsg is
+	// returned.  (Removing a non-existing property "succeeds"
+	// silently.)
+	Delete(name string) *ErrorMsg
+
+	// OwnPropertyKeys returns the list of (own) property names as a
+	// slice of strings.
+	OwnPropertyKeys() []string
+
+	// HasOwnProperty returns true if the specified property name
+	// exists on the object itself.
+	HasOwnProperty(string) bool
+
+	// HasProperty returns true if the specified property name
+	// exists on the object or its prototype chain.
+	HasProperty(string) bool
+}
+
+// object represents typical plain old JavaScript objects with
+// prototype, properties, etc.; this struct is also embedded in other,
+// less-plain object types like Array.
+type object struct {
 	owner      *Owner
-	proto      Value
+	proto      Object
 	properties map[string]property
 	f          bool
 }
@@ -39,32 +76,32 @@ type property struct {
 	i     bool
 }
 
-// *Object must satisfy Value.
-var _ Value = (*Object)(nil)
+// *object must satisfy Object.
+var _ Object = (*object)(nil)
 
-// Type always returns OBJECT for regular Objects.
-func (Object) Type() Type {
+// Type always returns OBJECT for regular objects.
+func (object) Type() Type {
 	return OBJECT
 }
 
-// Typeof always returns "object" for regular Objects.
-func (Object) Typeof() string {
+// Typeof always returns "object" for regular objects.
+func (object) Typeof() string {
 	return "object"
 }
 
-// IsPrimitive always returns false for regular Objects.
-func (Object) IsPrimitive() bool {
+// IsPrimitive always returns false for regular objects.
+func (object) IsPrimitive() bool {
 	return false
 }
 
 // Proto returns the prototype (parent) object for this object.
-func (obj Object) Proto() Value {
+func (obj object) Proto() Object {
 	return obj.proto
 }
 
 // Get returns the current value of the given property or an ErrorMsg
 // if that was not possible.
-func (obj Object) Get(key string) (Value, *ErrorMsg) {
+func (obj object) Get(key string) (Value, *ErrorMsg) {
 	pd, ok := obj.properties[key]
 	// FIXME: permissions check for property readability goes here
 	if ok {
@@ -80,7 +117,7 @@ func (obj Object) Get(key string) (Value, *ErrorMsg) {
 
 // Set sets the given property to the specified value or returns an
 // ErrorMsg if that was not possible.
-func (obj *Object) Set(key string, value Value) *ErrorMsg {
+func (obj *object) Set(key string, value Value) *ErrorMsg {
 	pd, ok := obj.properties[key]
 	if !ok { // Creating new property
 		// FIXME: permissions check for object writability goes here
@@ -101,9 +138,17 @@ func (obj *Object) Set(key string, value Value) *ErrorMsg {
 	return nil
 }
 
+// Delete removes the named property if possible.
+//
+// FIXME: perm / immutability checks!
+func (obj *object) Delete(key string) *ErrorMsg {
+	delete(obj.properties, key)
+	return nil
+}
+
 // OwnPropertyKeys returns the list of (own) property keys as a slice
 // of strings.
-func (obj *Object) OwnPropertyKeys() []string {
+func (obj *object) OwnPropertyKeys() []string {
 	keys := make([]string, len(obj.properties))
 	i := 0
 	for k := range obj.properties {
@@ -113,63 +158,55 @@ func (obj *Object) OwnPropertyKeys() []string {
 	return keys
 }
 
-// Delete removes the named property if possible.
-//
-// FIXME: perm / immutability checks!
-func (obj *Object) Delete(key string) *ErrorMsg {
-	delete(obj.properties, key)
-	return nil
-}
-
 // HasOwnProperty returns true if the specified property key exists
 // on the object itself.
-func (obj *Object) HasOwnProperty(key string) bool {
+func (obj *object) HasOwnProperty(key string) bool {
 	_, exists := obj.properties[key]
 	return exists
 }
 
 // HasProperty returns true if the specified property key exists on
 // the object or its prototype chain.
-func (obj *Object) HasProperty(key string) bool {
+func (obj *object) HasProperty(key string) bool {
 	return obj.HasOwnProperty(key) ||
 		obj.proto != nil && obj.proto.HasProperty(key)
 }
 
-// ToBoolean always returns true for regular Objects.
-func (Object) ToBoolean() Boolean {
+// ToBoolean always returns true for regular objects.
+func (object) ToBoolean() Boolean {
 	return true
 }
 
 // ToNumber returns the numeric equivalent of the object.
 //
-// BUG(cpcallen): Object.ToNumber is not strictly compliant with
+// BUG(cpcallen): object.ToNumber is not strictly compliant with
 // ES5.1 spec; it just returns .ToString().ToNumber().
-func (obj Object) ToNumber() Number {
+func (obj object) ToNumber() Number {
 	return obj.ToString().ToNumber()
 }
 
 // ToString returns a string representation of the object.  By default
 // this is "[object Object]" for plain objects.
 //
-// BUG(cpcallen): Object.ToString should call a user-code toString()
+// BUG(cpcallen): object.ToString should call a user-code toString()
 // method if present.
-func (Object) ToString() String {
+func (object) ToString() String {
 	return "[object Object]"
 }
 
 // ToPrimitive defaults to ToNumber on objects.
 //
-// BUG(cpcallen): Object.ToPrimitive should prefer to return the result
+// BUG(cpcallen): object.ToPrimitive should prefer to return the result
 // of ToString() on date objects.
-func (obj *Object) ToPrimitive() Value {
+func (obj *object) ToPrimitive() Value {
 	return obj.ToNumber()
 }
 
 // NewObject creates a new object with the specified owner and prototype,
 // initialises it as appropriate, and returns a pointer to the
 // newly-created object.
-func NewObject(owner *Owner, proto Value) *Object {
-	var obj = new(Object)
+func NewObject(owner *Owner, proto Object) *object {
+	var obj = new(object)
 	obj.init(owner, proto)
 	obj.f = true
 	return obj
@@ -178,13 +215,8 @@ func NewObject(owner *Owner, proto Value) *Object {
 // init is an internal initialisation routine, called from New and
 // also called when constructing other types of objects such as
 // Arrays, Owners, etc.
-func (obj *Object) init(owner *Owner, proto Value) {
+func (obj *object) init(owner *Owner, proto Object) {
 	obj.owner = owner
 	obj.proto = proto
 	obj.properties = make(map[string]property)
 }
-
-// ObjectProto is the default prototype for (plain) JavaScript objects
-// (i.e., ones created from object literals and not via
-// Object.create(nil)).
-var ObjectProto = NewObject(nil, Null{})

--- a/server/interpreter/data/object_test.go
+++ b/server/interpreter/data/object_test.go
@@ -18,10 +18,16 @@ package data
 
 import "testing"
 
+var protos *Protos
+
+func init() {
+	protos = NewProtos()
+}
+
 func TestObjectNonPrimitiveness(t *testing.T) {
 	var objs = []Value{
-		NewObject(nil, nil),
-		NewOwner(),
+		NewObject(nil, protos.ObjectProto),
+		NewOwner(protos.OwnerProto),
 	}
 
 	for _, o := range objs {

--- a/server/interpreter/data/owner.go
+++ b/server/interpreter/data/owner.go
@@ -18,12 +18,12 @@ package data
 
 // An Owner is an object that can own other objects and properties.
 type Owner struct {
-	Object
+	object
 	// FIXME: other fields go here.
 }
 
-// *Owner must satisfy Value.
-var _ Value = (*Owner)(nil)
+// *Owner must satisfy Object.
+var _ Object = (*Owner)(nil)
 
 // ToString always returns "[object Owner]" for Owners.
 //
@@ -35,13 +35,9 @@ func (Owner) ToString() String {
 
 // NewOwner returns a new Owner object, owned by itself and having
 // parent ObjectProto.
-func NewOwner() *Owner {
+func NewOwner(proto Object) *Owner {
 	var o = new(Owner)
-	o.init(o, OwnerProto)
+	o.init(o, proto)
+	o.f = false
 	return o
 }
-
-// OwnerProto is the the (plain) JavaScript object that is the
-// prototype for all Owner objects.  (It has no direct equivalent in
-// JavaScript, but if it did it would be Owner.prototype.)
-var OwnerProto = NewObject(nil, ObjectProto)

--- a/server/interpreter/data/primitives.go
+++ b/server/interpreter/data/primitives.go
@@ -133,7 +133,7 @@ func (Number) Type() Type {
 	return NUMBER
 }
 
-// Type always returns "number" for numbers.
+// Typeof always returns "number" for numbers.
 func (Number) Typeof() string {
 	return "number"
 }

--- a/server/interpreter/data/primitives.go
+++ b/server/interpreter/data/primitives.go
@@ -92,37 +92,6 @@ func (Boolean) IsPrimitive() bool {
 	return true
 }
 
-// Proto returns BooleanProto for all Booleans.
-func (Boolean) Proto() Value {
-	return BooleanProto
-}
-
-// Get on Boolean just passes to its prototype:
-func (b Boolean) Get(name string) (Value, *ErrorMsg) {
-	return b.Proto().Get(name)
-}
-
-// Set on Boolean always succeeds but has no effect.
-func (Boolean) Set(name string, value Value) *ErrorMsg {
-	return nil
-}
-
-// OwnPropertyKeys always returns an empty slice on Boolean.
-func (Boolean) OwnPropertyKeys() []string { return nil }
-
-// HasOwnProperty always returns false for Boolean values.
-func (Boolean) HasOwnProperty(string) bool { return false }
-
-// HasProperty just calls HasProperty on prototype for Boolean values.
-func (b Boolean) HasProperty(key string) bool {
-	return b.Proto().HasProperty(key)
-}
-
-// Delete always succeeds on Boolean.
-func (Boolean) Delete(name string) *ErrorMsg {
-	return nil
-}
-
 // ToBoolean on a Boolean just returns itself.
 func (b Boolean) ToBoolean() Boolean {
 	return b
@@ -172,37 +141,6 @@ func (Number) Typeof() string {
 // IsPrimitive alwasy returns true for Numbers.
 func (Number) IsPrimitive() bool {
 	return true
-}
-
-// Proto returns NumberProto for all Numbers.
-func (Number) Proto() Value {
-	return NumberProto
-}
-
-// Get on Number just passes to its prototype:
-func (n Number) Get(name string) (Value, *ErrorMsg) {
-	return n.Proto().Get(name)
-}
-
-// Set on Number always succeeds but has no effect.
-func (Number) Set(name string, value Value) *ErrorMsg {
-	return nil
-}
-
-// OwnPropertyKeys always returns an empty slice on Number.
-func (Number) OwnPropertyKeys() []string { return nil }
-
-// HasOwnProperty always returns false for Number values.
-func (Number) HasOwnProperty(string) bool { return false }
-
-// HasProperty just calls HasProperty on prototype for Boolean values.
-func (n Number) HasProperty(key string) bool {
-	return n.Proto().HasProperty(key)
-}
-
-// Delete always succeeds on Number.
-func (Number) Delete(name string) *ErrorMsg {
-	return nil
 }
 
 // ToBoolean on a number returns true if the number is not 0 or NaN.
@@ -272,55 +210,6 @@ func (String) IsPrimitive() bool {
 	return true
 }
 
-// Proto returns StringProto for all Strings.
-func (String) Proto() Value {
-	return StringProto
-}
-
-// Get on String implements a magic .length property itself,
-// and passes any other property lookups to its prototype:
-func (s String) Get(name string) (Value, *ErrorMsg) {
-	if name != "length" {
-		return s.Proto().Get(name)
-	}
-	return Number(len(utf16.Encode([]rune(string(s))))), nil
-}
-
-// Set on String always succeeds but has no effect (even on
-// length).
-func (String) Set(name string, value Value) *ErrorMsg {
-	return nil
-}
-
-// OwnPropertyKeys always returns just the length property on Strings.
-func (String) OwnPropertyKeys() []string { return []string{"length"} }
-
-// HasOwnProperty always returns true for "length" and false for all
-// other inputs for Strings.
-//
-// FIXME: should return true for numeric inputs 0 <= n < length!
-func (String) HasOwnProperty(key string) bool {
-	if key == "length" {
-		return true
-	}
-	return false
-}
-
-// HasProperty returns true if the specified property name exists on
-// the object or its prototype chain.
-func (s String) HasProperty(key string) bool {
-	return s.HasOwnProperty(key) || s.Proto().HasProperty(key)
-}
-
-// Delete always succeeds on String unless name is "length".
-func (s String) Delete(name string) *ErrorMsg {
-	if name != "length" {
-		return nil
-	}
-	return &ErrorMsg{"TypeError",
-		fmt.Sprintf("Cannot delete property 'length' of %s", s.ToString())}
-}
-
 // ToBoolean on String returns true iff the string is non-empty.
 func (s String) ToBoolean() Boolean {
 	return len(string(s)) != 0
@@ -378,6 +267,12 @@ func (s String) ToPrimitive() Value {
 	return s
 }
 
+// utf16len returns the length of the string in utf16 code units - the
+// standard way of measuring string length in JavaScript.
+func (s String) utf16len() int {
+	return len(utf16.Encode([]rune(string(s))))
+}
+
 /********************************************************************/
 
 // Null represents a JS null value.
@@ -399,48 +294,6 @@ func (Null) Typeof() string {
 // IsPrimitive alwasy returns true for Null.
 func (Null) IsPrimitive() bool {
 	return true
-}
-
-// Proto on Undefined and Null values should not be callable from
-// user code, but is used in various places internally (e.g.,
-// PropIter.Next()); we return nil to signal that there is no prototype.
-// (Previously we returned Undefined{} or Null{}, but this just forces
-// us to write additional code elsewhere to avoid infinite loops, and
-// violates the rule that there should be no prototype chain loops.)
-func (Null) Proto() Value {
-	return nil
-}
-
-// Get on Null always returns an error.
-func (Null) Get(name string) (Value, *ErrorMsg) {
-	return nil, &ErrorMsg{
-		Name:    "TypeError",
-		Message: fmt.Sprintf("Cannot read property '%s' of null", name),
-	}
-}
-
-// Set on Null always fails.
-func (Null) Set(name string, value Value) *ErrorMsg {
-	return &ErrorMsg{
-		Name:    "TypeError",
-		Message: fmt.Sprintf("Cannot set property '%s' of null", name),
-	}
-}
-
-// OwnPropertyKeys always returns an empty slice on Null.
-func (Null) OwnPropertyKeys() []string { return nil }
-
-// HasOwnProperty always returns false for Null values
-// FIXME: this should throw.
-func (Null) HasOwnProperty(string) bool { return false }
-
-// HasProperty always returns false for Null values
-// FIXME: this should throw.
-func (Null) HasProperty(string) bool { return false }
-
-// Delete should never be called on Null
-func (Null) Delete(name string) *ErrorMsg {
-	panic("Null.Delete() not callable")
 }
 
 // ToBoolean on Null always return false.
@@ -486,43 +339,6 @@ func (Undefined) IsPrimitive() bool {
 	return true
 }
 
-// Proto on Undefined returns nil; see not on Null.Proto() for why.
-func (Undefined) Proto() Value {
-	return nil
-}
-
-// Get on Undefined always returns an error.
-func (Undefined) Get(name string) (Value, *ErrorMsg) {
-	return nil, &ErrorMsg{
-		Name:    "TypeError",
-		Message: fmt.Sprintf("Cannot read property '%s' of undefined", name),
-	}
-}
-
-// Set on Undefined always fails.
-func (Undefined) Set(name string, value Value) *ErrorMsg {
-	return &ErrorMsg{
-		Name:    "TypeError",
-		Message: fmt.Sprintf("Cannot set property '%s' of undefined", name),
-	}
-}
-
-// OwnPropertyKeys always returns an empty slice on Undefined.
-func (Undefined) OwnPropertyKeys() []string { return nil }
-
-// HasOwnProperty always returns false for Undefined values
-// FIXME: this should throw.
-func (Undefined) HasOwnProperty(string) bool { return false }
-
-// HasProperty always returns false for Undefined values
-// FIXME: this should throw.
-func (Undefined) HasProperty(string) bool { return false }
-
-// Delete should never be called on Undeined.
-func (Undefined) Delete(name string) *ErrorMsg {
-	panic("Null.Delete() not callable")
-}
-
 // ToBoolean on Undefined always returns false.
 func (Undefined) ToBoolean() Boolean {
 	return false
@@ -542,20 +358,3 @@ func (Undefined) ToString() String {
 func (Undefined) ToPrimitive() Value {
 	return Undefined{}
 }
-
-/********************************************************************/
-
-// BooleanProto is the the (plain) JavaScript object that is the
-// prototype for all Boolean primitives.  (It would usually be
-// accessed in JavaScript as Boolean.prototype.)
-var BooleanProto = NewObject(nil, ObjectProto)
-
-// NumberProto is the the (plain) JavaScript object that is the
-// prototype for all Number primitives.  (It would usually be
-// accessed in JavaScript as Number.prototype.)
-var NumberProto = NewObject(nil, ObjectProto)
-
-// StringProto is the the (plain) JavaScript object that is the
-// prototype for all String primitives.  (It would usually be
-// accessed in JavaScript as String.prototype.)
-var StringProto = NewObject(nil, ObjectProto)

--- a/server/interpreter/data/primitives_test.go
+++ b/server/interpreter/data/primitives_test.go
@@ -61,7 +61,7 @@ func TestPrimitivesPrimitiveness(t *testing.T) {
 }
 
 func TestBoolean(t *testing.T) {
-	var b Boolean = Boolean(false)
+	var b = Boolean(false)
 	if b.Type() != BOOLEAN {
 		t.Errorf("%v.Type() == %#v (expected %#v)", b, b.Type(), BOOLEAN)
 	}
@@ -71,7 +71,7 @@ func TestBoolean(t *testing.T) {
 }
 
 func TestNumber(t *testing.T) {
-	var n Number = Number(0)
+	var n = Number(0)
 	if n.Type() != NUMBER {
 		t.Errorf("%v.Type() == %#v (expected %#v)", n, n.Type(), NUMBER)
 	}

--- a/server/interpreter/data/propiter.go
+++ b/server/interpreter/data/propiter.go
@@ -23,14 +23,14 @@ package data
 // FIXME: perhaps we should guarantee iteration order, as most
 // browsers (and ES6) do?
 type PropIter struct {
-	value Value
-	keys  []string
-	seen  map[string]bool
+	obj  Object
+	keys []string
+	seen map[string]bool
 }
 
 // NewPropIter takes any Value and returns an PropIter for it.
-func NewPropIter(v Value) *PropIter {
-	return &PropIter{v, v.OwnPropertyKeys(), make(map[string]bool)}
+func NewPropIter(obj Object) *PropIter {
+	return &PropIter{obj, obj.OwnPropertyKeys(), make(map[string]bool)}
 }
 
 // Next returns the next non-deleted, non-shadowed property key, with
@@ -42,15 +42,15 @@ func (iter *PropIter) Next() (string, bool) {
 		for len(iter.keys) > 0 {
 			key = iter.keys[0]
 			iter.keys = iter.keys[1:]
-			if iter.value.HasOwnProperty(key) && !iter.seen[key] {
+			if iter.obj.HasOwnProperty(key) && !iter.seen[key] {
 				iter.seen[key] = true
 				return key, true
 			}
 		}
-		iter.value = iter.value.Proto()
-		if iter.value == nil {
+		iter.obj = iter.obj.Proto()
+		if iter.obj == nil {
 			return "", false
 		}
-		iter.keys = iter.value.OwnPropertyKeys()
+		iter.keys = iter.obj.OwnPropertyKeys()
 	}
 }

--- a/server/interpreter/data/protos.go
+++ b/server/interpreter/data/protos.go
@@ -1,0 +1,69 @@
+/* Copyright 2017 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+// Protos is a struct containing prototypes for the various Object
+// classes defined in the ES5.1 spec.
+//
+// N.B.: BooleanProto is the prototype for BoxedBoolean objects, not
+// for Boolean values (which, as primitives, do not have a prototype);
+// similarly for NubmerProto and StringProto.
+//
+// FIXME: specify types of Errors and other prototypes once suitable
+// types defined.
+type Protos struct {
+	ObjectProto         Object
+	BooleanProto        *BoxedBoolean // See note
+	NumberProto         *BoxedNumber  // See note
+	StringProto         *BoxedString  // See note
+	FunctionProto       Object
+	ArrayProto          *Array
+	ErrorProto          Object
+	EvalErrorProto      Object
+	RangeErrorProto     Object
+	ReferenceErrorProto Object
+	SyntaxErrorProto    Object
+	TypeErrorProto      Object
+	URIErrorProto       Object
+	OwnerProto          *Owner
+}
+
+// NewProtos creates, initialises and populates a Proto struct with
+// default prototype objects.
+func NewProtos() *Protos {
+	var prts Protos
+	prts.ObjectProto = NewObject(nil, nil)
+
+	prts.BooleanProto = NewBoxedBoolean(nil, prts.ObjectProto, Boolean(false))
+	prts.NumberProto = NewBoxedNumber(nil, prts.ObjectProto, Number(0))
+	prts.StringProto = NewBoxedString(nil, prts.ObjectProto, String(""))
+
+	prts.FunctionProto = NewObject(nil, prts.ObjectProto)
+	prts.ArrayProto = NewArray(nil, prts.ObjectProto)
+	prts.ErrorProto = NewObject(nil, prts.ObjectProto)
+
+	prts.EvalErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.RangeErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.ReferenceErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.SyntaxErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.TypeErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.URIErrorProto = NewObject(nil, prts.ErrorProto)
+
+	prts.OwnerProto = NewOwner(prts.ObjectProto)
+
+	return &prts
+}

--- a/server/interpreter/data/testutil/util.go
+++ b/server/interpreter/data/testutil/util.go
@@ -69,9 +69,9 @@ func Identical(x, y data.Value) bool {
 		// Is the other also undefined?
 		_, ok := y.(data.Null)
 		return ok
-	case *data.Object:
-		// Is it a pointer to the same object?
-		yy, ok := y.(*data.Object)
+	case data.Object:
+		// Is it the same object?
+		yy, ok := y.(data.Object)
 		return ok && xx == yy
 	case nil:
 		return y == nil

--- a/server/interpreter/data/value.go
+++ b/server/interpreter/data/value.go
@@ -47,36 +47,6 @@ type Value interface {
 	// boolean, etc.).
 	IsPrimitive() bool
 
-	// Proto returns the prototype (parent) object for this object.
-	// N.B. this is object.__proto__, not Constructor.prototype!
-	Proto() Value
-
-	// Get returns the current value of the given property or an
-	// ErrorMsg if that was not possible.
-	Get(name string) (Value, *ErrorMsg)
-
-	// Set sets the given property to the specified value or returns
-	// an ErrorMsg if that was not possible.
-	Set(name string, value Value) *ErrorMsg
-
-	// Delete attempts to remove the named property.  If the property
-	// exists but can't be removed for some reason an ErrorMsg is
-	// returned.  (Removing a non-existing property "succeeds"
-	// silently.)
-	Delete(name string) *ErrorMsg
-
-	// OwnPropertyKeys returns the list of (own) property names as a
-	// slice of strings.
-	OwnPropertyKeys() []string
-
-	// HasOwnProperty returns true if the specified property name
-	// exists on the object itself.
-	HasOwnProperty(string) bool
-
-	// HasProperty returns true if the specified property name
-	// exists on the object or its prototype chain.
-	HasProperty(string) bool
-
 	// ToBoolean returns true iff the object is truthy.
 	ToBoolean() Boolean
 

--- a/server/interpreter/data/value.go
+++ b/server/interpreter/data/value.go
@@ -20,11 +20,12 @@
 // property descriptors) all conform to the Value interface.
 package data
 
-type Type int
-
 // Type is an enum identifying the formal type of a value, per §8 of
 // the ES5.1 spec.  Note that OBJECT identifies *any* object type
 // (including Arrays, Functions, closures, Owners, Regexps, etc.)
+type Type int
+
+// These constants define the valid values of a Type variable.
 const (
 	UNDEFINED Type = iota
 	NULL

--- a/server/interpreter/interpreter.go
+++ b/server/interpreter/interpreter.go
@@ -26,6 +26,7 @@ import (
 
 // Interpreter implements a JavaScript interpreter.
 type Interpreter struct {
+	global  *scope
 	state   state
 	value   *cval
 	Verbose bool
@@ -59,12 +60,9 @@ func NewFromJSON(astJSON string) (*Interpreter, error) {
 // will execute that program.
 func NewFromAST(tree *ast.Program) *Interpreter {
 	var intrp = new(Interpreter)
-	s := newScope(nil, nil)
-	initArrayProto(s)
-	s.newVar("undefined", data.Undefined{})
-	// FIXME: insert (more) global names into s
-	s.populate(tree)
-	intrp.state = newState(nil, s, tree)
+	intrp.global = newGlobalScope()
+	intrp.global.populate(tree)
+	intrp.state = newState(nil, intrp.global, tree)
 	return intrp
 }
 

--- a/server/interpreter/interpreter.go
+++ b/server/interpreter/interpreter.go
@@ -26,6 +26,7 @@ import (
 
 // Interpreter implements a JavaScript interpreter.
 type Interpreter struct {
+	protos  *data.Protos
 	global  *scope
 	state   state
 	value   *cval
@@ -60,7 +61,8 @@ func NewFromJSON(astJSON string) (*Interpreter, error) {
 // will execute that program.
 func NewFromAST(tree *ast.Program) *Interpreter {
 	var intrp = new(Interpreter)
-	intrp.global = newGlobalScope()
+	intrp.protos = data.NewProtos()
+	intrp.global = newGlobalScope(intrp.protos)
 	intrp.global.populate(tree)
 	intrp.state = newState(nil, intrp.global, tree)
 	return intrp
@@ -85,7 +87,7 @@ func (intrp *Interpreter) Step() bool {
 	if intrp.Verbose {
 		fmt.Printf("Next step is %T.step(%#v)\n", intrp.state, intrp.value)
 	}
-	intrp.state, intrp.value = intrp.state.step(intrp.value)
+	intrp.state, intrp.value = intrp.state.step(intrp, intrp.value)
 	return true
 }
 

--- a/server/interpreter/interpreter_test.go
+++ b/server/interpreter/interpreter_test.go
@@ -117,7 +117,7 @@ func TestInterpreterSimple(t *testing.T) {
 func TestInterpreterObjectExpression(t *testing.T) {
 	i, _ := NewFromJSON(objectExpression)
 	i.Run()
-	v, ok := i.Value().(*data.Object)
+	v, ok := i.Value().(data.Object)
 	if !ok {
 		t.Errorf("{foo: \"bar\", answer: 42} returned type %T "+
 			"(expected data.Object)", i.Value())
@@ -159,14 +159,17 @@ func TestInterpreterSwitchStatement(t *testing.T) {
 // instance.
 func TestPrototypeIndependence(t *testing.T) {
 	i1, _ := NewFromJSON(emptyProg)
-	op1, _ := i1.state.(*stateBlockStatement).scope.
-		getVar("Object").Get("prototype")
-	ap1, _ := i1.state.(*stateBlockStatement).scope.
-		getVar("Array").Get("prototype")
+	op1v, _ := i1.state.(*stateBlockStatement).scope.
+		getVar("Object").(data.Object).Get("prototype")
+	op1 := op1v.(data.Object)
+	ap1v, _ := i1.state.(*stateBlockStatement).scope.
+		getVar("Array").(data.Object).Get("prototype")
+	ap1 := ap1v.(data.Object)
 
 	i2, _ := NewFromJSON(emptyProg)
-	op2, _ := i2.state.(*stateBlockStatement).scope.
-		getVar("Object").Get("prototype")
+	op2v, _ := i2.state.(*stateBlockStatement).scope.
+		getVar("Object").(data.Object).Get("prototype")
+	op2 := op2v.(data.Object)
 
 	if op1.HasOwnProperty("foo") {
 		t.Errorf("Object.prototype.foo already defined")

--- a/server/interpreter/interpreter_test.go
+++ b/server/interpreter/interpreter_test.go
@@ -153,6 +153,41 @@ func TestInterpreterSwitchStatement(t *testing.T) {
 	}
 }
 
+func TestPrototypeIndependence(t *testing.T) {
+	i1, _ := NewFromJSON(emptyProg)
+	op1, _ := i1.state.(*stateBlockStatement).scope.
+		getVar("Object").Get("prototype")
+	ap1, _ := i1.state.(*stateBlockStatement).scope.
+		getVar("Array").Get("prototype")
+
+	i2, _ := NewFromJSON(emptyProg)
+	op2, _ := i2.state.(*stateBlockStatement).scope.
+		getVar("Object").Get("prototype")
+
+	v, e := op1.Get("foo")
+	if e == nil {
+		t.Errorf("Object.prototype.foo already defined as %#v", v)
+	}
+	v, e = op2.Get("foo")
+	if e == nil {
+		t.Errorf("(other) Object.prototype.foo already defined as %#v", v)
+	}
+	e = op1.Set("foo", data.String("bar"))
+	v, e = op1.Get("foo")
+	if e != nil {
+		t.Errorf("setting Object.prototype.foo failed: %s", e)
+	}
+	v, e = ap1.Get("foo")
+	if e != nil || v != data.String("bar") {
+		t.Errorf("Array.prototype.foo == %#v (%s) "+
+			"(expected String(\"bar\"), nil)", v, e)
+	}
+	v, e = op2.Get("foo")
+	if e == nil {
+		t.Errorf("(other) Object.prototype.foo now defined as %#v", v)
+	}
+}
+
 func BenchmarkFibonacci(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		i, _ := New(fibonacci10k)
@@ -550,3 +585,7 @@ const switchStatementWithBreaks = `{"type":"Program","start":0,"end":115,"body":
 // result
 // => ???
 const fibonacci10k = `{"type":"Program","start":0,"end":247,"body":[{"type":"VariableDeclaration","start":0,"end":161,"declarations":[{"type":"VariableDeclarator","start":4,"end":161,"id":{"type":"Identifier","start":4,"end":13,"name":"fibonacci"},"init":{"type":"FunctionExpression","start":16,"end":161,"id":null,"params":[{"type":"Identifier","start":25,"end":26,"name":"n"},{"type":"Identifier","start":28,"end":34,"name":"output"}],"body":{"type":"BlockStatement","start":36,"end":161,"body":[{"type":"VariableDeclaration","start":40,"end":62,"declarations":[{"type":"VariableDeclarator","start":44,"end":49,"id":{"type":"Identifier","start":44,"end":45,"name":"a"},"init":{"type":"Literal","start":48,"end":49,"value":1,"raw":"1"}},{"type":"VariableDeclarator","start":51,"end":56,"id":{"type":"Identifier","start":51,"end":52,"name":"b"},"init":{"type":"Literal","start":55,"end":56,"value":1,"raw":"1"}},{"type":"VariableDeclarator","start":58,"end":61,"id":{"type":"Identifier","start":58,"end":61,"name":"sum"},"init":null}],"kind":"var"},{"type":"ForStatement","start":65,"end":159,"init":{"type":"VariableDeclaration","start":70,"end":79,"declarations":[{"type":"VariableDeclarator","start":74,"end":79,"id":{"type":"Identifier","start":74,"end":75,"name":"i"},"init":{"type":"Literal","start":78,"end":79,"value":0,"raw":"0"}}],"kind":"var"},"test":{"type":"BinaryExpression","start":81,"end":86,"left":{"type":"Identifier","start":81,"end":82,"name":"i"},"operator":"<","right":{"type":"Identifier","start":85,"end":86,"name":"n"}},"update":{"type":"UpdateExpression","start":88,"end":91,"operator":"++","prefix":false,"argument":{"type":"Identifier","start":88,"end":89,"name":"i"}},"body":{"type":"BlockStatement","start":93,"end":159,"body":[{"type":"ExpressionStatement","start":99,"end":114,"expression":{"type":"CallExpression","start":99,"end":113,"callee":{"type":"MemberExpression","start":99,"end":110,"object":{"type":"Identifier","start":99,"end":105,"name":"output"},"property":{"type":"Identifier","start":106,"end":110,"name":"push"},"computed":false},"arguments":[{"type":"Identifier","start":111,"end":112,"name":"a"}]}},{"type":"ExpressionStatement","start":119,"end":131,"expression":{"type":"AssignmentExpression","start":119,"end":130,"operator":"=","left":{"type":"Identifier","start":119,"end":122,"name":"sum"},"right":{"type":"BinaryExpression","start":125,"end":130,"left":{"type":"Identifier","start":125,"end":126,"name":"a"},"operator":"+","right":{"type":"Identifier","start":129,"end":130,"name":"b"}}}},{"type":"ExpressionStatement","start":136,"end":142,"expression":{"type":"AssignmentExpression","start":136,"end":141,"operator":"=","left":{"type":"Identifier","start":136,"end":137,"name":"a"},"right":{"type":"Identifier","start":140,"end":141,"name":"b"}}},{"type":"ExpressionStatement","start":147,"end":155,"expression":{"type":"AssignmentExpression","start":147,"end":154,"operator":"=","left":{"type":"Identifier","start":147,"end":148,"name":"b"},"right":{"type":"Identifier","start":151,"end":154,"name":"sum"}}}]}}]}}}],"kind":"var"},{"type":"ForStatement","start":162,"end":240,"init":{"type":"VariableDeclaration","start":166,"end":175,"declarations":[{"type":"VariableDeclarator","start":170,"end":175,"id":{"type":"Identifier","start":170,"end":171,"name":"i"},"init":{"type":"Literal","start":174,"end":175,"value":0,"raw":"0"}}],"kind":"var"},"test":{"type":"BinaryExpression","start":177,"end":186,"left":{"type":"Identifier","start":177,"end":178,"name":"i"},"operator":"<","right":{"type":"Literal","start":181,"end":186,"value":10000,"raw":"10000"}},"update":{"type":"UpdateExpression","start":188,"end":191,"operator":"++","prefix":false,"argument":{"type":"Identifier","start":188,"end":189,"name":"i"}},"body":{"type":"BlockStatement","start":193,"end":240,"body":[{"type":"VariableDeclaration","start":197,"end":213,"declarations":[{"type":"VariableDeclarator","start":201,"end":212,"id":{"type":"Identifier","start":201,"end":207,"name":"result"},"init":{"type":"ArrayExpression","start":210,"end":212,"elements":[]}}],"kind":"var"},{"type":"ExpressionStatement","start":216,"end":238,"expression":{"type":"CallExpression","start":216,"end":237,"callee":{"type":"Identifier","start":216,"end":225,"name":"fibonacci"},"arguments":[{"type":"Literal","start":226,"end":228,"value":78,"raw":"78"},{"type":"Identifier","start":230,"end":236,"name":"result"}]}}]}},{"type":"ExpressionStatement","start":241,"end":247,"expression":{"type":"Identifier","start":241,"end":247,"name":"result"}}]}`
+
+// An empty program.  Used to initialise interpreter for tests that
+// don't involve running code.
+const emptyProg = `{"type":"Program","start":0,"end":0,"body":[]}`

--- a/server/interpreter/scope.go
+++ b/server/interpreter/scope.go
@@ -191,10 +191,10 @@ func (sc *scope) populate(node ast.Node) {
 }
 
 // newGlobalScope is a factory for top-level global scopes.
-func newGlobalScope() *scope {
+func newGlobalScope(protos *data.Protos) *scope {
 	sc := newScope(nil, nil)
-	initBuiltinObject(sc)
-	initBuiltinArray(sc)
+	initBuiltinObject(protos, sc)
+	initBuiltinArray(protos, sc)
 	sc.newVar("undefined", data.Undefined{})
 	// FIXME: insert (more) global names into sc
 	return sc

--- a/server/interpreter/scope.go
+++ b/server/interpreter/scope.go
@@ -189,3 +189,13 @@ func (sc *scope) populate(node ast.Node) {
 		panic(fmt.Errorf("Unrecognized ast.Node type %T", node))
 	}
 }
+
+// newGlobalScope is a factory for top-level global scopes.
+func newGlobalScope() *scope {
+	sc := newScope(nil, nil)
+	initBuiltinObject(sc)
+	initBuiltinArray(sc)
+	sc.newVar("undefined", data.Undefined{})
+	// FIXME: insert (more) global names into sc
+	return sc
+}

--- a/server/interpreter/scope.go
+++ b/server/interpreter/scope.go
@@ -41,8 +41,9 @@ type scope struct {
 }
 
 // newScope is a factory for scope objects.  The parent param is a
-// pointer to the parent (enclosing scope); it is nil if the scope
-// being created is the global scope.
+// pointer to the parent (enclosing scope).  The this param is the
+// value of ThisExpression in the given scope.  Both should be nil if
+// the scope being created is the global scope.
 func newScope(parent *scope, this data.Value) *scope {
 	return &scope{make(map[string]data.Value), parent, this}
 }

--- a/server/interpreter/state.go
+++ b/server/interpreter/state.go
@@ -1022,7 +1022,7 @@ type stateMemberExpression struct {
 	baseExpr ast.Expression // To be resolve to obtain base
 	membExpr ast.Expression // To be resolve to obtain name
 	computed bool           // Is this x[y] (rather than x.y)?
-	base     data.Value
+	base     data.Object
 }
 
 func (st *stateMemberExpression) init(node *ast.MemberExpression) {
@@ -1072,7 +1072,7 @@ func (st *stateMemberExpression) step(cv *cval) (state, *cval) {
 type stateObjectExpression struct {
 	stateCommon
 	props []*ast.Property
-	obj   *data.Object
+	obj   data.Object
 	n     int
 }
 
@@ -1546,7 +1546,7 @@ type lvalue struct {
 	baseExpr        ast.Expression // To be resolve to obtain base
 	membExpr        ast.Expression // To be resolve to obtain name
 	computed        bool           // Is this x[y] (rather than x.y)?
-	base            data.Value     // ECMA "base"
+	base            data.Object    // ECMA "base"
 	name            string         // ECMA "referenced name"
 	haveBase, ready bool
 }


### PR DESCRIPTION
We were originally planning to exclude boxed primitives (e.g., new Number(42)) from our implementation, because they are not very useful and are kind of confusing for beginners.

Because we still want to be able to invoke methods on primitives, we therefore previously had the Value interface (representing any arbitrary JS value) include lots of internal methods (like Get, Set and HasOwnProperty) that are only really applicable to object types;  these were implemented on primitives in way that simulated the observed behaviour.  E.g.:

    “foo”.length         // == 3
    “foo”.bar = 42     // does nothing
    “foo”.length = 4  // error!

The ES5.1 spec actually says that in a MemberExpression where the left hand side is a primitive (i.e., “foo”.length) the interpreter should create a boxed primitive (== new String(“foo)) and use that as the actual left-hand-side.  Because this box is thrown away after the MemberExpression has finished evaluation, only methods inherited from {Boolean,Number,String}.prototype would be able to tell the difference: with a boxed primitive, they could write a property to the box and then read it back (but only until the method call ends, unless they save a reference to the box), while with our primitives-masquerading-as-objects the write would just silently fail.

That’s not really a big deal, since the primitive prototype methods specified in ES5.1 don’t ever need to write to the box, and if we add additional methods to the primitive prototypes we could anticipate this slight non-conformity.

It turns out, however, that introducing boxed primitives for internal use in MemberExpressions (even if we don’t let users create them manually using the ‘new’ keyword) lets us improve the code in the following ways:

- The various internal methods that only apply to objects can be separated out into a new Object interface (that itself still implements Value); these methods can then be removed from the primitive types.

- Because the primitives no longer have a Proto() method, we can more easily solve the problem of primitives finding their (non-primitive) prototype object.

Previously, primitives found their prototype by looking at package-global variables data.BooleanProto, data.NumberProto, etc.; this meant that prototypes were incorrectly shared between multiple Interpreter instances (i.e., a property added to a primitive prototype in one Interpreter would incorrectly be visible in a separate second Interpreter instance).  The possible solutions were:

- Have every primitive store a pointer to its prototype.  This is quite memory-inefficient, because it would increase the size of Booleans and Numbers by at leat 50% (assuming type tag, float64 and pointer to prototype are all 8 bytes each).

- Have a “raft” of primitive protos (an “environment” object, env) which could be passed in to the .Proto() method; Object.Proto(protos) would ignore this extra argument but {Boolean,Number,String}.Proto(protos) would return photos.{Boolean,Number,String}Proto as appropriate.  Unfortunately, since Prototypes is called from Get, HasProperty, and other methods it ends up being necessary to pass this environment object around all over the place even though it is rarely used.

- Use boxed primitives, and let MemberExpression (and lvalue) worry about finding the correct prototype when boxing a primitive.  This still necessitates keeping a raft of primitives in the interpreter object, and passing a reference to it to every stateFooBar.step() method, but (a) at least we don’t have to pass it to almost every internal method on every Value object, and (b) we were almost certainly eventually going to have to give the sate step functions a way of accessing their enclosing interpreter anyway.