### PR TITLE
Closure type error fixes with a side helping of constructor fixes and toString refactoring

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -246,14 +246,8 @@ Interpreter.prototype.initFunction = function(scope) {
   var identifierRegexp = /^[A-Za-z_$][\w$]*$/;
   // Function constructor.
   wrapper = function(var_args) {
-    if (thisInterpreter.calledWithNew()) {
-      // Called as new Function().
-      var newFunc = this;
-    } else {
-      // Called as Function().
-      var newFunc = thisInterpreter.createFunction();
-      newFunc.addPrototype(thisInterpreter);
-    }
+    var newFunc = thisInterpreter.createFunction();
+    newFunc.addPrototype(thisInterpreter);
     if (arguments.length) {
       var code = String(arguments[arguments.length - 1]);
     } else {
@@ -579,13 +573,7 @@ Interpreter.prototype.initArray = function(scope) {
   var wrapper;
   // Array constructor.
   wrapper = function(var_args) {
-    if (thisInterpreter.calledWithNew()) {
-      // Called as new Array().
-      var newArray = this;
-    } else {
-      // Called as Array().
-      var newArray = thisInterpreter.createArray();
-    }
+    var newArray = thisInterpreter.createArray();
     var first = arguments[0];
     if (arguments.length === 1 && typeof first === 'number') {
       if (isNaN(thisInterpreter.legalArrayLength(first))) {
@@ -993,8 +981,9 @@ Interpreter.prototype.initDate = function(scope) {
     }
     // Called as new Date().
     var args = [null].concat(Array.from(arguments));
-    this.data = new (Function.prototype.bind.apply(Date, args));
-    return this;
+    var date = thisInterpreter.createDate();
+    date.date = new (Function.prototype.bind.apply(Date, args));
+    return date;
   };
   var DateConst = this.createNativeFunction(wrapper, this.DATE);
   this.addVariableToScope(scope, 'Date', DateConst);
@@ -1083,17 +1072,11 @@ Interpreter.prototype.initRegExp = function(scope) {
   this.REGEXP = this.createObject();
   // RegExp constructor.
   wrapper = function(pattern, flags) {
-    if (thisInterpreter.calledWithNew()) {
-      // Called as new RegExp().
-      var rgx = this;
-    } else {
-      // Called as RegExp().
-      var rgx = thisInterpreter.createRegExp()
-    }
+    var regexp = thisInterpreter.createRegExp();
     pattern = pattern ? pattern.toString() : '';
     flags = flags ? flags.toString() : '';
-    thisInterpreter.populateRegExp(rgx, new RegExp(pattern, flags));
-    return rgx;
+    thisInterpreter.populateRegExp(regexp, new RegExp(pattern, flags));
+    return regexp;
   };
   var RegExpConst = this.createNativeFunction(wrapper, this.REGEXP);
   this.addVariableToScope(scope, 'RegExp', RegExpConst);
@@ -1177,13 +1160,7 @@ Interpreter.prototype.initError = function(scope) {
   this.ERROR = this.createError(this.OBJECT);
   // Error constructor.
   var ErrorConst = this.createNativeFunction(function(opt_message) {
-    if (thisInterpreter.calledWithNew()) {
-      // Called as new Error().
-      var newError = this;
-    } else {
-      // Called as Error().
-      var newError = thisInterpreter.createError();
-    }
+    var newError = thisInterpreter.createError();
     if (opt_message) {
       thisInterpreter.setProperty(newError, 'message', String(opt_message),
           Interpreter.NONENUMERABLE_DESCRIPTOR);
@@ -1203,13 +1180,7 @@ Interpreter.prototype.initError = function(scope) {
         Interpreter.NONENUMERABLE_DESCRIPTOR);
     var constructor = thisInterpreter.createNativeFunction(
         function(opt_message) {
-          if (thisInterpreter.calledWithNew()) {
-            // Called as new XyzError().
-            var newError = this;
-          } else {
-            // Called as XyzError().
-            var newError = thisInterpreter.createError(prototype);
-          }
+          var newError = thisInterpreter.createError(prototype);
           if (opt_message) {
             thisInterpreter.setProperty(newError, 'message',
                 String(opt_message), Interpreter.NONENUMERABLE_DESCRIPTOR);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -255,13 +255,13 @@ Interpreter.prototype.initFunction = function(scope) {
       newFunc.addPrototype(thisInterpreter);
     }
     if (arguments.length) {
-      var code = arguments[arguments.length - 1].toString();
+      var code = String(arguments[arguments.length - 1]);
     } else {
       var code = '';
     }
     var args = [];
     for (var i = 0; i < arguments.length - 1; i++) {
-      var name = arguments[i].toString();
+      var name = String(arguments[i]);
       if (!name.match(identifierRegexp)) {
         thisInterpreter.throwException(thisInterpreter.SYNTAX_ERROR,
             'Invalid function argument: ' + name);
@@ -733,7 +733,7 @@ Interpreter.prototype.initArray = function(scope) {
     try {
       var text = [];
       for (var i = 0; i < this.length; i++) {
-        text[i] = this.properties[i].toString();
+        text[i] = String(this.properties[i]);
       }
     } finally {
       cycles.pop();
@@ -868,7 +868,7 @@ Interpreter.prototype.initNumber = function(scope) {
 
   wrapper = function(radix) {
     try {
-      return this.toString(radix);
+      return String(radix);
     } catch (e) {
       // Throws if radix isn't within 2-36.
       thisInterpreter.throwException(thisInterpreter.RANGE_ERROR, e.message);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -172,7 +172,7 @@ Interpreter.prototype.run = function() {
 
 /**
  * Initialize the global scope with buitin properties and functions.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initGlobalScope = function(scope) {
   // Initialize uneditable global properties.
@@ -238,7 +238,7 @@ Interpreter.prototype.initGlobalScope = function(scope) {
 
 /**
  * Initialize the Function class.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initFunction = function(scope) {
   var thisInterpreter = this;
@@ -349,7 +349,7 @@ Interpreter.prototype.initFunction = function(scope) {
 
 /**
  * Initialize the Object class.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initObject = function(scope) {
   var thisInterpreter = this;
@@ -561,7 +561,7 @@ Interpreter.prototype.initObject = function(scope) {
 
 /**
  * Initialize the Array class.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initArray = function(scope) {
   var thisInterpreter = this;
@@ -800,7 +800,7 @@ Interpreter.prototype.initArray = function(scope) {
 
 /**
  * Initialize the Number class.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initNumber = function(scope) {
   var thisInterpreter = this;
@@ -886,7 +886,7 @@ Interpreter.prototype.initNumber = function(scope) {
 
 /**
  * Initialize the String class.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initString = function(scope) {
   var thisInterpreter = this;
@@ -958,7 +958,7 @@ Interpreter.prototype.initString = function(scope) {
 
 /**
  * Initialize the Boolean class.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initBoolean = function(scope) {
   var thisInterpreter = this;
@@ -973,7 +973,7 @@ Interpreter.prototype.initBoolean = function(scope) {
 
 /**
  * Initialize the Date class.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initDate = function(scope) {
   var thisInterpreter = this;
@@ -1046,7 +1046,7 @@ Interpreter.prototype.initDate = function(scope) {
 
 /**
  * Initialize Math object.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initMath = function(scope) {
   var thisInterpreter = this;
@@ -1070,7 +1070,7 @@ Interpreter.prototype.initMath = function(scope) {
 
 /**
  * Initialize Regular Expression object.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initRegExp = function(scope) {
   var thisInterpreter = this;
@@ -1134,7 +1134,7 @@ Interpreter.prototype.initRegExp = function(scope) {
 
 /**
  * Initialize JSON object.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initJSON = function(scope) {
   var thisInterpreter = this;
@@ -1166,7 +1166,7 @@ Interpreter.prototype.initJSON = function(scope) {
 
 /**
  * Initialize the Error class.
- * @param {!Interpreter.Object} scope Global scope.
+ * @param {!Interpreter.Scope} scope Global scope.
  */
 Interpreter.prototype.initError = function(scope) {
   var thisInterpreter = this;
@@ -1416,6 +1416,7 @@ Interpreter.prototype.createObject = function(proto) {
  * Class for a function.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
+ * @extends {Interpreter.Object}
  */
 Interpreter.Function = function(proto) {
   Interpreter.Object.call(this, proto);
@@ -1464,6 +1465,7 @@ Interpreter.prototype.createFunction = function(proto) {
  * Class for an array.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
+ * @extends {Interpreter.Object}
  */
 Interpreter.Array = function(proto) {
   Interpreter.Object.call(this, proto);
@@ -1489,6 +1491,7 @@ Interpreter.prototype.createArray = function(proto) {
  * Class for a date.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
+ * @extends {Interpreter.Object}
  */
 Interpreter.Date = function(proto) {
   Interpreter.Object.call(this, proto);
@@ -1513,6 +1516,7 @@ Interpreter.prototype.createDate = function(proto) {
  * Class for a regexp.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
+ * @extends {Interpreter.Object}
  */
 Interpreter.RegExp = function(proto) {
   Interpreter.Object.call(this, proto);
@@ -1537,6 +1541,7 @@ Interpreter.prototype.createRegExp = function(proto) {
  * Class for an error object.
  * @param {Interpreter.Object} proto Prototype object.
  * @constructor
+ * @extends {Interpreter.Object}
  */
 Interpreter.Error = function(proto) {
   Interpreter.Object.call(this, proto);
@@ -1581,8 +1586,8 @@ Interpreter.prototype.populateRegExp = function(pseudoRegexp, nativeRegexp) {
 /**
  * Create a new function.
  * @param {!Object} node AST node defining the function.
- * @param {!Object} scope Parent scope.
- * @return {!Interpreter.Object} New function.
+ * @param {!Interpreter.Scope} scope Parent scope.
+ * @return {!Interpreter.Function} New function.
  */
 Interpreter.prototype.createFunctionFromAST = function(node, scope) {
   var func = this.createFunction();
@@ -1602,7 +1607,7 @@ Interpreter.prototype.createFunctionFromAST = function(node, scope) {
  *     .prototype property (with the object receiving a corresponding
  *     .constructor property).  If undefined or omitted the function
  *     cannot be used as a constructor (e.g. escape).
- * @return {!Interpreter.Object} New function.
+ * @return {!Interpreter.Function} New function.
  */
 Interpreter.prototype.createNativeFunction = function(nativeFunc, prototype) {
   var func = this.createFunction();
@@ -2011,7 +2016,7 @@ Interpreter.prototype.addVariableToScope =
 /**
  * Create a new scope for the given node.
  * @param {!Object} node AST node (program or function).
- * @param {!Interpreter.Object} scope Scope dictionary to populate.
+ * @param {!Interpreter.Scope} scope Scope dictionary to populate.
  * @private
  */
 Interpreter.prototype.populateScope_ = function(node, scope) {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -390,6 +390,9 @@ Interpreter.prototype.initObject = function(scope) {
   };
 
   // Static methods on Object.
+  this.setProperty(ObjectConst, 'is', this.createNativeFunction(Object.is),
+      Interpreter.NONENUMERABLE_DESCRIPTOR);
+
   wrapper = function(obj) {
     throwIfNullUndefined(obj);
     var props = obj.isObject ? obj.properties : obj;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1811,7 +1811,7 @@ Interpreter.prototype.hasProperty = function(obj, name) {
     return undefined;
   }
   name += '';
-  if (name === 'length' && obj instanceof Interprerter.Array) {
+  if (name === 'length' && obj instanceof Interpreter.Array) {
     return true;
   }
   do {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "codecity-server",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "dependencies": {
+    "tosource": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tosource/-/tosource-1.0.0.tgz",
+      "integrity": "sha1-QtiN0RZhi88A1hBt1URvNCeQL/E=",
+      "dev": true
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,9 @@
   "description": "Server for the CodeCity project",
   "main": "interpreter.js",
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "tosource": "^1.0.0"
+  },
   "scripts": {
     "test": "node tests/run.js"
   },

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -105,27 +105,27 @@ exports.testClasses = function(t) {
     Error: {},
     EvalError: {
       prototypeProto: 'Error.prototype',
-      prototypeClass: 'Error'
+      class: 'Error'
     },
     RangeError: {
       prototypeProto: 'Error.prototype',
-      prototypeClass: 'Error'
+      class: 'Error'
     },
     ReferenceError: {
       prototypeProto: 'Error.prototype',
-      prototypeClass: 'Error'
+      class: 'Error'
     },
     SyntaxError: {
       prototypeProto: 'Error.prototype',
-      prototypeClass: 'Error'
+      class: 'Error'
     },
     TypeError: {
       prototypeProto: 'Error.prototype',
-      prototypeClass: 'Error'
+      class: 'Error'
     },
     URIError: {
       prototypeProto: 'Error.prototype',
-      prototypeClass: 'Error'
+      class: 'Error'
     },
     Boolean: {
       literal: 'false',
@@ -159,7 +159,7 @@ exports.testClasses = function(t) {
     src = 'typeof ' + c + '.prototype;';
     runTest(t, name, src, prototypeType);
     // Check prototype has correct class:
-    var prototypeClass = (tc.prototypeClass || c);
+    var prototypeClass = (tc.prototypeClass || tc.class || c);
     name = c + 'PrototypeClassIs' + prototypeClass;
     src = 'Object.prototype.toString.apply(' + c + '.prototype);';
     runTest(t, name, src, '[object ' + prototypeClass + ']');
@@ -173,6 +173,8 @@ exports.testClasses = function(t) {
     name = c + 'PrototypeConstructorIs' + c;
     src = c + '.prototype.constructor === ' + c + ';';
     runTest(t, name, src, true);
+
+    var cls = tc.class || c;
     if (!tc.noInstance) {
       // Check instance's type:
       name = c + 'InstanceIs' + prototypeType;
@@ -183,9 +185,9 @@ exports.testClasses = function(t) {
       src = 'Object.getPrototypeOf(new ' + c + ') === ' + c + '.prototype;';
       runTest(t, name, src, true);
       // Check instance's class:
-      name = c + 'InstanceClassIs' + prototypeClass,
+      name = c + 'InstanceClassIs' + cls,
       src = 'Object.prototype.toString.apply(new ' + c + ');';
-      runTest(t, name, src, '[object ' + c + ']');
+      runTest(t, name, src, '[object ' + cls + ']');
     }
     if (tc.literal) {
       // Check literal's type:
@@ -199,9 +201,9 @@ exports.testClasses = function(t) {
           '.prototype;';
       runTest(t, name, src, true);
       // Check literal's class:
-      name = c + 'LiteralClassIs' + prototypeClass,
+      name = c + 'LiteralClassIs' + cls,
       src = 'Object.prototype.toString.apply(' + tc.literal + ');';
-      runTest(t, name, src, '[object ' + c + ']');
+      runTest(t, name, src, '[object ' + cls + ']');
     }
   }
 };

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -943,6 +943,87 @@ module.exports = [
     expected: true },
 
   /******************************************************************/
+  // Boolean
+  { name: 'Boolean', src: `
+    var tests = [
+      [undefined, false],
+      [null, false],
+      [false, false],
+      [true, true],
+      [NaN, false],
+      [0, false],
+      [1, true],
+      ['', false],
+      ['foo', true],
+      [{}, true],
+      [[], true],
+      [function() {}, true],
+    ];
+    var ok = 0;
+    for (var i = 0; i < tests.length; i++) {
+      if (Boolean(tests[i][0]) === tests[i][1]) {
+        ok++;
+      }
+    }
+    (ok === tests.length) ? 'pass' : 'fail';
+    `,
+    expected: 'pass' },
+
+  /******************************************************************/
+  // Number
+
+  { name: 'Number', src: `
+    var tests = [
+      [undefined, NaN],
+      [null, 0],
+      [true, 1],
+      [false, 0],
+      ['42', 42],
+      ['', 0],
+      [{}, NaN],
+      [[], 0],
+      [[42], 42],
+      [[1,2,3], NaN],
+      [function () {}, NaN],
+    ];
+    var ok = 0;
+    for (var i = 0; i < tests.length; i++) {
+      if (Object.is(Number(tests[i][0]), tests[i][1])) {
+        ok++;
+      }
+    }
+    (ok === tests.length) ? 'pass' : 'fail';
+    `,
+    expected: 'pass' },
+
+  /******************************************************************/
+  // String
+
+  { name: 'String', src: `
+    var tests = [
+      [undefined, 'undefined'],
+      [null, 'null'],
+      [true, 'true'],
+      [false, 'false'],
+      [0, '0'],
+      [-0, '0'],
+      [Infinity, 'Infinity'],
+      [-Infinity, '-Infinity'],
+      [NaN, 'NaN'],
+      [{}, '[object Object]'],
+      [[1, 2, 3,,5], '1,2,3,,5'],
+    ];
+    var ok = 0;
+    for (var i = 0; i < tests.length; i++) {
+      if (String(tests[i][0]) === tests[i][1]) {
+        ok++;
+      }
+    }
+    (ok === tests.length) ? 'pass' : 'fail';
+    `,
+    expected: 'pass' },
+
+  /******************************************************************/
   // Other tests (all are skipped):
 
   { name: 'newHack', src: `

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -548,12 +548,48 @@ module.exports = [
 
   { name: 'internalNativeFuncToString', src: `
     var o = {};
-    o[function f() {}] = null;
+    o[Object.create] = null;
     for(var key in o) {
       key;
     }
     `,
     expected: '[object Function]' },
+
+  { name: 'internalArrayToString', src: `
+    var o = {};
+    o[[1, 2, 3]] = null;
+    for(var key in o) {
+      key;
+    }
+    `,
+    expected: '1,2,3' },
+
+  { name: 'internalDateToString', src: `
+    var o = {};
+    o[new Date(0)] = null;
+    for(var key in o) {
+      key;
+    }
+    `,
+    expected: (new Date(0)).toString() },
+
+  { name: 'internalRegExpToString', src: `
+    var o = {};
+    o[/foo/g] = null;
+    for(var key in o) {
+      key;
+    }
+    `,
+    expected: '/foo/g' },
+
+  { name: 'internalErrorToString', src: `
+    var o = {};
+    o[Error('oops')] = null;
+    for(var key in o) {
+      key;
+    }
+    `,
+    expected: 'Error: oops' },
 
   // FIXME: enable once arguments implemented:
   // { name: 'internalArgumentsToString', src: `

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -450,6 +450,27 @@ module.exports = [
     `,
     expected: true },
 
+  { name: 'binaryInParent', src: `
+    var p = {foo: 'bar'};
+    var o = Object.create(p);
+    'foo' in o && !('bar' in o);
+    `,
+    expected: true },
+
+  { name: 'binaryInArrayLength', src: `
+    'length' in [];
+    `,
+    expected: true },
+
+  { name: 'binaryInStringLength', src: `
+    try {
+      'length' in '';
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
   { name: 'strictBoxedThis', src: `
     'use strict';
     Object.prototype.foo = function() { return typeof this; };

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -559,22 +559,24 @@ module.exports = [
     expected: '[object Object]' },
 
   { name: 'internalFunctionToString', src: `
-    var o = {};
-    o[function(){}] = null;
+    var o = {}, s, f = function(){};
+    o[f] = null;
     for(var key in o) {
-      key;
+      s = key;
     }
+    /^function.*\(.*\).*{.*}$/.test(s);
     `,
-    expected: '[object Function]' },
+    expected: true },
 
   { name: 'internalNativeFuncToString', src: `
-    var o = {};
-    o[Object.create] = null;
+    var o = {}, s, f = Object.create;
+    o[f] = null;
     for(var key in o) {
-      key;
+      s = key;
     }
+    /^function.*\(.*\).*{.*}$/.test(s);
     `,
-    expected: '[object Function]' },
+    expected: true },
 
   { name: 'internalArrayToString', src: `
     var o = {};

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -926,6 +926,16 @@ module.exports = [
     `,
     expected: false },
 
+  { name: 'FunctionPrototypeToStringApplyNonFunctionThrows', src: `
+    try {
+      Function.prototype.toString.apply({});
+    } catch (e) {
+      e.name;
+    }
+    `,
+    // SKIP: expected: 'TypeError'
+  },
+
   /******************************************************************/
   // Array and Array.prototype
 
@@ -1024,6 +1034,18 @@ module.exports = [
     (ok === tests.length) ? 'pass' : 'fail';
     `,
     expected: 'pass' },
+
+  /******************************************************************/
+  // RegExp
+
+  { name: 'RegExpPrototypeTestApplyNonRegExpThrows', src: `
+    try {
+      /foo/.test.apply({}, ['foo']);
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
 
   /******************************************************************/
   // Other tests (all are skipped):


### PR DESCRIPTION
- Fixed lots of type errors (and several real bugs).
- Made sure Function, Array, Date, RegExp, and *Error constructors actually construct a value of the correct type (and not just with the correct prototype).
- Split up Interpreter.Object.prototype.toString and moved the bits to where they belong.
- Always use String() for string conversion.
- Added many tests.