### PR TITLE
Fix stepCallExpression broken by e434075c596a57aa6dd64e2d43d20ee28e9b3a30

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2292,7 +2292,8 @@ Interpreter.prototype['stepCallExpression'] = function() {
       state.func_ = this.getValue(func);
       state.components_ = func;
     } else {
-      // Already evaluated function: (function(){...})();
+      // Callee was not an Identifier or MemberExpression, and is
+      // already fully evaluated.
       state.func_ = func;
     }
     state.arguments_ = [];
@@ -2309,7 +2310,10 @@ Interpreter.prototype['stepCallExpression'] = function() {
     }
     // Determine value of 'this' in function.
     if (state.node['type'] === 'NewExpression') {
-      if (func.illegalConstructor) {
+      var func = state.func_;
+      if (!func || !func.isObject) {
+        this.throwException(this.TYPE_ERROR, func + ' is not a function');
+      } else if (func.illegalConstructor) {
         // Illegal: new escape();
         this.throwException(this.TYPE_ERROR, func + ' is not a constructor');
       }
@@ -2328,6 +2332,8 @@ Interpreter.prototype['stepCallExpression'] = function() {
   if (!state.doneExec_) {
     state.doneExec_ = true;
     var func = state.func_;
+    // TODO(fraser): determine if this check is redundant; remove it or add
+    // tests that depend on it.
     if (!func || !func.isObject) {
       this.throwException(this.TYPE_ERROR, func + ' is not a function');
     }

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -575,6 +575,14 @@ module.exports = [
     `,
     expected: 'TypeError' },
 
+  { name: 'newExpression', src: `
+    function T(x, y) { this.sum += x + y; };
+    T.prototype = { sum: 70 }
+    var t = new T(7, 0.7);
+    t.sum;
+    `,
+    expected: 77.7 },
+
   /******************************************************************/
   // Object and Object.prototype
   


### PR DESCRIPTION
Tests newHackNotAvailable, ObjectDefinePropertiesNoArgs and
ObjectDefinePropertiesNonObject were all crashing because
`func.properties.illegalConstructor` throws a TypeError when func is
not an object (including when it is undefined because it is an
uninitialised variable).

Fix this and add a test for new to catch any similarly blatant
regression.