### PR TITLE
Move legalArrayIndex and legalArrayLength; add tests

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -562,7 +562,7 @@ Interpreter.prototype.initArray = function(scope) {
     var newArray = new thisInterpreter.Array;
     var first = arguments[0];
     if (arguments.length === 1 && typeof first === 'number') {
-      if (isNaN(thisInterpreter.legalArrayLength(first))) {
+      if (isNaN(Interpreter.legalArrayLength(first))) {
         thisInterpreter.throwException(thisInterpreter.RANGE_ERROR,
                                        'Invalid array length');
       }
@@ -1239,7 +1239,7 @@ Interpreter.prototype.isa = function(child, constructor) {
  * @return {number} Zero, or a positive integer if the value can be
  *     converted to such.  NaN otherwise.
  */
-Interpreter.prototype.legalArrayLength = function(n) {
+Interpreter.legalArrayLength = function(n) {
   n = Number(n);
   // Array length must be between 0 and 2^32-1 (inclusive).
   return (n === n >>> 0) ? n : NaN;
@@ -1251,7 +1251,7 @@ Interpreter.prototype.legalArrayLength = function(n) {
  * @return {number} Zero, or a positive integer if the value can be
  *     converted to such.  NaN otherwise.
  */
-Interpreter.prototype.legalArrayIndex = function(n) {
+Interpreter.legalArrayIndex = function(n) {
   n = Number(n);
   // Array index cannot be 2^32-1, otherwise length would be 2^32.
   // 0xffffffff is 2^32-1.
@@ -1492,7 +1492,7 @@ Interpreter.prototype.getProperty = function(obj, name) {
     // Might have numbers in there?
     // Special cases for string array indexing
     if (typeof obj === 'string') {
-      var n = this.legalArrayIndex(name);
+      var n = Interpreter.legalArrayIndex(name);
       if (!isNaN(n) && n < obj.length) {
         return obj[n];
       }
@@ -1551,13 +1551,13 @@ Interpreter.prototype.setProperty = function(obj, name, value, opt_descriptor) {
     var i;
     if (name === 'length') {
       // Delete elements if length is smaller.
-      var newLength = this.legalArrayLength(value);
+      var newLength = Interpreter.legalArrayLength(value);
       if (isNaN(newLength)) {
         this.throwException(this.RANGE_ERROR, 'Invalid array length');
       }
       if (newLength < obj.length) {
         for (i in obj.properties) {
-          i = this.legalArrayIndex(i);
+          i = Interpreter.legalArrayIndex(i);
           if (!isNaN(i) && newLength <= i) {
             delete obj.properties[i];
           }
@@ -1565,7 +1565,7 @@ Interpreter.prototype.setProperty = function(obj, name, value, opt_descriptor) {
       }
       obj.length = newLength;
       return;  // Don't set a real length property.
-    } else if (!isNaN(i = this.legalArrayIndex(name))) {
+    } else if (!isNaN(i = Interpreter.legalArrayIndex(name))) {
       // Increase length if this index is larger.
       obj.length = Math.max(obj.length, i + 1);
     }

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -607,7 +607,12 @@ exports.testAeca = function(t) {
   }
 };
 
-exports.testNumber = function(t) {
+/**
+ * Run some tests of Number.toString(radix) with various different
+ * radix arguments.
+ * @param {T} t The test runner object.
+ */
+exports.testNumberToString = function(t) {
   var cases = [
     ['(42).toString()', '42'],
     ['(42).toString(16)', '2a'],
@@ -622,6 +627,62 @@ exports.testNumber = function(t) {
   for (var i = 0; i < cases.length; i++) {
     var tc = cases[i];
     var src = tc[0] + ';';
-    runTest(t, 'Number.toString: ' + tc[0], src, tc[1]);
+    runTest(t, 'testNumberToString: ' + tc[0], src, tc[1]);
+  }
+};
+
+/**
+ * Unit tests for Interpreter.legalArrayIndex and
+ * Interpreter.legalArrayLength.
+ * @param {T} t The test runner object.
+ */
+exports.testLegalArrayIndexLength = function(t) {
+  var intrp = new Interpreter;
+  var cases = [
+    // [value, asIndex, asLength]
+    [false, NaN, 0],
+    [true, NaN, 1],
+
+    [0, 0, 0],
+    [1, 1, 1],
+    [0xfffffffe, 0xfffffffe, 0xfffffffe],
+    [0xffffffff, NaN, 0xffffffff],
+    [0x100000000, NaN, NaN],
+    [4.5, NaN, NaN],
+    [-1, NaN, NaN],
+
+    ['0', 0, 0],
+    ['1', 1, 1],
+    ['0xfffffffe', NaN, 0xfffffffe],
+    ['0xffffffff', NaN, 0xffffffff],
+    ['0x100000000', NaN, NaN],
+    ['4294967294', 0xfffffffe, 0xfffffffe],
+    ['4294967295', NaN, 0xffffffff],
+    ['4294967296', NaN, NaN],
+    ['4.5', NaN, NaN],
+    ['-1', NaN, NaN],
+
+    ['hello', NaN, NaN],
+    [null, NaN, 0],  // wat
+    [undefined, NaN, NaN],
+    [new intrp.Array, NaN, 0],  // wat!
+    [new intrp.Object, NaN, NaN],
+  ];
+  for (var i = 0; i < cases.length; i++) {
+    var tc = cases[i];
+    var name = 'testLegalArrayIndex: ' + tc[0];
+    var r = Interpreter.legalArrayIndex(tc[0]);
+    if (Object.is(r, tc[1])) {
+      t.pass(name);
+    } else {
+      t.fail(name, util.format('got: %s  want: %s', String(r), String(tc[1])));
+    }
+    name = 'testLegalArrayLength: ' + tc[0];
+    r = Interpreter.legalArrayLength(tc[0]);
+    if (Object.is(r, tc[2])) {
+      t.pass(name);
+    } else {
+      t.fail(name, util.format('got: %s  want: %s', String(r), String(tc[2])));
+    }
   }
 };


### PR DESCRIPTION
These two functions don’t need to be on interpreter instances, so move them to Interpreter.

Add unit test for them, plus an integration test for array behaviour.