### PR TITLE
Replace ErrorMsg with NativeError; actually throw Errors

### DIFF
--- a/server/interpreter/data/array_test.go
+++ b/server/interpreter/data/array_test.go
@@ -109,15 +109,15 @@ func TestArrayLength(t *testing.T) {
 	a := NewArray(nil, protos.ArrayProto)
 
 	set := func(n int64, v Value) {
-		err := a.Set(fmt.Sprintf("%d", n), v)
-		if err != nil {
-			t.Error(err)
+		ne := a.Set(fmt.Sprintf("%d", n), v)
+		if ne != nil {
+			t.Error(ne)
 		}
 	}
 	checkLen := func(expected int64) {
-		l, err := a.Get("length")
-		if err != nil {
-			t.Error(err)
+		l, ne := a.Get("length")
+		if ne != nil {
+			t.Error(ne)
 		} else if l != Number(float64(expected)) {
 			t.Errorf("%v.length == %#v (expected %d)", a, l, expected)
 		}
@@ -127,9 +127,9 @@ func TestArrayLength(t *testing.T) {
 	checkLen(0)
 
 	// Adding non-numeric properties does not increase length:
-	err := a.Set("zero", Number(0))
-	if err != nil {
-		t.Error(err)
+	ne := a.Set("zero", Number(0))
+	if ne != nil {
+		t.Error(ne)
 	}
 	checkLen(0)
 
@@ -162,9 +162,9 @@ func TestArrayLength(t *testing.T) {
 	checkLen(math.MaxUint32)
 
 	setLen := func(l int) {
-		err := a.Set("length", Number(float64(l)))
-		if err != nil {
-			t.Error(err)
+		ne := a.Set("length", Number(float64(l)))
+		if ne != nil {
+			t.Error(ne)
 		}
 	}
 	check := func(n int64, exists bool) {

--- a/server/interpreter/data/boxes.go
+++ b/server/interpreter/data/boxes.go
@@ -121,7 +121,7 @@ var _ Object = (*BoxedString)(nil)
 // lookups to its embedded object.
 //
 // BUG(cpcallen): character indicides not implemented.
-func (bstr *BoxedString) Get(key string) (Value, *ErrorMsg) {
+func (bstr *BoxedString) Get(key string) (Value, *NativeError) {
 	if key == "length" {
 		return Number(bstr.value.utf16len()), nil
 	}
@@ -132,10 +132,9 @@ func (bstr *BoxedString) Get(key string) (Value, *ErrorMsg) {
 // character indicies, and otherwise delegates to the embedded object.
 //
 // BUG(cpcallen): character indicides not implemented.
-func (bstr *BoxedString) Set(key string, value Value) *ErrorMsg {
+func (bstr *BoxedString) Set(key string, value Value) *NativeError {
 	if key == "length" {
-		return &ErrorMsg{"TypeError",
-			fmt.Sprintf("Cannot assign to read only property '%s' of %s", key, bstr.ToString())}
+		return &NativeError{TypeError, fmt.Sprintf("Cannot assign to read only property '%s' of %s", key, bstr.ToString())}
 	}
 	return bstr.object.Set(key, value)
 }
@@ -144,10 +143,9 @@ func (bstr *BoxedString) Set(key string, value Value) *ErrorMsg {
 // character indicies, and otherwise defers to the embedded object.
 //
 // BUG(cpcallen): character indicides not implemented.
-func (bstr *BoxedString) Delete(key string) *ErrorMsg {
+func (bstr *BoxedString) Delete(key string) *NativeError {
 	if key == "length" {
-		return &ErrorMsg{"TypeError",
-			fmt.Sprintf("Cannot delete property '%s' of %s", key, bstr.ToString())}
+		return &NativeError{TypeError, fmt.Sprintf("Cannot delete property '%s' of %s", key, bstr.ToString())}
 	}
 	return bstr.object.Delete(key)
 }

--- a/server/interpreter/data/error.go
+++ b/server/interpreter/data/error.go
@@ -16,17 +16,27 @@
 
 package data
 
-// ErrorMsg is a (name, description)-tuple used to report error
-// conditions inside the JavaScript interpreter.  It's not actually a
-// JS Error object, but might get turned into one if appropriate.
-type ErrorMsg struct {
-	Name    string
+// NativeError is a (type, description) tuple used to indicate that an
+// error condition which is specified to throw a JS native error has
+// occurred.  It's not actually a JS Error object itself (because
+// creating one would require access to the appropriate prototype
+// object), but the interpreter should turn it into one and then
+// trhrow the result.
+type NativeError struct {
+	Type    NativeErrorType
 	Message string
 }
 
-// *ErrorMsg must satisfy error.
-var _ error = (*ErrorMsg)(nil)
+// NativeErrorType is an enum of the native error types listed in
+// ES5.1 §15.11.6: EvalError, RangeError, etc.
+type NativeErrorType int
 
-func (err ErrorMsg) Error() string {
-	return err.Name + ": " + err.Message
-}
+// Type constants for NativeErrorType.
+const (
+	EvalError NativeErrorType = iota
+	RangeError
+	ReferenceError
+	SyntaxError
+	TypeError
+	URIError
+)

--- a/server/interpreter/data/eval.go
+++ b/server/interpreter/data/eval.go
@@ -30,7 +30,7 @@ import (
 // BinaryOperator ("==", "!=", "===", "!==", "<", "<=", ">", ">=",
 // "<<", ">>", ">>>", "+", "-", "*", "/", "%", "|", "^", "&", "in" or
 // "instanceof"
-func BinaryOp(left Value, op string, right Value) (Value, *ErrorMsg) {
+func BinaryOp(left Value, op string, right Value) (Value, *NativeError) {
 	switch op {
 	case "==":
 		return Boolean(aeca(left, right)), nil
@@ -94,9 +94,7 @@ func BinaryOp(left Value, op string, right Value) (Value, *ErrorMsg) {
 	case "in":
 		obj, isObject := right.(Object)
 		if !isObject {
-			return nil, &ErrorMsg{"TypeError", fmt.Sprintf(
-				"Cannot use 'in' operator to search for '%s' in %#v",
-				left.ToString(), right)}
+			return nil, &NativeError{TypeError, fmt.Sprintf("Cannot use 'in' operator to search for '%s' in %#v", left.ToString(), right)}
 		}
 		return Boolean(obj.HasProperty(string(left.ToString()))), nil
 	case "instanceof":

--- a/server/interpreter/data/eval_extern_test.go
+++ b/server/interpreter/data/eval_extern_test.go
@@ -225,23 +225,21 @@ func TestBinaryOpIn(t *testing.T) {
 	var parent = NewObject(nil, nil)
 	var obj = NewObject(nil, parent)
 
-	v, e := BinaryOp(String("foo"), "in", obj)
-	if v != Boolean(false) || e != nil {
-		t.Errorf(`"foo" in, %#v == (%#v, %#v) (expected (false, nil))`,
-			obj, v, e)
+	v, ne := BinaryOp(String("foo"), "in", obj)
+	if v != Boolean(false) || ne != nil {
+		t.Errorf(`"foo" in, %#v == (%#v, %#v) (expected (false, nil))`, obj, v, ne)
 	}
 	parent.Set("foo", Undefined{})
-	v, e = BinaryOp(String("foo"), "in", obj)
-	if v != Boolean(true) || e != nil {
-		t.Errorf(`"foo" in, %#v == (%#v, %#v) (expected (true, nil))`,
-			obj, v, e)
+	v, ne = BinaryOp(String("foo"), "in", obj)
+	if v != Boolean(true) || ne != nil {
+		t.Errorf(`"foo" in, %#v == (%#v, %#v) (expected (true, nil))`, obj, v, ne)
 	}
-	v, e = BinaryOp(String("length"), "in", NewArray(nil, protos.ArrayProto))
-	if v != Boolean(true) || e != nil {
-		t.Errorf(`"foo" in [] == (%#v, %#v) (expected true, nil)`, v, e)
+	v, ne = BinaryOp(String("length"), "in", NewArray(nil, protos.ArrayProto))
+	if v != Boolean(true) || ne != nil {
+		t.Errorf(`"foo" in [] == (%#v, %#v) (expected true, nil)`, v, ne)
 	}
-	v, e = BinaryOp(String("length"), "in", String("foo"))
-	if e == nil || e.Name != "TypeError" {
-		t.Errorf(`"length" in "foo" == (%#v, %#v) (expected nil, TypeError)`, v, e)
+	v, ne = BinaryOp(String("length"), "in", String("foo"))
+	if ne == nil || ne.Type != TypeError {
+		t.Errorf(`"length" in "foo" == (%#v, %#v) (expected nil, TypeError)`, v, ne)
 	}
 }

--- a/server/interpreter/data/object.go
+++ b/server/interpreter/data/object.go
@@ -28,18 +28,18 @@ type Object interface {
 	Proto() Object
 
 	// Get returns the current value of the given property or an
-	// ErrorMsg if that was not possible.
-	Get(name string) (Value, *ErrorMsg)
+	// NativeError if that was not possible.
+	Get(name string) (Value, *NativeError)
 
 	// Set sets the given property to the specified value or returns
-	// an ErrorMsg if that was not possible.
-	Set(name string, value Value) *ErrorMsg
+	// an NativeError if that was not possible.
+	Set(name string, value Value) *NativeError
 
 	// Delete attempts to remove the named property.  If the property
-	// exists but can't be removed for some reason an ErrorMsg is
+	// exists but can't be removed for some reason an NativeError is
 	// returned.  (Removing a non-existing property "succeeds"
 	// silently.)
-	Delete(name string) *ErrorMsg
+	Delete(name string) *NativeError
 
 	// OwnPropertyKeys returns the list of (own) property names as a
 	// slice of strings.
@@ -101,9 +101,9 @@ func (obj object) Proto() Object {
 	return obj.proto
 }
 
-// Get returns the current value of the given property or an ErrorMsg
-// if that was not possible.
-func (obj object) Get(key string) (Value, *ErrorMsg) {
+// Get returns the current value of the given property or an
+// NativeError if that was not possible.
+func (obj object) Get(key string) (Value, *NativeError) {
 	pd, ok := obj.properties[key]
 	// FIXME: permissions check for property readability goes here
 	if ok {
@@ -118,8 +118,8 @@ func (obj object) Get(key string) (Value, *ErrorMsg) {
 }
 
 // Set sets the given property to the specified value or returns an
-// ErrorMsg if that was not possible.
-func (obj *object) Set(key string, value Value) *ErrorMsg {
+// NativeError if that was not possible.
+func (obj *object) Set(key string, value Value) *NativeError {
 	pd, ok := obj.properties[key]
 	if !ok { // Creating new property
 		// FIXME: permissions check for object writability goes here
@@ -143,7 +143,7 @@ func (obj *object) Set(key string, value Value) *ErrorMsg {
 // Delete removes the named property if possible.
 //
 // FIXME: perm / immutability checks!
-func (obj *object) Delete(key string) *ErrorMsg {
+func (obj *object) Delete(key string) *NativeError {
 	delete(obj.properties, key)
 	return nil
 }

--- a/server/interpreter/data/propiter_test.go
+++ b/server/interpreter/data/propiter_test.go
@@ -22,9 +22,9 @@ func TestPropIterSimpleObj(t *testing.T) {
 	keys := []string{"foo", "bar", "baz"}
 	obj := NewObject(nil, nil)
 	for _, k := range keys {
-		err := obj.Set(k, String(k))
-		if err != nil {
-			t.Error(err)
+		ne := obj.Set(k, String(k))
+		if ne != nil {
+			t.Errorf("obj.Set(%#v, %#v) returned %v", k, String(k), ne)
 		}
 	}
 
@@ -52,15 +52,15 @@ func TestPropIterInheritance(t *testing.T) {
 	obj1 := NewObject(nil, nil)
 	obj2 := NewObject(nil, obj1)
 	for _, k := range keys1 {
-		err := obj1.Set(k, String(k))
-		if err != nil {
-			t.Error(err)
+		ne := obj1.Set(k, String(k))
+		if ne != nil {
+			t.Error(ne)
 		}
 	}
 	for _, k := range keys2 {
-		err := obj2.Set(k, String(k))
-		if err != nil {
-			t.Error(err)
+		ne := obj2.Set(k, String(k))
+		if ne != nil {
+			t.Errorf("obj.Set(%#v, %#v) returned %v", k, String(k), ne)
 		}
 	}
 
@@ -84,9 +84,9 @@ func TestPropIterDelete(t *testing.T) {
 	keys := []string{"foo", "bar", "baz"}
 	obj := NewObject(nil, nil)
 	for _, k := range keys {
-		err := obj.Set(k, String(k))
-		if err != nil {
-			t.Error(err)
+		ne := obj.Set(k, String(k))
+		if ne != nil {
+			t.Errorf("obj.Set(%#v, %#v) returned %v", k, String(k), ne)
 		}
 	}
 

--- a/server/interpreter/data/protos.go
+++ b/server/interpreter/data/protos.go
@@ -57,11 +57,17 @@ func NewProtos() *Protos {
 	prts.ErrorProto = NewObject(nil, prts.ObjectProto)
 
 	prts.EvalErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.EvalErrorProto.Set("name", String("EvalError"))
 	prts.RangeErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.RangeErrorProto.Set("name", String("RangeError"))
 	prts.ReferenceErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.ReferenceErrorProto.Set("name", String("ReferenceError"))
 	prts.SyntaxErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.SyntaxErrorProto.Set("name", String("SyntaxError"))
 	prts.TypeErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.TypeErrorProto.Set("name", String("TypeError"))
 	prts.URIErrorProto = NewObject(nil, prts.ErrorProto)
+	prts.URIErrorProto.Set("name", String("URIError"))
 
 	prts.OwnerProto = NewOwner(prts.ObjectProto)
 

--- a/server/interpreter/interpreter.go
+++ b/server/interpreter/interpreter.go
@@ -124,3 +124,32 @@ func (intrp *Interpreter) toObject(value data.Value, owner *data.Owner) data.Obj
 		panic(fmt.Errorf("Can't coerce a %T to Object", v))
 	}
 }
+
+// nativeError takes a data.NativeError error specification and an
+// owner and creates a corresponding native error object.
+func (intrp *Interpreter) nativeError(ne *data.NativeError, o *data.Owner) data.Object {
+	var e data.Object
+	switch ne.Type {
+	case data.EvalError:
+		e = data.NewObject(o, intrp.protos.EvalErrorProto)
+	case data.RangeError:
+		e = data.NewObject(o, intrp.protos.RangeErrorProto)
+	case data.ReferenceError:
+		e = data.NewObject(o, intrp.protos.ReferenceErrorProto)
+	case data.SyntaxError:
+		e = data.NewObject(o, intrp.protos.SyntaxErrorProto)
+	case data.TypeError:
+		e = data.NewObject(o, intrp.protos.TypeErrorProto)
+	case data.URIError:
+		e = data.NewObject(o, intrp.protos.URIErrorProto)
+	default:
+		panic(fmt.Errorf("Unknown NativeErrorType %d", ne.Type))
+	}
+	e.Set("message", data.String(ne.Message))
+	return e
+}
+
+func (intrp *Interpreter) throw(ne *data.NativeError) *cval {
+	// FIXME: set owner.
+	return &cval{THROW, intrp.nativeError(ne, nil), ""}
+}


### PR DESCRIPTION
NativeError doesn’t implement the go Error interface, to make it clear
this is a template for JS Error objects rather than a structured Go
error type.

Add Interpreter.newError (to construct JS Error objects) and
Interpreter.throw (to throw them); use these where previously we
panic()ed a ErrorMsg.