### PR TITLE
Internal improvements in advance of implementing threads

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -511,10 +511,23 @@ Interpreter.prototype.initObject = function(scope) {
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   // Instance methods on Object.
-  this.setNativeFunctionPrototype(ObjectConst, 'toString',
-      Interpreter.Object.prototype.toString);
-  this.setNativeFunctionPrototype(ObjectConst, 'toLocaleString',
-      Interpreter.Object.prototype.toString);
+  wrapper = function () {
+    var c;
+    if (this instanceof Interpreter.Object) {
+      c = this.class;
+    } else {
+      c = ({
+        undefined: 'Undefined',
+        null: 'Null',
+        boolean: 'Boolean',
+        number: 'Number',
+        string: 'String',
+      })[typeof this];
+    }
+    return '[object ' + c + ']';
+  };
+  this.setNativeFunctionPrototype(ObjectConst, 'toString', wrapper);
+  this.setNativeFunctionPrototype(ObjectConst, 'toLocaleString', wrapper);
   this.setNativeFunctionPrototype(ObjectConst, 'valueOf',
       Interpreter.Object.prototype.valueOf);
 
@@ -1331,6 +1344,10 @@ Interpreter.Object.prototype.data = null;
  * @override
  */
 Interpreter.Object.prototype.toString = function() {
+  // TODO(cpcallen): this funciton should not exist in its present
+  // form.  Each of the different classes (Object, Function, Array)
+  // should have their own toString implementation as described in the
+  // spec.
   if (this.class === 'Array') {
     // Array
     var cycles = Interpreter.toStringCycles_;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -184,9 +184,9 @@ Interpreter.prototype.initGlobalScope = function(scope) {
   // Create the objects which will become Object.prototype,
   // Function.prototype and Array.prototype, which are needed to
   // bootstrap everything else:
-  this.OBJECTPROTO = this.createObjectProto(null);
-  this.FUNCTIONPROTO = this.createFunction(this.OBJECTPROTO);
-  this.ARRAYPROTO = this.createArray(this.OBJECTPROTO);
+  this.OBJECT = this.createObjectProto(null);
+  this.FUNCTION = this.createFunction(this.OBJECT);
+  this.ARRAY = this.createArray(this.OBJECT);
   
   // Initialize global objects.
   this.initObject(scope);
@@ -286,7 +286,7 @@ Interpreter.prototype.initFunction = function(scope) {
         Interpreter.READONLY_DESCRIPTOR);
     return newFunc;
   };
-  var FunctionConst = this.createNativeFunction(wrapper, this.FUNCTIONPROTO);
+  var FunctionConst = this.createNativeFunction(wrapper, this.FUNCTION);
   this.addVariableToScope(scope, 'Function', FunctionConst);
 
   wrapper = function(thisArg, args) {
@@ -363,7 +363,7 @@ Interpreter.prototype.initObject = function(scope) {
         return this;
       } else {
         // Called as Object().
-        return thisInterpreter.createObjectProto(thisInterpreter.OBJECTPROTO);
+        return thisInterpreter.createObjectProto(thisInterpreter.OBJECT);
       }
     }
     if (!value.isObject) {
@@ -374,7 +374,7 @@ Interpreter.prototype.initObject = function(scope) {
     // Return the provided object.
     return value;
   };
-  var ObjectConst = this.createNativeFunction(wrapper, this.OBJECTPROTO);
+  var ObjectConst = this.createNativeFunction(wrapper, this.OBJECT);
   this.addVariableToScope(scope, 'Object', ObjectConst);
 
   /**
@@ -598,7 +598,7 @@ Interpreter.prototype.initArray = function(scope) {
     }
     return newArray;
   };
-  var ArrayConst = this.createNativeFunction(wrapper, this.ARRAYPROTO);
+  var ArrayConst = this.createNativeFunction(wrapper, this.ARRAY);
   this.addVariableToScope(scope, 'Array', ArrayConst);
 
   // Static methods on Array.
@@ -806,10 +806,10 @@ Interpreter.prototype.initNumber = function(scope) {
   var thisInterpreter = this;
   var wrapper;
   // Number prototype.
-  this.NUMBERPROTO = this.createObjectProto(this.OBJECTPROTO);
-  this.NUMBERPROTO.class = 'Number';
+  this.NUMBER = this.createObjectProto(this.OBJECT);
+  this.NUMBER.class = 'Number';
   // Number constructor.
-  var NumberConst = this.createNativeFunction(Number, this.NUMBERPROTO);
+  var NumberConst = this.createNativeFunction(Number, this.NUMBER);
   NumberConst.illegalConstructor = true;  // Don't allow 'new Number(x)'.
   this.addVariableToScope(scope, 'Number', NumberConst);
 
@@ -892,10 +892,10 @@ Interpreter.prototype.initString = function(scope) {
   var thisInterpreter = this;
   var wrapper;
   // String prototype.
-  this.STRINGPROTO = this.createObjectProto(this.OBJECTPROTO);
-  this.STRINGPROTO.class = 'String';
+  this.STRING = this.createObjectProto(this.OBJECT);
+  this.STRING.class = 'String';
   // String constructor.
-  var StringConst = this.createNativeFunction(String, this.STRINGPROTO);
+  var StringConst = this.createNativeFunction(String, this.STRING);
   StringConst.illegalConstructor = true;  // Don't allow 'new String(x)'.
   this.addVariableToScope(scope, 'String', StringConst);
 
@@ -963,10 +963,10 @@ Interpreter.prototype.initString = function(scope) {
 Interpreter.prototype.initBoolean = function(scope) {
   var thisInterpreter = this;
   // Boolean prototype.
-  this.BOOLEANPROTO = this.createObjectProto(this.OBJECTPROTO);
-  this.BOOLEANPROTO.class = 'Boolean';
+  this.BOOLEAN = this.createObjectProto(this.OBJECT);
+  this.BOOLEAN.class = 'Boolean';
   // Boolean constructor.
-  var BooleanConst = this.createNativeFunction(Boolean, this.BOOLEANPROTO);
+  var BooleanConst = this.createNativeFunction(Boolean, this.BOOLEAN);
   BooleanConst.illegalConstructor = true;  // Don't allow 'new Boolean(x)'.
   this.addVariableToScope(scope, 'Boolean', BooleanConst);
 };
@@ -1047,7 +1047,7 @@ Interpreter.prototype.initDate = function(scope) {
  */
 Interpreter.prototype.initMath = function(scope) {
   var thisInterpreter = this;
-  var myMath = this.createObjectProto(this.OBJECTPROTO);
+  var myMath = this.createObjectProto(this.OBJECT);
   this.addVariableToScope(scope, 'Math', myMath);
   var mathConsts = ['E', 'LN2', 'LN10', 'LOG2E', 'LOG10E', 'PI',
                     'SQRT1_2', 'SQRT2'];
@@ -1087,7 +1087,7 @@ Interpreter.prototype.initRegExp = function(scope) {
     return rgx;
   };
   var RegExpConst = this.createNativeFunction(wrapper, true);
-  this.REGEXPPROTO = thisInterpreter.getProperty(RegExpConst, 'prototype');
+  this.REGEXP = thisInterpreter.getProperty(RegExpConst, 'prototype');
   this.addVariableToScope(scope, 'RegExp', RegExpConst);
 
   this.setProperty(RegExpConst.properties['prototype'], 'global', undefined,
@@ -1133,7 +1133,7 @@ Interpreter.prototype.initRegExp = function(scope) {
  */
 Interpreter.prototype.initJSON = function(scope) {
   var thisInterpreter = this;
-  var myJSON = thisInterpreter.createObjectProto(this.OBJECTPROTO);
+  var myJSON = thisInterpreter.createObjectProto(this.OBJECT);
   this.addVariableToScope(scope, 'JSON', myJSON);
 
   var wrapper = function(text) {
@@ -1166,7 +1166,7 @@ Interpreter.prototype.initJSON = function(scope) {
 Interpreter.prototype.initError = function(scope) {
   var thisInterpreter = this;
   // Error prototype:
-  this.ERRORPROTO = this.createError(this.OBJECTPROTO);
+  this.ERROR = this.createError(this.OBJECT);
   // Error constructor.
   var ErrorConst = this.createNativeFunction(function(opt_message) {
     if (thisInterpreter.calledWithNew()) {
@@ -1181,12 +1181,12 @@ Interpreter.prototype.initError = function(scope) {
           Interpreter.NONENUMERABLE_DESCRIPTOR);
     }
     return newError;
-  }, this.ERRORPROTO);
+  }, this.ERROR);
   this.addVariableToScope(scope, 'Error', ErrorConst);
   
-  this.setProperty(this.ERRORPROTO, 'message', '',
+  this.setProperty(this.ERROR, 'message', '',
       Interpreter.NONENUMERABLE_DESCRIPTOR);
-  this.setProperty(this.ERRORPROTO, 'name', 'Error',
+  this.setProperty(this.ERROR, 'name', 'Error',
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   var createErrorSubclass = function(name) {
@@ -1451,11 +1451,11 @@ Interpreter.prototype.createObjectProto = function(proto) {
 /**
  * Create a new function object.
  * @param {Interpreter.Object=} proto Prototype object (or null);
- *     defaults to this.FUNCTIONPROTO.
+ *     defaults to this.FUNCTION.
  * @return {!Interpreter.Object} New data object.
  */
 Interpreter.prototype.createFunction = function(proto) {
-  var p = (proto === undefined ? this.FUNCTIONPROTO : proto);
+  var p = (proto === undefined ? this.FUNCTION : proto);
   var obj = this.createObjectProto(p);
   obj.class = 'Function';
   return obj;
@@ -1476,7 +1476,7 @@ Interpreter.prototype.addFunctionPrototype = function(func, prototype) {
   } else if (func.illegalConstructor) {
     throw TypeError('func claims not to be a constructor!');
   }
-  var protoObj = prototype || this.createObjectProto(this.OBJECTPROTO);
+  var protoObj = prototype || this.createObjectProto(this.OBJECT);
   this.setProperty(func, 'prototype', protoObj,
       Interpreter.NONENUMERABLE_NONCONFIGURABLE_DESCRIPTOR);
   this.setProperty(protoObj, 'constructor', func,
@@ -1486,11 +1486,11 @@ Interpreter.prototype.addFunctionPrototype = function(func, prototype) {
 /**
  * Create a new array object.  See §15.4 of the ES5.1 spec.
  * @param {Interpreter.Object=} proto Prototype object (or null);
- *     defaults to this.ARRAYPROTO
+ *     defaults to this.ARRAY
  * @return {!Interpreter.Object} New array object.
  */
 Interpreter.prototype.createArray = function(proto) {
-  var p = (proto === undefined ? this.ARRAYPROTO : proto);
+  var p = (proto === undefined ? this.ARRAY : proto);
   var obj = this.createObjectProto(p);
   obj.class = 'Array';
   obj.length = 0;
@@ -1500,11 +1500,11 @@ Interpreter.prototype.createArray = function(proto) {
 /**
  * Create a new regexp object.
  * @param {Interpreter.Object=} proto Prototype object (or null);
- *     defaults to this.REGEXPPROTO
+ *     defaults to this.REGEXP
  * @return {!Interpreter.Object} New data object.
  */
 Interpreter.prototype.createRegExp = function(proto) {
-  var p = (proto === undefined ? this.REGEXPPROTO : proto);
+  var p = (proto === undefined ? this.REGEXP : proto);
   var obj = this.createObjectProto(p);
   obj.class = 'RegExp';
   return obj;
@@ -1513,11 +1513,11 @@ Interpreter.prototype.createRegExp = function(proto) {
 /**
  * Create a new error object.  See §15.11 of the ES5.1 spec.
  * @param {Interpreter.Object=} proto Prototype object (or null);
- *     defaults to this.ERRORPROTO
+ *     defaults to this.ERROR
  * @return {!Interpreter.Object} New array object.
  */
 Interpreter.prototype.createError = function(proto) {
-  var p = (proto === undefined ? this.ERRORPROTO : proto);
+  var p = (proto === undefined ? this.ERROR : proto);
   var obj = this.createObjectProto(p);
   obj.class = 'Error';
   return obj;
@@ -1645,7 +1645,7 @@ Interpreter.prototype.nativeToPseudo = function(nativeObj) {
       this.setProperty(pseudoObj, i, this.nativeToPseudo(nativeObj[i]));
     }
   } else {  // Object.
-    pseudoObj = this.createObjectProto(this.OBJECTPROTO);
+    pseudoObj = this.createObjectProto(this.OBJECT);
     for (var key in nativeObj) {
       this.setProperty(pseudoObj, key, this.nativeToPseudo(nativeObj[key]));
     }
@@ -1713,11 +1713,11 @@ Interpreter.prototype.pseudoToNative = function(pseudoObj, opt_cycles) {
 Interpreter.prototype.getPrototype = function(value) {
   switch (typeof value) {
     case 'number':
-      return this.NUMBERPROTO;
+      return this.NUMBER;
     case 'boolean':
-      return this.BOOLEANPROTO;
+      return this.BOOLEAN;
     case 'string':
-      return this.STRINGPROTO;
+      return this.STRING;
   }
   if (value) {
     return value.proto;
@@ -2878,7 +2878,7 @@ Interpreter.prototype['stepObjectExpression'] = function() {
   var property = state.node['properties'][n];
   if (!state.object_) {
     // First execution.
-    state.object_ = this.createObjectProto(this.OBJECTPROTO);
+    state.object_ = this.createObjectProto(this.OBJECT);
   } else {
     // Determine property name.
     var key = property['key'];

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -204,10 +204,10 @@ Interpreter.prototype.initGlobalScope = function(scope) {
   // Initialize global functions.
   var thisInterpreter = this;
   this.addVariableToScope(scope, 'isNaN',
-      this.createNativeFunction(isNaN, false));
+      this.createNativeFunction(isNaN));
 
   this.addVariableToScope(scope, 'isFinite',
-      this.createNativeFunction(isFinite, false));
+      this.createNativeFunction(isFinite));
 
   var func = this.createFunction();
   func.eval = true;
@@ -232,7 +232,7 @@ Interpreter.prototype.initGlobalScope = function(scope) {
       };
     })(strFunctions[i][0]);
     this.addVariableToScope(scope, strFunctions[i][1],
-        this.createNativeFunction(wrapper, false));
+        this.createNativeFunction(wrapper));
   }
 };
 
@@ -336,14 +336,14 @@ Interpreter.prototype.initFunction = function(scope) {
   };
   this.setNativeFunctionPrototype(FunctionConst, 'toString', wrapper);
   this.setProperty(FunctionConst, 'toString',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
   wrapper = function() {
     return this.valueOf();
   };
   this.setNativeFunctionPrototype(FunctionConst, 'valueOf', wrapper);
   this.setProperty(FunctionConst, 'valueOf',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 };
 
@@ -396,7 +396,7 @@ Interpreter.prototype.initObject = function(scope) {
     return thisInterpreter.nativeToPseudo(Object.getOwnPropertyNames(props));
   };
   this.setProperty(ObjectConst, 'getOwnPropertyNames',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   wrapper = function(obj) {
@@ -413,7 +413,7 @@ Interpreter.prototype.initObject = function(scope) {
     return thisInterpreter.nativeToPseudo(list);
   };
   this.setProperty(ObjectConst, 'keys',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   wrapper = function(proto) {
@@ -427,7 +427,7 @@ Interpreter.prototype.initObject = function(scope) {
     return thisInterpreter.createObject(proto);
   };
   this.setProperty(ObjectConst, 'create',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   wrapper = function(obj, prop, descriptor) {
@@ -454,7 +454,7 @@ Interpreter.prototype.initObject = function(scope) {
     return obj;
   };
   this.setProperty(ObjectConst, 'defineProperty',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   wrapper = function(obj, prop) {
@@ -479,7 +479,7 @@ Interpreter.prototype.initObject = function(scope) {
     return descriptor;
   };
   this.setProperty(ObjectConst, 'getOwnPropertyDescriptor',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   wrapper = function(obj) {
@@ -487,14 +487,14 @@ Interpreter.prototype.initObject = function(scope) {
     return thisInterpreter.getPrototype(obj);
   };
   this.setProperty(ObjectConst, 'getPrototypeOf',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   wrapper = function(obj) {
     return Boolean(obj) && !obj.preventExtensions;
   };
   this.setProperty(ObjectConst, 'isExtensible',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   wrapper = function(obj) {
@@ -504,7 +504,7 @@ Interpreter.prototype.initObject = function(scope) {
     return obj;
   };
   this.setProperty(ObjectConst, 'preventExtensions',
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   // Instance methods on Object.
@@ -606,7 +606,7 @@ Interpreter.prototype.initArray = function(scope) {
     return obj instanceof Interpreter.Array;
   };
   this.setProperty(ArrayConst, 'isArray',
-                   this.createNativeFunction(wrapper, false),
+                   this.createNativeFunction(wrapper),
                    Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   // Instance methods on Array.
@@ -822,10 +822,10 @@ Interpreter.prototype.initNumber = function(scope) {
 
   // Static methods on Number.
 
-  var nativeParseFloat = this.createNativeFunction(Number.parseFloat, false);
+  var nativeParseFloat = this.createNativeFunction(Number.parseFloat);
   this.setProperty(NumberConst, 'parseFloat', nativeParseFloat);
 
-  var nativeParseInt = this.createNativeFunction(Number.parseInt, false);
+  var nativeParseInt = this.createNativeFunction(Number.parseInt);
   this.setProperty(NumberConst, 'parseInt', nativeParseInt);
 
   // parseFloat and parseInt === Number.parseFloat and Number.parseInt
@@ -901,7 +901,7 @@ Interpreter.prototype.initString = function(scope) {
 
   // Static methods on String.
   this.setProperty(StringConst, 'fromCharCode',
-      this.createNativeFunction(String.fromCharCode, false),
+      this.createNativeFunction(String.fromCharCode),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   // Instance methods on String.
@@ -978,6 +978,9 @@ Interpreter.prototype.initBoolean = function(scope) {
 Interpreter.prototype.initDate = function(scope) {
   var thisInterpreter = this;
   var wrapper;
+  // Date prototype.  As of ES6 this is just an ordinary object.  (In
+  // ES5 it had [[Class]] Date.)
+  this.DATE = this.createObject();
   // Date constructor.
   wrapper = function(value, var_args) {
     if (!thisInterpreter.calledWithNew()) {
@@ -990,18 +993,18 @@ Interpreter.prototype.initDate = function(scope) {
     this.data = new (Function.prototype.bind.apply(Date, args));
     return this;
   };
-  var DateProto = this.createNativeFunction(wrapper, true);
-  this.addVariableToScope(scope, 'Date', DateProto);
+  var DateConst = this.createNativeFunction(wrapper, this.DATE);
+  this.addVariableToScope(scope, 'Date', DateConst);
 
   // Static methods on Date.
-  this.setProperty(DateProto, 'now', this.createNativeFunction(Date.now, false),
+  this.setProperty(DateConst, 'now', this.createNativeFunction(Date.now),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
-  this.setProperty(DateProto, 'parse',
-      this.createNativeFunction(Date.parse, false),
+  this.setProperty(DateConst, 'parse',
+      this.createNativeFunction(Date.parse),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
-  this.setProperty(DateProto, 'UTC', this.createNativeFunction(Date.UTC, false),
+  this.setProperty(DateConst, 'UTC', this.createNativeFunction(Date.UTC),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   // Instance methods on Date.
@@ -1022,7 +1025,7 @@ Interpreter.prototype.initDate = function(scope) {
         return this.data[nativeFunc].apply(this.data, arguments);
       };
     })(functions[i]);
-    this.setNativeFunctionPrototype(DateProto, functions[i], wrapper);
+    this.setNativeFunctionPrototype(DateConst, functions[i], wrapper);
   }
   var functions = ['toLocaleDateString', 'toLocaleString',
                    'toLocaleTimeString'];
@@ -1037,7 +1040,7 @@ Interpreter.prototype.initDate = function(scope) {
         return this.data[nativeFunc].call(this.data, locales, options);
       };
     })(functions[i]);
-    this.setNativeFunctionPrototype(DateProto, functions[i], wrapper);
+    this.setNativeFunctionPrototype(DateConst, functions[i], wrapper);
   }
 };
 
@@ -1060,7 +1063,7 @@ Interpreter.prototype.initMath = function(scope) {
                       'round', 'sin', 'sqrt', 'tan'];
   for (var i = 0; i < numFunctions.length; i++) {
     this.setProperty(myMath, numFunctions[i],
-        this.createNativeFunction(Math[numFunctions[i]], false),
+        this.createNativeFunction(Math[numFunctions[i]]),
         Interpreter.NONENUMERABLE_DESCRIPTOR);
   }
 };
@@ -1072,6 +1075,9 @@ Interpreter.prototype.initMath = function(scope) {
 Interpreter.prototype.initRegExp = function(scope) {
   var thisInterpreter = this;
   var wrapper;
+  // RegExp prototype.  As of ES6 this is just an ordinary object.
+  // (In ES5 it had [[Class]] RegExp.)
+  this.REGEXP = this.createObject();
   // RegExp constructor.
   wrapper = function(pattern, flags) {
     if (thisInterpreter.calledWithNew()) {
@@ -1086,8 +1092,7 @@ Interpreter.prototype.initRegExp = function(scope) {
     thisInterpreter.populateRegExp(rgx, new RegExp(pattern, flags));
     return rgx;
   };
-  var RegExpConst = this.createNativeFunction(wrapper, true);
-  this.REGEXP = thisInterpreter.getProperty(RegExpConst, 'prototype');
+  var RegExpConst = this.createNativeFunction(wrapper, this.REGEXP);
   this.addVariableToScope(scope, 'RegExp', RegExpConst);
 
   this.setProperty(RegExpConst.properties['prototype'], 'global', undefined,
@@ -1144,7 +1149,7 @@ Interpreter.prototype.initJSON = function(scope) {
     }
     return thisInterpreter.nativeToPseudo(nativeObj);
   };
-  this.setProperty(myJSON, 'parse', this.createNativeFunction(wrapper, false));
+  this.setProperty(myJSON, 'parse', this.createNativeFunction(wrapper));
 
   wrapper = function(value) {
     var nativeObj = thisInterpreter.pseudoToNative(value);
@@ -1156,7 +1161,7 @@ Interpreter.prototype.initJSON = function(scope) {
     return str;
   };
   this.setProperty(myJSON, 'stringify',
-      this.createNativeFunction(wrapper, false));
+      this.createNativeFunction(wrapper));
 };
 
 /**
@@ -1165,7 +1170,7 @@ Interpreter.prototype.initJSON = function(scope) {
  */
 Interpreter.prototype.initError = function(scope) {
   var thisInterpreter = this;
-  // Error prototype:
+  // Error prototype.
   this.ERROR = this.createError(this.OBJECT);
   // Error constructor.
   var ErrorConst = this.createNativeFunction(function(opt_message) {
@@ -1440,7 +1445,7 @@ Interpreter.prototype.createObject = function(proto) {
 };
 
 /**
- * Class for a function
+ * Class for a function.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
  */
@@ -1462,10 +1467,13 @@ Interpreter.Function.prototype.class = 'Function';
  */
 Interpreter.Function.prototype.addPrototype = function(thisInterpreter, prototype) {
   if (this.illegalConstructor) {
-    throw TypeError("You said this wasn't constructor!");
+    // It's almost certainly an erro add a .prototype property to a
+    // function we have declared isn't a constructor.  (This doesn't
+    // prevent user code from doing so - just makes sure we don't do
+    // it accidentally when bootstrapping or whatever.)
+    throw TypeError("Illogical addition of .prototype to non-constructor");
   }
-  var protoObj = prototype ||
-      thisInterpreter.createObject();
+  var protoObj = prototype || thisInterpreter.createObject();
   thisInterpreter.setProperty(this, 'prototype', protoObj,
       Interpreter.NONENUMERABLE_NONCONFIGURABLE_DESCRIPTOR);
   thisInterpreter.setProperty(protoObj, 'constructor', this,
@@ -1485,7 +1493,7 @@ Interpreter.prototype.createFunction = function(proto) {
 };
 
 /**
- * Class for an array
+ * Class for an array.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
  */
@@ -1510,7 +1518,31 @@ Interpreter.prototype.createArray = function(proto) {
 };
 
 /**
- * Class for a regexp
+ * Class for a date.
+ * @param {Interpreter.Object} proto Prototype object.
+ * @constructor
+ */
+Interpreter.Date = function(proto) {
+  Interpreter.Object.call(this, proto);
+};
+
+Interpreter.Date.prototype = Object.create(Interpreter.Object.prototype);
+Interpreter.Date.prototype.constructor = Interpreter.Date;
+Interpreter.Date.prototype.class = 'Date';
+
+/**
+ * Create a new date object.
+ * @param {Interpreter.Object=} proto Prototype object (or null);
+ *     defaults to this.DATE
+ * @return {!Interpreter.Object} New data object.
+ */
+Interpreter.prototype.createDate = function(proto) {
+  var p = (proto === undefined ? this.DATE : proto);
+  return new Interpreter.Date(p);
+};
+
+/**
+ * Class for a regexp.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
  */
@@ -1534,7 +1566,7 @@ Interpreter.prototype.createRegExp = function(proto) {
 };
 
 /**
- * Class for an error object
+ * Class for an error object.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
  */
@@ -1597,13 +1629,11 @@ Interpreter.prototype.createFunctionFromAST = function(node, scope) {
 /**
  * Create a new native function.
  * @param {!Function} nativeFunc JavaScript function.
- * @param {!Interpreter.Object|boolean=} prototype If an object is
- *     supplied, that object will be added as the function's
- *     .prototype property (with the object receivieng a corresponding
- *     .constructor properyt).  If true, a new ordinary
- *     Interpreter.Object will be created for the purpose.  If false
- *     (or unspecified) the function cannot be used as a constructor
- *     (e.g. escape).
+ * @param {!Interpreter.Object|boolean=} prototype If an object (or
+ *     null) is supplied, that object will be added as the function's
+ *     .prototype property (with the object receiving a corresponding
+ *     .constructor property).  If undefined or omitted the function
+ *     cannot be used as a constructor (e.g. escape).
  * @return {!Interpreter.Object} New function.
  */
 Interpreter.prototype.createNativeFunction = function(nativeFunc, prototype) {
@@ -1612,12 +1642,10 @@ Interpreter.prototype.createNativeFunction = function(nativeFunc, prototype) {
   nativeFunc.id = this.functionCounter_++;
   this.setProperty(func, 'length', nativeFunc.length,
       Interpreter.READONLY_DESCRIPTOR);
-  if (prototype === true) {
-    func.addPrototype(this);
-  } else if (prototype) {
-    func.addPrototype(this, prototype);
-  } else {
+  if (prototype === undefined) {
     func.illegalConstructor = true;
+  } else {
+    func.addPrototype(this, prototype);
   }
   return func;
 };
@@ -1917,7 +1945,7 @@ Interpreter.prototype.deleteProperty = function(obj, name) {
 Interpreter.prototype.setNativeFunctionPrototype =
     function(obj, name, wrapper) {
   this.setProperty(obj.properties['prototype'], name,
-      this.createNativeFunction(wrapper, false),
+      this.createNativeFunction(wrapper),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1142,7 +1142,7 @@ Interpreter.prototype.initError = function(scope) {
       var newError = this;
     } else {
       // Called as Error().
-      var newError = thisInterpreter.createObject(thisInterpreter.ERROR);
+      var newError = thisInterpreter.createError();
     }
     if (opt_message) {
       thisInterpreter.setProperty(newError, 'message', opt_message + '',
@@ -1173,7 +1173,7 @@ Interpreter.prototype.initError = function(scope) {
           return newError;
         }, true);
     thisInterpreter.setProperty(constructor, 'prototype',
-        thisInterpreter.createObject(thisInterpreter.ERROR));
+        thisInterpreter.createError());
     thisInterpreter.setProperty(constructor.properties['prototype'], 'name',
         name, Interpreter.NONENUMERABLE_DESCRIPTOR);
     thisInterpreter.addVariableToScope(scope, name, constructor);
@@ -1409,11 +1409,6 @@ Interpreter.prototype.createObject = function(constructor) {
  */
 Interpreter.prototype.createObjectProto = function(proto) {
   var obj = new Interpreter.Object(proto);
-  // Arrays have length.
-  // TODO(cpcallen): Move this bit to a separate createError function.
-  if (this.isa(obj, this.ERROR)) {
-    obj.class = 'Error';
-  }
   return obj;
 };
 
@@ -1433,13 +1428,23 @@ Interpreter.prototype.createFunction = function() {
 };
 
 /**
- * Create a new array object.  See §15.4 fo the ES5.1 spec.
+ * Create a new array object.  See §15.4 of the ES5.1 spec.
  * @return {!Interpreter.Object} New array object.
  */
 Interpreter.prototype.createArray = function() {
   var obj = this.createObject(this.ARRAY);
   obj.class = 'Array';
   obj.length = 0;
+  return obj;
+};
+
+/**
+ * Create a new error object.  See §15.11 of the ES5.1 spec.
+ * @return {!Interpreter.Object} New array object.
+ */
+Interpreter.prototype.createError = function() {
+  var obj = this.createObject(this.ERROR);
+  obj.class = 'Error';
   return obj;
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -565,7 +565,7 @@ Interpreter.prototype.initArray = function(scope) {
       var newArray = this;
     } else {
       // Called as Array().
-      var newArray = thisInterpreter.createObject(thisInterpreter.ARRAY);
+      var newArray = thisInterpreter.createArray();
     }
     var first = arguments[0];
     if (arguments.length === 1 && typeof first === 'number') {
@@ -660,7 +660,7 @@ Interpreter.prototype.initArray = function(scope) {
     }
     howmany = getInt(howmany, Infinity);
     howmany = Math.min(howmany, this.length - index);
-    var removed = thisInterpreter.createObject(thisInterpreter.ARRAY);
+    var removed = thisInterpreter.createArray();
     // Remove specified elements.
     for (var i = index; i < index + howmany; i++) {
       removed.properties[removed.length++] = this.properties[i];
@@ -688,7 +688,7 @@ Interpreter.prototype.initArray = function(scope) {
   this.setNativeFunctionPrototype(this.ARRAY, 'splice', wrapper);
 
   wrapper = function(opt_begin, opt_end) {
-    var list = thisInterpreter.createObject(thisInterpreter.ARRAY);
+    var list = thisInterpreter.createArray();
     var begin = getInt(opt_begin, 0);
     if (begin < 0) {
       begin = this.length + begin;
@@ -724,7 +724,7 @@ Interpreter.prototype.initArray = function(scope) {
   this.setNativeFunctionPrototype(this.ARRAY, 'join', wrapper);
 
   wrapper = function(var_args) {
-    var list = thisInterpreter.createObject(thisInterpreter.ARRAY);
+    var list = thisInterpreter.createArray();
     var length = 0;
     // Start by copying the current array.
     for (var i = 0; i < this.length; i++) {
@@ -1083,7 +1083,7 @@ Interpreter.prototype.initRegExp = function(scope) {
     thisInterpreter.setProperty(this, 'lastIndex', this.data.lastIndex);
 
     if (match) {
-      var result = thisInterpreter.createObject(thisInterpreter.ARRAY);
+      var result = thisInterpreter.createArray();
       for (var i = 0; i < match.length; i++) {
         thisInterpreter.setProperty(result, i, match[i]);
       }
@@ -1410,11 +1410,6 @@ Interpreter.prototype.createObject = function(constructor) {
 Interpreter.prototype.createObjectProto = function(proto) {
   var obj = new Interpreter.Object(proto);
   // Arrays have length.
-  // TODO(cpcallen): Move this bit to a separate createArray function.
-  if (this.isa(obj, this.ARRAY)) {
-    obj.length = 0;
-    obj.class = 'Array';
-  }
   // TODO(cpcallen): Move this bit to a separate createError function.
   if (this.isa(obj, this.ERROR)) {
     obj.class = 'Error';
@@ -1423,8 +1418,8 @@ Interpreter.prototype.createObjectProto = function(proto) {
 };
 
 /**
- * Create a new function object and its associated prototype.  This
- * implements parts of §13.2 of the ES5.1 spec.
+ * Create a new function object and its associated prototype object.
+ * This implements parts of §13.2 of the ES5.1 spec.
  * @return {!Interpreter.Object} New data object.
  */
 Interpreter.prototype.createFunction = function() {
@@ -1434,6 +1429,17 @@ Interpreter.prototype.createFunction = function() {
   var protoObj = this.createObject(this.OBJECT || null);
   this.setProperty(obj, 'prototype', protoObj);
   this.setProperty(protoObj, 'constructor', obj);
+  return obj;
+};
+
+/**
+ * Create a new array object.  See §15.4 fo the ES5.1 spec.
+ * @return {!Interpreter.Object} New array object.
+ */
+Interpreter.prototype.createArray = function() {
+  var obj = this.createObject(this.ARRAY);
+  obj.class = 'Array';
+  obj.length = 0;
   return obj;
 };
 
@@ -1550,7 +1556,7 @@ Interpreter.prototype.nativeToPseudo = function(nativeObj) {
 
   var pseudoObj;
   if (Array.isArray(nativeObj)) {  // Array.
-    pseudoObj = this.createObject(this.ARRAY);
+    pseudoObj = this.createArray();
     for (var i = 0; i < nativeObj.length; i++) {
       this.setProperty(pseudoObj, i, this.nativeToPseudo(nativeObj[i]));
     }
@@ -2076,7 +2082,7 @@ Interpreter.prototype['stepArrayExpression'] = function() {
   var elements = state.node['elements'];
   var n = state.n_ || 0;
   if (!state.array_) {
-    state.array_ = this.createObject(this.ARRAY);
+    state.array_ = this.createArray();
   } else if (state.value) {
     this.setProperty(state.array_, n - 1, state.value);
   }
@@ -2365,7 +2371,7 @@ Interpreter.prototype['stepCallExpression'] = function() {
         this.addVariableToScope(scope, paramName, paramValue);
       }
       // Build arguments variable.
-      var argsList = this.createObject(this.ARRAY);
+      var argsList = this.createArray();
       for (var i = 0; i < state.arguments_.length; i++) {
         this.setProperty(argsList, i, state.arguments_[i]);
       }

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1455,7 +1455,7 @@ Interpreter.prototype.populateRegExp = function(pseudoRegexp, nativeRegexp) {
  * @param {!Object} scope Parent scope.
  * @return {!Interpreter.Object} New function.
  */
-Interpreter.prototype.createFunction = function(node, scope) {
+Interpreter.prototype.createFunctionFromAST = function(node, scope) {
   var func = this.createObject(this.FUNCTION);
   func.parentScope = scope;
   func.node = node;
@@ -1902,7 +1902,7 @@ Interpreter.prototype.populateScope_ = function(node, scope) {
     }
   } else if (node['type'] === 'FunctionDeclaration') {
     this.addVariableToScope(scope, node['id']['name'],
-                            this.createFunction(node, scope));
+                            this.createFunctionFromAST(node, scope));
     return;  // Do not recurse into function.
   } else if (node['type'] === 'FunctionExpression') {
     return;  // Do not recurse into function.
@@ -2683,7 +2683,7 @@ Interpreter.prototype['stepFunctionExpression'] = function() {
   var stack = this.stateStack;
   var state = stack.pop();
   stack[stack.length - 1].value =
-      this.createFunction(state.node, this.getScope());
+      this.createFunctionFromAST(state.node, this.getScope());
 };
 
 Interpreter.prototype['stepIdentifier'] = function() {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -363,7 +363,7 @@ Interpreter.prototype.initObject = function(scope) {
         return this;
       } else {
         // Called as Object().
-        return thisInterpreter.createObject(thisInterpreter.OBJECT);
+        return thisInterpreter.createObject();
       }
     }
     if (!value.isObject) {
@@ -806,7 +806,7 @@ Interpreter.prototype.initNumber = function(scope) {
   var thisInterpreter = this;
   var wrapper;
   // Number prototype.
-  this.NUMBER = this.createObject(this.OBJECT);
+  this.NUMBER = this.createObject();
   this.NUMBER.class = 'Number';
   // Number constructor.
   var NumberConst = this.createNativeFunction(Number, this.NUMBER);
@@ -892,7 +892,7 @@ Interpreter.prototype.initString = function(scope) {
   var thisInterpreter = this;
   var wrapper;
   // String prototype.
-  this.STRING = this.createObject(this.OBJECT);
+  this.STRING = this.createObject();
   this.STRING.class = 'String';
   // String constructor.
   var StringConst = this.createNativeFunction(String, this.STRING);
@@ -963,7 +963,7 @@ Interpreter.prototype.initString = function(scope) {
 Interpreter.prototype.initBoolean = function(scope) {
   var thisInterpreter = this;
   // Boolean prototype.
-  this.BOOLEAN = this.createObject(this.OBJECT);
+  this.BOOLEAN = this.createObject();
   this.BOOLEAN.class = 'Boolean';
   // Boolean constructor.
   var BooleanConst = this.createNativeFunction(Boolean, this.BOOLEAN);
@@ -1047,7 +1047,7 @@ Interpreter.prototype.initDate = function(scope) {
  */
 Interpreter.prototype.initMath = function(scope) {
   var thisInterpreter = this;
-  var myMath = this.createObject(this.OBJECT);
+  var myMath = this.createObject();
   this.addVariableToScope(scope, 'Math', myMath);
   var mathConsts = ['E', 'LN2', 'LN10', 'LOG2E', 'LOG10E', 'PI',
                     'SQRT1_2', 'SQRT2'];
@@ -1133,7 +1133,7 @@ Interpreter.prototype.initRegExp = function(scope) {
  */
 Interpreter.prototype.initJSON = function(scope) {
   var thisInterpreter = this;
-  var myJSON = thisInterpreter.createObject(this.OBJECT);
+  var myJSON = thisInterpreter.createObject();
   this.addVariableToScope(scope, 'JSON', myJSON);
 
   var wrapper = function(text) {
@@ -1465,7 +1465,7 @@ Interpreter.Function.prototype.addPrototype = function(thisInterpreter, prototyp
     throw TypeError("You said this wasn't constructor!");
   }
   var protoObj = prototype ||
-      thisInterpreter.createObject(thisInterpreter.OBJECT);
+      thisInterpreter.createObject();
   thisInterpreter.setProperty(this, 'prototype', protoObj,
       Interpreter.NONENUMERABLE_NONCONFIGURABLE_DESCRIPTOR);
   thisInterpreter.setProperty(protoObj, 'constructor', this,
@@ -1679,7 +1679,7 @@ Interpreter.prototype.nativeToPseudo = function(nativeObj) {
       this.setProperty(pseudoObj, i, this.nativeToPseudo(nativeObj[i]));
     }
   } else {  // Object.
-    pseudoObj = this.createObject(this.OBJECT);
+    pseudoObj = this.createObject();
     for (var key in nativeObj) {
       this.setProperty(pseudoObj, key, this.nativeToPseudo(nativeObj[key]));
     }
@@ -2910,7 +2910,7 @@ Interpreter.prototype['stepObjectExpression'] = function() {
   var property = state.node['properties'][n];
   if (!state.object_) {
     // First execution.
-    state.object_ = this.createObject(this.OBJECT);
+    state.object_ = this.createObject();
   } else {
     // Determine property name.
     var key = property['key'];

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1429,17 +1429,6 @@ Interpreter.Object.prototype.valueOf = function() {
 
 /**
  * Create a new data object.
- * @param {Interpreter.Object} constructor Parent constructor function,
- *     or null if scope object.
- * @return {!Interpreter.Object} New data object.
- */
-Interpreter.prototype.createObject = function(constructor) {
-  return this.createObjectProto(constructor &&
-                                constructor.properties['prototype']);
-};
-
-/**
- * Create a new data object.
  * @param {Interpreter.Object} proto Prototype object.
  * @return {!Interpreter.Object} New data object.
  */
@@ -2421,7 +2410,8 @@ Interpreter.prototype['stepCallExpression'] = function() {
         this.throwException(this.TYPE_ERROR, func + ' is not a constructor');
       }
       // Constructor, 'this' is new object.
-      state.funcThis_ = this.createObject(func);
+      state.funcThis_ = this.createObjectProto(
+          this.getProperty(func, 'prototype'));
       state.isConstructor = true;
     } else if (state.components_) {
       // Method function, 'this' is object.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2236,9 +2236,11 @@ Interpreter.prototype['stepBinaryExpression'] = function() {
     }
     value = this.hasProperty(rightSide, leftSide);
   } else if (node['operator'] === 'instanceof') {
-    if (!this.isa(rightSide, this.FUNCTION)) {
+    // TODO(cpcallen): rewrite this as rightSide instanceof
+    // Interpreter.Function once such a class exists.
+    if (!rightSide || !rightSide.class === 'function') {
       this.throwException(this.TYPE_ERROR,
-          'Expecting a function in instanceof check');
+          'Right-hand side of instanceof is not an object');
     }
     value = leftSide.isObject ? this.isa(leftSide, rightSide) : false;
   } else {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1429,13 +1429,27 @@ Interpreter.Object.prototype.valueOf = function() {
 
 /**
  * Create a new data object.
- * @param {Interpreter.Object} proto Prototype object.
+ * @param {Interpreter.Object=} proto Prototype object (or null);
+ *     defaults to this.OBJECT.
  * @return {!Interpreter.Object} New data object.
  */
 Interpreter.prototype.createObject = function(proto) {
-  var obj = new Interpreter.Object(proto);
-  return obj;
+  var p = (proto === undefined ? this.OBJECT : proto);
+  return new Interpreter.Object(p);
 };
+
+/**
+ * Class for a function
+ * @param {Interpreter.Object} proto Prototype object.
+ * @constructor
+ */
+Interpreter.Function = function(proto) {
+  Interpreter.Object.call(this, proto);
+};
+
+Interpreter.Function.prototype = Object.create(Interpreter.Object.prototype);
+Interpreter.Function.prototype.constructor = Interpreter.Function;
+Interpreter.Function.prototype.class = 'Function';
 
 /**
  * Create a new function object.
@@ -1445,9 +1459,7 @@ Interpreter.prototype.createObject = function(proto) {
  */
 Interpreter.prototype.createFunction = function(proto) {
   var p = (proto === undefined ? this.FUNCTION : proto);
-  var obj = this.createObject(p);
-  obj.class = 'Function';
-  return obj;
+  return new Interpreter.Function(p);
 };
 
 /**
@@ -1473,6 +1485,20 @@ Interpreter.prototype.addFunctionPrototype = function(func, prototype) {
 };
 
 /**
+ * Class for an array
+ * @param {Interpreter.Object} proto Prototype object.
+ * @constructor
+ */
+Interpreter.Array = function(proto) {
+  Interpreter.Object.call(this, proto);
+  this.length = 0;
+};
+
+Interpreter.Array.prototype = Object.create(Interpreter.Object.prototype);
+Interpreter.Array.prototype.constructor = Interpreter.Array;
+Interpreter.Array.prototype.class = 'Array';
+
+/**
  * Create a new array object.  See §15.4 of the ES5.1 spec.
  * @param {Interpreter.Object=} proto Prototype object (or null);
  *     defaults to this.ARRAY
@@ -1480,11 +1506,21 @@ Interpreter.prototype.addFunctionPrototype = function(func, prototype) {
  */
 Interpreter.prototype.createArray = function(proto) {
   var p = (proto === undefined ? this.ARRAY : proto);
-  var obj = this.createObject(p);
-  obj.class = 'Array';
-  obj.length = 0;
-  return obj;
+  return new Interpreter.Array(p);
 };
+
+/**
+ * Class for a regexp
+ * @param {Interpreter.Object} proto Prototype object.
+ * @constructor
+ */
+Interpreter.RegExp = function(proto) {
+  Interpreter.Object.call(this, proto);
+};
+
+Interpreter.RegExp.prototype = Object.create(Interpreter.Object.prototype);
+Interpreter.RegExp.prototype.constructor = Interpreter.RegExp;
+Interpreter.RegExp.prototype.class = 'RegExp';
 
 /**
  * Create a new regexp object.
@@ -1494,10 +1530,21 @@ Interpreter.prototype.createArray = function(proto) {
  */
 Interpreter.prototype.createRegExp = function(proto) {
   var p = (proto === undefined ? this.REGEXP : proto);
-  var obj = this.createObject(p);
-  obj.class = 'RegExp';
-  return obj;
+  return new Interpreter.RegExp(p);
 };
+
+/**
+ * Class for an error object
+ * @param {Interpreter.Object} proto Prototype object.
+ * @constructor
+ */
+Interpreter.Error = function(proto) {
+  Interpreter.Object.call(this, proto);
+};
+
+Interpreter.Error.prototype = Object.create(Interpreter.Object.prototype);
+Interpreter.Error.prototype.constructor = Interpreter.Error;
+Interpreter.Error.prototype.class = 'Error';
 
 /**
  * Create a new error object.  See §15.11 of the ES5.1 spec.
@@ -1507,9 +1554,7 @@ Interpreter.prototype.createRegExp = function(proto) {
  */
 Interpreter.prototype.createError = function(proto) {
   var p = (proto === undefined ? this.ERROR : proto);
-  var obj = this.createObject(p);
-  obj.class = 'Error';
-  return obj;
+  return new Interpreter.Error(p);
 };
 
 /**

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -836,7 +836,7 @@ Interpreter.prototype.initNumber = function(scope) {
       return this.toExponential(fractionDigits);
     } catch (e) {
       // Throws if fractionDigits isn't within 0-20.
-      thisInterpreter.throwException(thisInterpreter.ERROR, e.message);
+      thisInterpreter.throwException(thisInterpreter.RANGE_ERROR, e.message);
     }
   };
   this.setNativeFunctionPrototype(this.NUMBER, 'toExponential', wrapper);
@@ -846,7 +846,7 @@ Interpreter.prototype.initNumber = function(scope) {
       return this.toFixed(digits);
     } catch (e) {
       // Throws if digits isn't within 0-20.
-      thisInterpreter.throwException(thisInterpreter.ERROR, e.message);
+      thisInterpreter.throwException(thisInterpreter.RANGE_ERROR, e.message);
     }
   };
   this.setNativeFunctionPrototype(this.NUMBER, 'toFixed', wrapper);
@@ -856,7 +856,7 @@ Interpreter.prototype.initNumber = function(scope) {
       return this.toPrecision(precision);
     } catch (e) {
       // Throws if precision isn't within range (depends on implementation).
-      thisInterpreter.throwException(thisInterpreter.ERROR, e.message);
+      thisInterpreter.throwException(thisInterpreter.RANGE_ERROR, e.message);
     }
   };
   this.setNativeFunctionPrototype(this.NUMBER, 'toPrecision', wrapper);
@@ -866,7 +866,7 @@ Interpreter.prototype.initNumber = function(scope) {
       return this.toString(radix);
     } catch (e) {
       // Throws if radix isn't within 2-36.
-      thisInterpreter.throwException(thisInterpreter.ERROR, e.message);
+      thisInterpreter.throwException(thisInterpreter.RANGE_ERROR, e.message);
     }
   };
   this.setNativeFunctionPrototype(this.NUMBER, 'toString', wrapper);
@@ -1158,8 +1158,10 @@ Interpreter.prototype.initJSON = function(scope) {
  */
 Interpreter.prototype.initError = function(scope) {
   var thisInterpreter = this;
+  // Error prototype:
+  this.ERRORPROTO = this.createError(this.OBJECTPROTO);
   // Error constructor.
-  this.ERROR = this.createNativeFunction(function(opt_message) {
+  var ErrorConst = this.createNativeFunction(function(opt_message) {
     if (thisInterpreter.calledWithNew()) {
       // Called as new Error().
       var newError = this;
@@ -1172,14 +1174,18 @@ Interpreter.prototype.initError = function(scope) {
           Interpreter.NONENUMERABLE_DESCRIPTOR);
     }
     return newError;
-  }, true);
-  this.addVariableToScope(scope, 'Error', this.ERROR);
-  this.setProperty(this.ERROR.properties['prototype'], 'message', '',
+  }, this.ERRORPROTO);
+  this.addVariableToScope(scope, 'Error', ErrorConst);
+  
+  this.setProperty(this.ERRORPROTO, 'message', '',
       Interpreter.NONENUMERABLE_DESCRIPTOR);
-  this.setProperty(this.ERROR.properties['prototype'], 'name', 'Error',
+  this.setProperty(this.ERRORPROTO, 'name', 'Error',
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   var createErrorSubclass = function(name) {
+    var prototype = thisInterpreter.createError();
+    thisInterpreter.setProperty(prototype, 'name', name,
+        Interpreter.NONENUMERABLE_DESCRIPTOR);
     var constructor = thisInterpreter.createNativeFunction(
         function(opt_message) {
           if (thisInterpreter.calledWithNew()) {
@@ -1187,21 +1193,17 @@ Interpreter.prototype.initError = function(scope) {
             var newError = this;
           } else {
             // Called as XyzError().
-            var newError = thisInterpreter.createObject(constructor);
+            var newError = thisInterpreter.createError(prototype);
           }
           if (opt_message) {
             thisInterpreter.setProperty(newError, 'message', opt_message + '',
                 Interpreter.NONENUMERABLE_DESCRIPTOR);
           }
           return newError;
-        }, true);
-    thisInterpreter.setProperty(constructor, 'prototype',
-        thisInterpreter.createError());
-    thisInterpreter.setProperty(constructor.properties['prototype'], 'name',
-        name, Interpreter.NONENUMERABLE_DESCRIPTOR);
+        }, prototype);
     thisInterpreter.addVariableToScope(scope, name, constructor);
 
-    return constructor;
+    return prototype;
   };
 
   this.EVAL_ERROR = createErrorSubclass('EvalError');
@@ -1503,10 +1505,13 @@ Interpreter.prototype.createRegExp = function(proto) {
 
 /**
  * Create a new error object.  See §15.11 of the ES5.1 spec.
+ * @param {Interpreter.Object=} proto Prototype object (or null);
+ *     defaults to this.ERRORPROTO
  * @return {!Interpreter.Object} New array object.
  */
-Interpreter.prototype.createError = function() {
-  var obj = this.createObject(this.ERROR);
+Interpreter.prototype.createError = function(proto) {
+  var p = (proto === undefined ? this.ERRORPROTO : proto);
+  var obj = this.createObjectProto(p);
   obj.class = 'Error';
   return obj;
 };
@@ -2088,15 +2093,17 @@ Interpreter.prototype.setValue = function(left, value) {
  * interpreter try/catch statement.  If unhandled, a real exception will
  * be thrown.  Can be called with either an error class and a message, or
  * with an actual object to be thrown.
- * @param {!Interpreter.Object} errorClass Type of error (if message is
- *   provided) or the value to throw (if no message).
+ * @param {*} value Value to be thrown.  If message is provided a new
+ *     error object is created using value as the prototype; if not it
+ *     is used directly.
  * @param {string=} opt_message Message being thrown.
  */
-Interpreter.prototype.throwException = function(errorClass, opt_message) {
+Interpreter.prototype.throwException = function(value, opt_message) {
+  var error
   if (opt_message === undefined) {
-    var error = errorClass;  // This is a value to throw, not an error class.
+    error = value;  // This is a value to throw, not an error proto.
   } else {
-    var error = this.createObject(errorClass);
+    error = this.createError(value);
     this.setProperty(error, 'message', opt_message,
         Interpreter.NONENUMERABLE_DESCRIPTOR);
   }
@@ -2124,7 +2131,7 @@ Interpreter.prototype.executeException = function(error) {
 
   // Throw a real error.
   var realError;
-  if (this.isa(error, this.ERROR)) {
+  if (error.class === 'Error') {
     var errorTable = {
       'EvalError': EvalError,
       'RangeError': RangeError,

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1614,6 +1614,14 @@ Interpreter.prototype.pseudoToNative = function(pseudoObj, opt_cycles) {
 Interpreter.prototype.getPrototype = function(value) {
   switch (typeof value) {
     case 'number':
+      // TODO(cpcallen): Do not depend on the *current* value of
+      // Number.prototype (etc.).  Existing code below is correctly
+      // unaffected by userland assignments to Number, but should also
+      // be immune to userland assignments to Number.prototype.
+      //
+      // (In fact, there is no reason for the interpreter to have its
+      // own private handles for Boolean, Number and String since they
+      // are never needed except during global scope creation.)
       return this.NUMBER.properties['prototype'];
     case 'boolean':
       return this.BOOLEAN.properties['prototype'];

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -184,7 +184,7 @@ Interpreter.prototype.initGlobalScope = function(scope) {
   // Create the objects which will become Object.prototype,
   // Function.prototype and Array.prototype, which are needed to
   // bootstrap everything else:
-  this.OBJECT = this.createObjectProto(null);
+  this.OBJECT = this.createObject(null);
   this.FUNCTION = this.createFunction(this.OBJECT);
   this.ARRAY = this.createArray(this.OBJECT);
   
@@ -363,7 +363,7 @@ Interpreter.prototype.initObject = function(scope) {
         return this;
       } else {
         // Called as Object().
-        return thisInterpreter.createObjectProto(thisInterpreter.OBJECT);
+        return thisInterpreter.createObject(thisInterpreter.OBJECT);
       }
     }
     if (!value.isObject) {
@@ -418,13 +418,13 @@ Interpreter.prototype.initObject = function(scope) {
 
   wrapper = function(proto) {
     if (proto === null) {
-      return thisInterpreter.createObjectProto(null);
+      return thisInterpreter.createObject(null);
     }
     if (proto === undefined || !proto.isObject) {
       thisInterpreter.throwException(thisInterpreter.TYPE_ERROR,
           'Object prototype may only be an Object or null');
     }
-    return thisInterpreter.createObjectProto(proto);
+    return thisInterpreter.createObject(proto);
   };
   this.setProperty(ObjectConst, 'create',
       this.createNativeFunction(wrapper, false),
@@ -806,7 +806,7 @@ Interpreter.prototype.initNumber = function(scope) {
   var thisInterpreter = this;
   var wrapper;
   // Number prototype.
-  this.NUMBER = this.createObjectProto(this.OBJECT);
+  this.NUMBER = this.createObject(this.OBJECT);
   this.NUMBER.class = 'Number';
   // Number constructor.
   var NumberConst = this.createNativeFunction(Number, this.NUMBER);
@@ -892,7 +892,7 @@ Interpreter.prototype.initString = function(scope) {
   var thisInterpreter = this;
   var wrapper;
   // String prototype.
-  this.STRING = this.createObjectProto(this.OBJECT);
+  this.STRING = this.createObject(this.OBJECT);
   this.STRING.class = 'String';
   // String constructor.
   var StringConst = this.createNativeFunction(String, this.STRING);
@@ -963,7 +963,7 @@ Interpreter.prototype.initString = function(scope) {
 Interpreter.prototype.initBoolean = function(scope) {
   var thisInterpreter = this;
   // Boolean prototype.
-  this.BOOLEAN = this.createObjectProto(this.OBJECT);
+  this.BOOLEAN = this.createObject(this.OBJECT);
   this.BOOLEAN.class = 'Boolean';
   // Boolean constructor.
   var BooleanConst = this.createNativeFunction(Boolean, this.BOOLEAN);
@@ -1047,7 +1047,7 @@ Interpreter.prototype.initDate = function(scope) {
  */
 Interpreter.prototype.initMath = function(scope) {
   var thisInterpreter = this;
-  var myMath = this.createObjectProto(this.OBJECT);
+  var myMath = this.createObject(this.OBJECT);
   this.addVariableToScope(scope, 'Math', myMath);
   var mathConsts = ['E', 'LN2', 'LN10', 'LOG2E', 'LOG10E', 'PI',
                     'SQRT1_2', 'SQRT2'];
@@ -1133,7 +1133,7 @@ Interpreter.prototype.initRegExp = function(scope) {
  */
 Interpreter.prototype.initJSON = function(scope) {
   var thisInterpreter = this;
-  var myJSON = thisInterpreter.createObjectProto(this.OBJECT);
+  var myJSON = thisInterpreter.createObject(this.OBJECT);
   this.addVariableToScope(scope, 'JSON', myJSON);
 
   var wrapper = function(text) {
@@ -1432,7 +1432,7 @@ Interpreter.Object.prototype.valueOf = function() {
  * @param {Interpreter.Object} proto Prototype object.
  * @return {!Interpreter.Object} New data object.
  */
-Interpreter.prototype.createObjectProto = function(proto) {
+Interpreter.prototype.createObject = function(proto) {
   var obj = new Interpreter.Object(proto);
   return obj;
 };
@@ -1445,7 +1445,7 @@ Interpreter.prototype.createObjectProto = function(proto) {
  */
 Interpreter.prototype.createFunction = function(proto) {
   var p = (proto === undefined ? this.FUNCTION : proto);
-  var obj = this.createObjectProto(p);
+  var obj = this.createObject(p);
   obj.class = 'Function';
   return obj;
 };
@@ -1465,7 +1465,7 @@ Interpreter.prototype.addFunctionPrototype = function(func, prototype) {
   } else if (func.illegalConstructor) {
     throw TypeError('func claims not to be a constructor!');
   }
-  var protoObj = prototype || this.createObjectProto(this.OBJECT);
+  var protoObj = prototype || this.createObject(this.OBJECT);
   this.setProperty(func, 'prototype', protoObj,
       Interpreter.NONENUMERABLE_NONCONFIGURABLE_DESCRIPTOR);
   this.setProperty(protoObj, 'constructor', func,
@@ -1480,7 +1480,7 @@ Interpreter.prototype.addFunctionPrototype = function(func, prototype) {
  */
 Interpreter.prototype.createArray = function(proto) {
   var p = (proto === undefined ? this.ARRAY : proto);
-  var obj = this.createObjectProto(p);
+  var obj = this.createObject(p);
   obj.class = 'Array';
   obj.length = 0;
   return obj;
@@ -1494,7 +1494,7 @@ Interpreter.prototype.createArray = function(proto) {
  */
 Interpreter.prototype.createRegExp = function(proto) {
   var p = (proto === undefined ? this.REGEXP : proto);
-  var obj = this.createObjectProto(p);
+  var obj = this.createObject(p);
   obj.class = 'RegExp';
   return obj;
 };
@@ -1507,7 +1507,7 @@ Interpreter.prototype.createRegExp = function(proto) {
  */
 Interpreter.prototype.createError = function(proto) {
   var p = (proto === undefined ? this.ERROR : proto);
-  var obj = this.createObjectProto(p);
+  var obj = this.createObject(p);
   obj.class = 'Error';
   return obj;
 };
@@ -1634,7 +1634,7 @@ Interpreter.prototype.nativeToPseudo = function(nativeObj) {
       this.setProperty(pseudoObj, i, this.nativeToPseudo(nativeObj[i]));
     }
   } else {  // Object.
-    pseudoObj = this.createObjectProto(this.OBJECT);
+    pseudoObj = this.createObject(this.OBJECT);
     for (var key in nativeObj) {
       this.setProperty(pseudoObj, key, this.nativeToPseudo(nativeObj[key]));
     }
@@ -2410,8 +2410,7 @@ Interpreter.prototype['stepCallExpression'] = function() {
         this.throwException(this.TYPE_ERROR, func + ' is not a constructor');
       }
       // Constructor, 'this' is new object.
-      state.funcThis_ = this.createObjectProto(
-          this.getProperty(func, 'prototype'));
+      state.funcThis_ = this.createObject(this.getProperty(func, 'prototype'));
       state.isConstructor = true;
     } else if (state.components_) {
       // Method function, 'this' is object.
@@ -2868,7 +2867,7 @@ Interpreter.prototype['stepObjectExpression'] = function() {
   var property = state.node['properties'][n];
   if (!state.object_) {
     // First execution.
-    state.object_ = this.createObjectProto(this.OBJECT);
+    state.object_ = this.createObject(this.OBJECT);
   } else {
     // Determine property name.
     var key = property['key'];

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -300,7 +300,7 @@ Interpreter.prototype.initFunction = function(scope) {
     state.arguments_ = [];
     if (args) {
       // TODO(cpcallen): this should probably accept array-like object too.
-      if (args.class === 'array') {
+      if (args instanceof Interpreter.Array) {
         for (var i = 0; i < args.length; i++) {
           state.arguments_[i] = thisInterpreter.getProperty(args, i);
         }
@@ -603,7 +603,7 @@ Interpreter.prototype.initArray = function(scope) {
 
   // Static methods on Array.
   wrapper = function(obj) {
-    return obj && obj.class === 'Array';
+    return obj instanceof Interpreter.Array;
   };
   this.setProperty(ArrayConst, 'isArray',
                    this.createNativeFunction(wrapper, false),
@@ -750,7 +750,7 @@ Interpreter.prototype.initArray = function(scope) {
     // Loop through all arguments and copy them in.
     for (var i = 0; i < arguments.length; i++) {
       var value = arguments[i];
-      if (value && value.class === 'Array') {
+      if (value instanceof Interpreter.Array) {
         for (var j = 0; j < value.length; j++) {
           var element = thisInterpreter.getProperty(value, j);
           thisInterpreter.setProperty(list, length++, element);
@@ -925,7 +925,7 @@ Interpreter.prototype.initString = function(scope) {
   this.setNativeFunctionPrototype(StringConst, 'localeCompare', wrapper);
 
   wrapper = function(separator, limit) {
-    if (separator && separator.class === 'RegExp') {
+    if (separator && separator instanceof Interpreter.RegExp) {
       separator = separator.data;
     }
     var jsList = this.split(separator, limit);
@@ -1222,7 +1222,8 @@ Interpreter.prototype.initError = function(scope) {
 };
 
 /**
- * Is an object of a certain class?
+ * Does the object have a certain constructor's .prototype in its
+ * proto chain?
  * @param {*} child Object to check.
  * @param {Interpreter.Object} constructor Constructor of object.
  * @return {boolean} True if object is the class or inherits from it.
@@ -1360,7 +1361,7 @@ Interpreter.Object.prototype.toString = function() {
   // form.  Each of the different classes (Object, Function, Array)
   // should have their own toString implementation as described in the
   // spec.
-  if (this.class === 'Array') {
+  if (this instanceof Interpreter.Array) {
     // Array
     var cycles = Interpreter.toStringCycles_;
     cycles.push(this);
@@ -1376,7 +1377,7 @@ Interpreter.Object.prototype.toString = function() {
     }
     return strs.join(',');
   }
-  if (this.class === 'Error') {
+  if (this instanceof Interpreter.Error) {
     var cycles = Interpreter.toStringCycles_;
     if (cycles.indexOf(this) !== -1) {
       return '[object Error]';
@@ -1405,7 +1406,7 @@ Interpreter.Object.prototype.toString = function() {
     }
     return message ? name + ': ' + message : name + '';
   }
-  if (this.class === 'Function') {
+  if (this instanceof Interpreter.Function) {
     // TODO: Return the source code.
     return '[object Function]';
   }
@@ -1701,7 +1702,7 @@ Interpreter.prototype.pseudoToNative = function(pseudoObj, opt_cycles) {
     return pseudoObj;
   }
 
-  if (pseudoObj.class === 'RegExp') {  // Regular expression.
+  if (pseudoObj instanceof Interpreter.RegExp) {  // Regular expression.
     return pseudoObj.data;
   }
 
@@ -1715,7 +1716,7 @@ Interpreter.prototype.pseudoToNative = function(pseudoObj, opt_cycles) {
   }
   cycles.pseudo.push(pseudoObj);
   var nativeObj;
-  if (pseudoObj.class === 'Array') {  // Array.
+  if (pseudoObj instanceof Interpreter.Array) {  // Array.
     nativeObj = [];
     cycles.native.push(nativeObj);
     for (var i = 0; i < pseudoObj.length; i++) {
@@ -1774,7 +1775,7 @@ Interpreter.prototype.getProperty = function(obj, name) {
     // Special cases for magic length property.
     if (typeof obj === 'string') {
       return obj.length;
-    } else if (obj.class === 'Array') {
+    } else if (obj instanceof Interpreter.Array) {
       return obj.length;
     }
   } else if (name.charCodeAt(0) < 0x40) {
@@ -1808,7 +1809,7 @@ Interpreter.prototype.hasProperty = function(obj, name) {
     return undefined;
   }
   name += '';
-  if (name === 'length' && obj.class === 'Array') {
+  if (name === 'length' && obj instanceof Interprerter.Array) {
     return true;
   }
   do {
@@ -1835,7 +1836,7 @@ Interpreter.prototype.setProperty = function(obj, name, value, opt_descriptor) {
     this.throwException(this.TYPE_ERROR, "Can't create property '" + name +
                         "' on '" + obj + "'");
   }
-  if (obj.class === 'Array') {
+  if (obj instanceof Interpreter.Array) {
     // Arrays have a magic length variable that is bound to the elements.
     var i;
     if (name === 'length') {
@@ -1900,7 +1901,7 @@ Interpreter.prototype.deleteProperty = function(obj, name) {
   if (!obj || !obj.isObject || obj.notWritable.has(name)) {
     return false;
   }
-  if (name === 'length' && obj.class === 'Array') {
+ if (name === 'length' && obj instanceof Interpreter.Array) {
     return false;
   }
   return delete obj.properties[name];
@@ -2163,7 +2164,7 @@ Interpreter.prototype.executeException = function(error) {
 
   // Throw a real error.
   var realError;
-  if (error.class === 'Error') {
+  if (error instanceof Interpreter.Error) {
     var errorTable = {
       'EvalError': EvalError,
       'RangeError': RangeError,
@@ -2337,9 +2338,7 @@ Interpreter.prototype['stepBinaryExpression'] = function() {
     }
     value = this.hasProperty(rightSide, leftSide);
   } else if (node['operator'] === 'instanceof') {
-    // TODO(cpcallen): rewrite this as rightSide instanceof
-    // Interpreter.Function once such a class exists.
-    if (!rightSide || !rightSide.class === 'function') {
+    if (!(rightSide instanceof Interpreter.Function)) {
       this.throwException(this.TYPE_ERROR,
           'Right-hand side of instanceof is not an object');
     }
@@ -3130,7 +3129,7 @@ Interpreter.prototype['stepUnaryExpression'] = function() {
                           name + "' of '" + obj + "'");
     }
   } else if (node['operator'] === 'typeof') {
-    value = (value && value.class === 'Function') ? 'function' : typeof value;
+    value = (value instanceof Interpreter.Function) ? 'function' : typeof value;
   } else if (node['operator'] === 'void') {
     value = undefined;
   } else {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -990,18 +990,18 @@ Interpreter.prototype.initDate = function(scope) {
     this.data = new (Function.prototype.bind.apply(Date, args));
     return this;
   };
-  this.DATE = this.createNativeFunction(wrapper, true);
-  this.addVariableToScope(scope, 'Date', this.DATE);
+  var DateProto = this.createNativeFunction(wrapper, true);
+  this.addVariableToScope(scope, 'Date', DateProto);
 
   // Static methods on Date.
-  this.setProperty(this.DATE, 'now', this.createNativeFunction(Date.now, false),
+  this.setProperty(DateProto, 'now', this.createNativeFunction(Date.now, false),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
-  this.setProperty(this.DATE, 'parse',
+  this.setProperty(DateProto, 'parse',
       this.createNativeFunction(Date.parse, false),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
-  this.setProperty(this.DATE, 'UTC', this.createNativeFunction(Date.UTC, false),
+  this.setProperty(DateProto, 'UTC', this.createNativeFunction(Date.UTC, false),
       Interpreter.NONENUMERABLE_DESCRIPTOR);
 
   // Instance methods on Date.
@@ -1022,7 +1022,7 @@ Interpreter.prototype.initDate = function(scope) {
         return this.data[nativeFunc].apply(this.data, arguments);
       };
     })(functions[i]);
-    this.setNativeFunctionPrototype(this.DATE, functions[i], wrapper);
+    this.setNativeFunctionPrototype(DateProto, functions[i], wrapper);
   }
   var functions = ['toLocaleDateString', 'toLocaleString',
                    'toLocaleTimeString'];
@@ -1037,7 +1037,7 @@ Interpreter.prototype.initDate = function(scope) {
         return this.data[nativeFunc].call(this.data, locales, options);
       };
     })(functions[i]);
-    this.setNativeFunctionPrototype(this.DATE, functions[i], wrapper);
+    this.setNativeFunctionPrototype(DateProto, functions[i], wrapper);
   }
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -376,6 +376,8 @@ Interpreter.prototype.initObject = function(scope) {
   };
   var ObjectConst = this.createNativeFunction(wrapper, true);
   this.setProperty(ObjectConst, 'prototype', this.OBJECTPROTO, {});
+  this.setProperty(this.OBJECTPROTO, 'constructor', ObjectConst,
+      Interpreter.NONENUMERABLE_DESCRIPTOR);
   this.addVariableToScope(scope, 'Object', ObjectConst);
 
   /**

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -109,6 +109,21 @@ function deserialize(json, interpreter) {
       case 'PseudoObject':
         obj = new Interpreter.Object(null);
         break;
+      case 'PseudoFunction':
+        obj = new Interpreter.Function(null);
+        break;
+      case 'PseudoArray':
+        obj = new Interpreter.Array(null);
+        break;
+      case 'PseudoDate':
+        obj = new Interpreter.Date(null);
+        break;
+      case 'PseudoRegExp':
+        obj = new Interpreter.RegExp(null);
+        break;
+      case 'PseudoError':
+        obj = new Interpreter.Error(null);
+        break;
       case 'Node':
         obj = Object.create(nodeProto);
         break;
@@ -235,6 +250,21 @@ function serialize(interpreter) {
         break;
       case Interpreter.Object.prototype:
         jsonObj['type'] = 'PseudoObject';
+        break;
+      case Interpreter.Function.prototype:
+        jsonObj['type'] = 'PseudoFunction';
+        break;
+      case Interpreter.Array.prototype:
+        jsonObj['type'] = 'PseudoArray';
+        break;
+      case Interpreter.Date.prototype:
+        jsonObj['type'] = 'PseudoDate';
+        break;
+      case Interpreter.RegExp.prototype:
+        jsonObj['type'] = 'PseudoRegExp';
+        break;
+      case Interpreter.Error.prototype:
+        jsonObj['type'] = 'PseudoError';
         break;
       case nodeProto:
         jsonObj['type'] = 'Node';

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -96,11 +96,11 @@ exports.testClasses = function(t) {
       literal: '[]'
     },
     RegExp: {
-      prototypeClass: 'Object',
+      prototypeClass: 'Object', // Was 'RegExp' in ES5.1.
       literal: '/foo/'
     },
     Date: {
-      prototypeClass: 'Object'
+      prototypeClass: 'Object' // Was 'RegExp' in ES5.1.
     },
     Error: {},
     EvalError: {
@@ -126,6 +126,21 @@ exports.testClasses = function(t) {
     URIError: {
       prototypeProto: 'Error.prototype',
       prototypeClass: 'Error'
+    },
+    Boolean: {
+      literal: 'false',
+      literalType: 'boolean',
+      noInstance: true,
+    },
+    Number: {
+      literal: '42',
+      literalType: 'number',
+      noInstance: true,
+    },
+    String: {
+      literal: '"hello"',
+      literalType: 'string',
+      noInstance: true,
     },
   };   
   for (var c in classes) {
@@ -158,23 +173,26 @@ exports.testClasses = function(t) {
     name = c + 'PrototypeConstructorIs' + c;
     src = c + '.prototype.constructor === ' + c + ';';
     runTest(t, name, src, true);
-    // Check instance's type:
-    name = c + 'InstanceIs' + prototypeType;
-    src = 'typeof (new ' + c + ');';
-    runTest(t, name, src, prototypeType);
-    // Check instance's proto:
-    name = c + 'InstancePrototypeIs' + c + 'Prototype';
-    src = 'Object.getPrototypeOf(new ' + c + ') === ' + c + '.prototype;';
-    runTest(t, name, src, true);
-    // Check instance's class:
-    name = c + 'InstanceClassIs' + prototypeClass,
-    src = 'Object.prototype.toString.apply(new ' + c + ');';
-    runTest(t, name, src, '[object ' + prototypeClass + ']');
+    if (!tc.noInstance) {
+      // Check instance's type:
+      name = c + 'InstanceIs' + prototypeType;
+      src = 'typeof (new ' + c + ');';
+      runTest(t, name, src, prototypeType);
+      // Check instance's proto:
+      name = c + 'InstancePrototypeIs' + c + 'Prototype';
+      src = 'Object.getPrototypeOf(new ' + c + ') === ' + c + '.prototype;';
+      runTest(t, name, src, true);
+      // Check instance's class:
+      name = c + 'InstanceClassIs' + prototypeClass,
+      src = 'Object.prototype.toString.apply(new ' + c + ');';
+      runTest(t, name, src, '[object ' + c + ']');
+    }
     if (tc.literal) {
       // Check literal's type:
-      name = c + 'LiteralIs' + prototypeType;
+      var literalType = (tc.literalType || prototypeType);
+      name = c + 'LiteralIs' + literalType;
       src = 'typeof (' + tc.literal + ');';
-      runTest(t, name, src, prototypeType);
+      runTest(t, name, src, literalType);
       // Check literal's proto:
       name = c + 'LiteralPrototypeIs' + c + 'Prototype';
       src = 'Object.getPrototypeOf(' + tc.literal + ') === ' + c +
@@ -183,7 +201,7 @@ exports.testClasses = function(t) {
       // Check literal's class:
       name = c + 'LiteralClassIs' + prototypeClass,
       src = 'Object.prototype.toString.apply(' + tc.literal + ');';
-      runTest(t, name, src, '[object ' + prototypeClass + ']');
+      runTest(t, name, src, '[object ' + c + ']');
     }
   }
 };

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -167,9 +167,9 @@ exports.testClasses = function(t) {
     src = 'Object.getPrototypeOf(new ' + c + ') === ' + c + '.prototype;';
     runTest(t, name, src, true);
     // Check instance's class:
-    name = c + 'InstanceClassIs' + c,
+    name = c + 'InstanceClassIs' + prototypeClass,
     src = 'Object.prototype.toString.apply(new ' + c + ');';
-    runTest(t, name, src, '[object ' + c + ']');
+    runTest(t, name, src, '[object ' + prototypeClass + ']');
     if (tc.literal) {
       // Check literal's type:
       name = c + 'LiteralIs' + prototypeType;
@@ -181,9 +181,9 @@ exports.testClasses = function(t) {
           '.prototype;';
       runTest(t, name, src, true);
       // Check literal's class:
-      name = c + 'LiteralClassIs' + c,
+      name = c + 'LiteralClassIs' + prototypeClass,
       src = 'Object.prototype.toString.apply(' + tc.literal + ');';
-      runTest(t, name, src, '[object ' + c + ']');
+      runTest(t, name, src, '[object ' + prototypeClass + ']');
     }
   }
 };

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -85,27 +85,48 @@ exports.testSimple = function(t) {
 exports.testClasses = function(t) {
   var classes = {
     Object: {
-      prototypeType: 'object',
       prototypeProto: 'null',
-      instance: '{}'},
+      instance: '{}'
+    },
     Function: {
       prototypeType: 'function',
-      prototypeProto: 'Object.prototype',
-      instance: 'function(){}'},
+      instance: 'function(){}'
+    },
     Array: {
-      prototypeType: 'object',
-      prototypeProto: 'Object.prototype',
-      instance: '[]'},
+      instance: '[]'
+    },
     RegExp: {
-      prototypeType: 'object',
-      prototypeProto: 'Object.prototype',
       prototypeClass: 'Object',
-      instance: '/foo/'},
+      instance: '/foo/'
+    },
     Date: {
-      prototypeType: 'object',
-      prototypeProto: 'Object.prototype',
-      prototypeClass: 'Object',
-      instance: 'new Date()'}, // Not actually a instance, but whatever.
+      prototypeClass: 'Object'
+    },
+    Error: {},
+    EvalError: {
+      prototypeProto: 'Error.prototype',
+      prototypeClass: 'Error'
+    },
+    RangeError: {
+      prototypeProto: 'Error.prototype',
+      prototypeClass: 'Error'
+    },
+    ReferenceError: {
+      prototypeProto: 'Error.prototype',
+      prototypeClass: 'Error'
+    },
+    SyntaxError: {
+      prototypeProto: 'Error.prototype',
+      prototypeClass: 'Error'
+    },
+    TypeError: {
+      prototypeProto: 'Error.prototype',
+      prototypeClass: 'Error'
+    },
+    URIError: {
+      prototypeProto: 'Error.prototype',
+      prototypeClass: 'Error'
+    },
   };   
   for (var c in classes) {
     var name, src, tc = classes[c];
@@ -118,33 +139,37 @@ exports.testClasses = function(t) {
     src = 'Object.getPrototypeOf(' + c + ') === Function.prototype;';
     runTest(t, name, src, true);
     // Check prototype is of correct type:
-    name = c + 'PrototypeIs' + tc.prototypeType;
+    var prototypeType = (tc.prototypeType || 'object');
+    name = c + 'PrototypeIs' + prototypeType
     src = 'typeof ' + c + '.prototype;';
-    runTest(t, name, src, tc.prototypeType);
+    runTest(t, name, src, prototypeType);
     // Check prototype has correct class:
-    name = c + 'PrototypeClassIs' + (tc.prototypeClass || c)
+    var prototypeClass = (tc.prototypeClass || c);
+    name = c + 'PrototypeClassIs' + prototypeClass;
     src = 'Object.prototype.toString.apply(' + c + '.prototype);';
-    runTest(t, name, src, '[object ' + (tc.prototypeClass || c) + ']');
+    runTest(t, name, src, '[object ' + prototypeClass + ']');
     // Check prototype has correct proto:
-    name = c + 'PrototypeProtoIs' + tc.prototypeProto;
+    var prototypeProto = (tc.prototypeProto || 'Object.prototype');
+    name = c + 'PrototypeProtoIs' + prototypeProto;
     src = 'Object.getPrototypeOf(' + c + '.prototype) === ' +
-        tc.prototypeProto + ';';
+        prototypeProto + ';';
     runTest(t, name, src, true);
     // Check prototype's .constructor is constructor:
     name = c + 'PrototypeConstructorIs' + c;
     src = c + '.prototype.constructor === ' + c + ';';
     runTest(t, name, src, true);
     // Check instance's type:
-    name = c + 'InstanceIs' + tc.prototypeType;
-    src = 'typeof (' + tc.instance + ');';
-    runTest(t, name, src, tc.prototypeType);
+    var instance = (tc.instance || 'new ' + c);
+    name = c + 'InstanceIs' + prototypeType;
+    src = 'typeof (' + instance + ');';
+    runTest(t, name, src, prototypeType);
     // Check instance's proto:
     name = c + 'InstancePrototypeIs' + c + 'Prototype';
-    src = 'Object.getPrototypeOf(' + tc.instance + ') === ' + c + '.prototype;';
+    src = 'Object.getPrototypeOf(' + instance + ') === ' + c + '.prototype;';
     runTest(t, name, src, true);
     // Check instance's class:
     name = c + 'InstanceClassIs' + c,
-    src = 'Object.prototype.toString.apply(' + tc.instance + ');';
+    src = 'Object.prototype.toString.apply(' + instance + ');';
     runTest(t, name, src, '[object ' + c + ']');
   }
 };

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -99,10 +99,12 @@ exports.testClasses = function(t) {
     RegExp: {
       prototypeType: 'object',
       prototypeProto: 'Object.prototype',
+      prototypeClass: 'Object',
       instance: '/foo/'},
     Date: {
       prototypeType: 'object',
       prototypeProto: 'Object.prototype',
+      prototypeClass: 'Object',
       instance: 'new Date()'}, // Not actually a instance, but whatever.
   };   
   for (var c in classes) {
@@ -120,9 +122,9 @@ exports.testClasses = function(t) {
     src = 'typeof ' + c + '.prototype;';
     runTest(t, name, src, tc.prototypeType);
     // Check prototype has correct class:
-    name = c + 'PrototypeClassIs' + c
+    name = c + 'PrototypeClassIs' + (tc.prototypeClass || c)
     src = 'Object.prototype.toString.apply(' + c + '.prototype);';
-    runTest(t, name, src, '[object ' + c + ']');
+    runTest(t, name, src, '[object ' + (tc.prototypeClass || c) + ']');
     // Check prototype has correct proto:
     name = c + 'PrototypeProtoIs' + tc.prototypeProto;
     src = 'Object.getPrototypeOf(' + c + '.prototype) === ' +
@@ -140,6 +142,10 @@ exports.testClasses = function(t) {
     name = c + 'InstancePrototypeIs' + c + 'Prototype';
     src = 'Object.getPrototypeOf(' + tc.instance + ') === ' + c + '.prototype;';
     runTest(t, name, src, true);
+    // Check instance's class:
+    name = c + 'InstanceClassIs' + c,
+    src = 'Object.prototype.toString.apply(' + tc.instance + ');';
+    runTest(t, name, src, '[object ' + c + ']');
   }
 };
 

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -86,18 +86,18 @@ exports.testClasses = function(t) {
   var classes = {
     Object: {
       prototypeProto: 'null',
-      instance: '{}'
+      literal: '{}'
     },
     Function: {
       prototypeType: 'function',
-      instance: 'function(){}'
+      listeral: 'function(){}'
     },
     Array: {
-      instance: '[]'
+      literal: '[]'
     },
     RegExp: {
       prototypeClass: 'Object',
-      instance: '/foo/'
+      literal: '/foo/'
     },
     Date: {
       prototypeClass: 'Object'
@@ -159,18 +159,32 @@ exports.testClasses = function(t) {
     src = c + '.prototype.constructor === ' + c + ';';
     runTest(t, name, src, true);
     // Check instance's type:
-    var instance = (tc.instance || 'new ' + c);
     name = c + 'InstanceIs' + prototypeType;
-    src = 'typeof (' + instance + ');';
+    src = 'typeof (new ' + c + ');';
     runTest(t, name, src, prototypeType);
     // Check instance's proto:
     name = c + 'InstancePrototypeIs' + c + 'Prototype';
-    src = 'Object.getPrototypeOf(' + instance + ') === ' + c + '.prototype;';
+    src = 'Object.getPrototypeOf(new ' + c + ') === ' + c + '.prototype;';
     runTest(t, name, src, true);
     // Check instance's class:
     name = c + 'InstanceClassIs' + c,
-    src = 'Object.prototype.toString.apply(' + instance + ');';
+    src = 'Object.prototype.toString.apply(new ' + c + ');';
     runTest(t, name, src, '[object ' + c + ']');
+    if (tc.literal) {
+      // Check literal's type:
+      name = c + 'LiteralIs' + prototypeType;
+      src = 'typeof (' + tc.literal + ');';
+      runTest(t, name, src, prototypeType);
+      // Check literal's proto:
+      name = c + 'LiteralPrototypeIs' + c + 'Prototype';
+      src = 'Object.getPrototypeOf(' + tc.literal + ') === ' + c +
+          '.prototype;';
+      runTest(t, name, src, true);
+      // Check literal's class:
+      name = c + 'LiteralClassIs' + c,
+      src = 'Object.prototype.toString.apply(' + tc.literal + ');';
+      runTest(t, name, src, '[object ' + c + ']');
+    }
   }
 };
 

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -78,6 +78,72 @@ exports.testSimple = function(t) {
 };
 
 /**
+ * Run some tests of the various constructors and their associated
+ * literals and prototype objects.
+ * @param {T} t The test runner object.
+ */
+exports.testClasses = function(t) {
+  var classes = {
+    Object: {
+      prototypeType: 'object',
+      prototypeProto: 'null',
+      instance: '{}'},
+    Function: {
+      prototypeType: 'function',
+      prototypeProto: 'Object.prototype',
+      instance: 'function(){}'},
+    Array: {
+      prototypeType: 'object',
+      prototypeProto: 'Object.prototype',
+      instance: '[]'},
+    RegExp: {
+      prototypeType: 'object',
+      prototypeProto: 'Object.prototype',
+      instance: '/foo/'},
+    Date: {
+      prototypeType: 'object',
+      prototypeProto: 'Object.prototype',
+      instance: 'new Date()'}, // Not actually a instance, but whatever.
+  };   
+  for (var c in classes) {
+    var name, src, tc = classes[c];
+    // Check constructor is a function:
+    name = c + 'IsFunction';
+    src = 'typeof ' + c + ';';
+    runTest(t, name, src, 'function');
+    // Check constructor's proto is Function.prototype
+    name = c + 'ProtoIsFunctionPrototype';
+    src = 'Object.getPrototypeOf(' + c + ') === Function.prototype;';
+    runTest(t, name, src, true);
+    // Check prototype is of correct type:
+    name = c + 'PrototypeIs' + tc.prototypeType;
+    src = 'typeof ' + c + '.prototype;';
+    runTest(t, name, src, tc.prototypeType);
+    // Check prototype has correct class:
+    name = c + 'PrototypeClassIs' + c
+    src = 'Object.prototype.toString.apply(' + c + '.prototype);';
+    runTest(t, name, src, '[object ' + c + ']');
+    // Check prototype has correct proto:
+    name = c + 'PrototypeProtoIs' + tc.prototypeProto;
+    src = 'Object.getPrototypeOf(' + c + '.prototype) === ' +
+        tc.prototypeProto + ';';
+    runTest(t, name, src, true);
+    // Check prototype's .constructor is constructor:
+    name = c + 'PrototypeConstructorIs' + c;
+    src = c + '.prototype.constructor === ' + c + ';';
+    runTest(t, name, src, true);
+    // Check instance's type:
+    name = c + 'InstanceIs' + tc.prototypeType;
+    src = 'typeof (' + tc.instance + ');';
+    runTest(t, name, src, tc.prototypeType);
+    // Check instance's proto:
+    name = c + 'InstancePrototypeIs' + c + 'Prototype';
+    src = 'Object.getPrototypeOf(' + tc.instance + ') === ' + c + '.prototype;';
+    runTest(t, name, src, true);
+  }
+};
+
+/**
  * Run some tests of switch statement with fallthrough.
  * @param {T} t The test runner object.
  */
@@ -188,7 +254,7 @@ exports.testArca = function(t) {
     ['"11", "2"', true], // String
   ];
   for (var i in cases) {
-    var tc = cases[i]
+    var tc = cases[i];
     var src = `
         (function(a,b){
           return ((a < b) || (a >= b)) ? (a < b) : undefined;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -586,6 +586,11 @@ module.exports = [
   /******************************************************************/
   // Object and Object.prototype
   
+  { name: 'ObjectIsFunction', src: `
+    Object.getPrototypeOf(Object) === Function.prototype;
+    `,
+    expected: true },
+
   { name: 'ObjectDefinePropertyNoArgs', src: `
     try {
       Object.defineProperty();
@@ -633,7 +638,7 @@ module.exports = [
     `,
     expected: 78 },
 
-  { name: 'ObjectGetPrototypeOf', src: `
+  { name: 'ObjectGetPrototypeOfObj', src: `
     Object.getPrototypeOf({}) === Object.prototype;
     `,
     expected: true },
@@ -866,13 +871,33 @@ module.exports = [
   /******************************************************************/
   // Function and Function.prototype
 
-  { name: 'FunctionPrototype', src: `
+  { name: 'FunctionIsFunction', src: `
+    typeof Function;
+    `,
+    expected: 'function' },
+
+  { name: 'FunctionProtoIsFunctionPrototype', src: `
     Object.getPrototypeOf(Function) === Function.prototype;
     `,
     expected: true },
 
-  { name: 'FunctionPrototypePrototype', src: `
+  { name: 'FunctionPrototypeIsFunction', src: `
+    typeof Function.prototype;
+    `,
+    expected: 'function' },
+
+  { name: 'FunctionPrototypeProto', src: `
     Object.getPrototypeOf(Function.prototype) === Object.prototype;
+    `,
+    expected: false },
+
+  { name: 'FunctionPrototypeHasNoPrototype', src: `
+    Function.prototype.hasOwnProperty('prototype');
+    `,
+    expected: false },
+
+  { name: 'FunctionsAreFunctions', src: `
+    Object.getPrototypeOf(function(){}) === Function.prototype;
     `,
     expected: true },
 

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -907,6 +907,44 @@ module.exports = [
     expected: true },
 
   /******************************************************************/
+  // Array and Array.prototype
+
+  { name: 'ArrayIsFunction', src: `
+    typeof Array;
+    `,
+    expected: 'function' },
+
+  { name: 'ArrayProtoIsFunctionPrototype', src: `
+    Object.getPrototypeOf(Array) === Function.prototype;
+    `,
+    expected: true },
+
+  { name: 'ArrayPrototypeIsObject', src: `
+    typeof Array.prototype;
+    `,
+    expected: 'object' },
+
+  { name: 'ArrayIsArrayArrayPrototype', src: `
+    Array.isArray(Array.prototype);
+    `,
+    expected: true },
+
+  { name: 'ArrayPrototypeProto', src: `
+    Object.getPrototypeOf(Array.prototype) === Object.prototype;
+    `,
+    expected: true },
+
+  { name: 'ArrayPrototypeHasNoPrototype', src: `
+    Array.prototype.hasOwnProperty('prototype');
+    `,
+    expected: false },
+
+  { name: 'ArraysAreArrays', src: `
+    Object.getPrototypeOf([]) === Array.prototype;
+    `,
+    expected: true },
+
+  /******************************************************************/
   // Other tests (all are skipped):
 
   { name: 'newHack', src: `

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -596,6 +596,27 @@ module.exports = [
     `,
     expected: true },
 
+  { name: 'ObjectPrototypeIsObject', src: `
+    typeof Object.prototype;
+    `,
+    expected: 'object' },
+
+  { name: 'ObjectPrototypeConstructorIsObject', src: `
+    Object.prototype.constructor === Object;
+    `,
+    expected: true },
+
+  { name: 'ObjectPrototypeProtoIsNull', src: `
+    Object.getPrototypeOf(Object.prototype)
+    `,
+    expected: null },
+
+  { name: 'ObjectsAreObjects', src: `
+    Object.getPrototypeOf({}) === Object.prototype;
+    `,
+    expected: true },
+
+
   { name: 'ObjectDefinePropertyNoArgs', src: `
     try {
       Object.defineProperty();
@@ -642,16 +663,6 @@ module.exports = [
     r;
     `,
     expected: 78 },
-
-  { name: 'ObjectGetPrototypeOfObj', src: `
-    Object.getPrototypeOf({}) === Object.prototype;
-    `,
-    expected: true },
-
-  { name: 'ObjectGetPrototypeOfObjectPrototype', src: `
-    Object.getPrototypeOf(Object.prototype) == null;
-    `,
-    expected: true },
 
   { name: 'ObjectGetPrototypeOfNullUndefined', src: `
     var r = '', prims = [null, undefined];
@@ -733,7 +744,7 @@ module.exports = [
     var o = {}, r = 0;
     Object.defineProperty(o, 'foo', { value: 'bar' });
     var desc = Object.getOwnPropertyDescriptor(o, 'foo');
-    desc.value == o.foo && 
+    desc.value === o.foo && 
         !desc.writeable && !desc.enumerable && !desc.configurable;
     `,
     expected: true },
@@ -891,6 +902,11 @@ module.exports = [
     `,
     expected: 'function' },
 
+  { name: 'FunctionPrototypeConstructorIsFunction', src: `
+    Function.prototype.constructor === Function;
+    `,
+    expected: true },
+
   { name: 'FunctionPrototypeProto', src: `
     Object.getPrototypeOf(Function.prototype) === Object.prototype;
     `,
@@ -923,6 +939,11 @@ module.exports = [
     typeof Array.prototype;
     `,
     expected: 'object' },
+
+  { name: 'ArrayPrototypeConstructorIsArray', src: `
+    Array.prototype.constructor === Array;
+    `,
+    expected: true },
 
   { name: 'ArrayIsArrayArrayPrototype', src: `
     Array.isArray(Array.prototype);

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -894,7 +894,7 @@ module.exports = [
   { name: 'FunctionPrototypeProto', src: `
     Object.getPrototypeOf(Function.prototype) === Object.prototype;
     `,
-    expected: false },
+    expected: true },
 
   { name: 'FunctionPrototypeHasNoPrototype', src: `
     Function.prototype.hasOwnProperty('prototype');

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -586,37 +586,6 @@ module.exports = [
   /******************************************************************/
   // Object and Object.prototype
   
-  { name: 'ObjectIsFunction', src: `
-    typeof Object;
-    `,
-    expected: 'function' },
-
-  { name: 'ObjectProtoIsFunctionPrototype', src: `
-    Object.getPrototypeOf(Object) === Function.prototype;
-    `,
-    expected: true },
-
-  { name: 'ObjectPrototypeIsObject', src: `
-    typeof Object.prototype;
-    `,
-    expected: 'object' },
-
-  { name: 'ObjectPrototypeConstructorIsObject', src: `
-    Object.prototype.constructor === Object;
-    `,
-    expected: true },
-
-  { name: 'ObjectPrototypeProtoIsNull', src: `
-    Object.getPrototypeOf(Object.prototype)
-    `,
-    expected: null },
-
-  { name: 'ObjectsAreObjects', src: `
-    Object.getPrototypeOf({}) === Object.prototype;
-    `,
-    expected: true },
-
-
   { name: 'ObjectDefinePropertyNoArgs', src: `
     try {
       Object.defineProperty();
@@ -887,81 +856,16 @@ module.exports = [
   /******************************************************************/
   // Function and Function.prototype
 
-  { name: 'FunctionIsFunction', src: `
-    typeof Function;
-    `,
-    expected: 'function' },
-
-  { name: 'FunctionProtoIsFunctionPrototype', src: `
-    Object.getPrototypeOf(Function) === Function.prototype;
-    `,
-    expected: true },
-
-  { name: 'FunctionPrototypeIsFunction', src: `
-    typeof Function.prototype;
-    `,
-    expected: 'function' },
-
-  { name: 'FunctionPrototypeConstructorIsFunction', src: `
-    Function.prototype.constructor === Function;
-    `,
-    expected: true },
-
-  { name: 'FunctionPrototypeProto', src: `
-    Object.getPrototypeOf(Function.prototype) === Object.prototype;
-    `,
-    expected: true },
-
   { name: 'FunctionPrototypeHasNoPrototype', src: `
     Function.prototype.hasOwnProperty('prototype');
     `,
     expected: false },
 
-  { name: 'FunctionsAreFunctions', src: `
-    Object.getPrototypeOf(function(){}) === Function.prototype;
-    `,
-    expected: true },
-
   /******************************************************************/
   // Array and Array.prototype
 
-  { name: 'ArrayIsFunction', src: `
-    typeof Array;
-    `,
-    expected: 'function' },
-
-  { name: 'ArrayProtoIsFunctionPrototype', src: `
-    Object.getPrototypeOf(Array) === Function.prototype;
-    `,
-    expected: true },
-
-  { name: 'ArrayPrototypeIsObject', src: `
-    typeof Array.prototype;
-    `,
-    expected: 'object' },
-
-  { name: 'ArrayPrototypeConstructorIsArray', src: `
-    Array.prototype.constructor === Array;
-    `,
-    expected: true },
-
   { name: 'ArrayIsArrayArrayPrototype', src: `
     Array.isArray(Array.prototype);
-    `,
-    expected: true },
-
-  { name: 'ArrayPrototypeProto', src: `
-    Object.getPrototypeOf(Array.prototype) === Object.prototype;
-    `,
-    expected: true },
-
-  { name: 'ArrayPrototypeHasNoPrototype', src: `
-    Array.prototype.hasOwnProperty('prototype');
-    `,
-    expected: false },
-
-  { name: 'ArraysAreArrays', src: `
-    Object.getPrototypeOf([]) === Array.prototype;
     `,
     expected: true },
 

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -944,6 +944,11 @@ module.exports = [
     `,
     expected: true },
 
+  { name: 'ArrayIsArrayArrayLiteral', src: `
+    Array.isArray([]);
+    `,
+    expected: true },
+
   /******************************************************************/
   // Other tests (all are skipped):
 

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -869,6 +869,11 @@ module.exports = [
     `,
     expected: true },
 
+  { name: 'ArrayIsArrayArrayInstance', src: `
+    Array.isArray(new Array);
+    `,
+    expected: true },
+
   { name: 'ArrayIsArrayArrayLiteral', src: `
     Array.isArray([]);
     `,

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -587,6 +587,11 @@ module.exports = [
   // Object and Object.prototype
   
   { name: 'ObjectIsFunction', src: `
+    typeof Object;
+    `,
+    expected: 'function' },
+
+  { name: 'ObjectProtoIsFunctionPrototype', src: `
     Object.getPrototypeOf(Object) === Function.prototype;
     `,
     expected: true },


### PR DESCRIPTION
The first part of rearranging code in preparation for creating threads.  The main changes are:

- `Interpreter.OBJECT`, `Interpreter.FUNCTION`, etc. are now the corresponding prototypes, instead of constructors, and `Interpreter.prototype.createObjec` now takes a prototype rather than a constructor.
- There are new classes `Interpreter.Function`, `Interpreter.Array` etc. that are subclasses of `Interpreter.Object`, and corresponding new factory functions `Interpreter.prototype.createFunction`, `Interpreter.prototype.createArray` etc.
- Bootstrapping of top of object tree fixed.
- Many more tests, the preponderance of which actually pass.