### PR TITLE
Implement intrp.Function.hasInstance to replace Interpreter.prototype.isa

### DIFF
--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -187,11 +187,11 @@ exports.testClasses = function(t) {
       src = 'Object.getPrototypeOf(new ' + c + ') === ' + c + '.prototype;';
       runTest(t, name, src, true);
       // Check instance's class:
-      name = c + 'InstanceClassIs' + cls,
+      name = c + 'InstanceClassIs' + cls;
       src = 'Object.prototype.toString.apply(new ' + c + ');';
       runTest(t, name, src, '[object ' + cls + ']');
       // Check instance is instanceof its contructor:
-      name = c + 'InstanceIsInstanceof' + c,
+      name = c + 'InstanceIsInstanceof' + c;
       src = '(new ' + c + ') instanceof ' + c + ';';
       runTest(t, name, src, true);
     }
@@ -207,13 +207,13 @@ exports.testClasses = function(t) {
           '.prototype;';
       runTest(t, name, src, true);
       // Check literal's class:
-      name = c + 'LiteralClassIs' + cls,
+      name = c + 'LiteralClassIs' + cls;
       src = 'Object.prototype.toString.apply(' + tc.literal + ');';
       runTest(t, name, src, '[object ' + cls + ']');
       // Primitives can never be instances.
-      if (literalType == 'object' || literalType == 'function') { 
+      if (literalType === 'object' || literalType === 'function') { 
         // Check literal is instanceof its contructor.
-        name = c + 'LiteralIsInstanceof' + c,
+        name = c + 'LiteralIsInstanceof' + c;
         src = '(' + tc.literal + ') instanceof ' + c + ';';
         runTest(t, name, src, true);
       }

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -190,6 +190,10 @@ exports.testClasses = function(t) {
       name = c + 'InstanceClassIs' + cls,
       src = 'Object.prototype.toString.apply(new ' + c + ');';
       runTest(t, name, src, '[object ' + cls + ']');
+      // Check instance is instanceof its contructor:
+      name = c + 'InstanceIsInstanceof' + c,
+      src = '(new ' + c + ') instanceof ' + c + ';';
+      runTest(t, name, src, true);
     }
     if (tc.literal) {
       // Check literal's type:
@@ -206,6 +210,13 @@ exports.testClasses = function(t) {
       name = c + 'LiteralClassIs' + cls,
       src = 'Object.prototype.toString.apply(' + tc.literal + ');';
       runTest(t, name, src, '[object ' + cls + ']');
+      // Primitives can never be instances.
+      if (literalType == 'object' || literalType == 'function') { 
+        // Check literal is instanceof its contructor.
+        name = c + 'LiteralIsInstanceof' + c,
+        src = '(' + tc.literal + ') instanceof ' + c + ';';
+        runTest(t, name, src, true);
+      }
     }
   }
 };

--- a/server/tests/run.js
+++ b/server/tests/run.js
@@ -124,7 +124,7 @@ T.prototype.constructor = T;
  * @param {*} opt_message Additional info to log.
  */
 T.prototype.result = function (status, name, opt_message) {
-  console.log('%s\t%s', status, name);
+  status === 'OK' || console.log('%s\t%s', status, name);
   if (opt_message) {
     console.log(opt_message);
   }

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -562,6 +562,40 @@ module.exports = [
     `,
     expected: 'TypeError' },
 
+  { name: 'instanceofBasics', src: `
+    function F(){}
+    var f = new F;
+    f instanceof F && f instanceof Object && !(f.prototype instanceof F);
+    `,
+    expected: true },
+
+  { name: 'instanceofNonObjectLHS', src: `
+    function F() {}
+    F.prototype = null;
+    42 instanceof F;
+    `,
+    expected: false },
+  
+  { name: 'instanceofNonFunctionRHS', src: `
+    try {
+      ({}) instanceof 0;
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
+  { name: 'instanceofNonObjectPrototype', src: `
+    function F() {};
+    F.prototype = 'hello';
+    try {
+      ({}) instanceof F;
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
   { name: 'strictBoxedThis', src: `
     'use strict';
     Object.prototype.foo = function() { return typeof this; };


### PR DESCRIPTION
Since isa was only being called from stepBinaryExpression instanceof,
reimplement that operator in terms of how it is described in the spec.

And add tests.