### PR TITLE
Remove final use of .isObject

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1845,8 +1845,6 @@ Interpreter.prototype.Object = function(proto) {
 };
 /** @type {Interpreter.prototype.Object} */
 Interpreter.prototype.Object.prototype.proto = null;
-/** @type {boolean} */
-Interpreter.prototype.Object.prototype.isObject = false;
 /** @type {string} */
 Interpreter.prototype.Object.prototype.class = '';
 /** @return {string} */
@@ -2121,8 +2119,8 @@ Interpreter.prototype.installTypes = function() {
       var strs = [];
       for (var i = 0; i < this.length; i++) {
         var value = this.properties[i];
-        strs[i] = (value && value.isObject && cycles.indexOf(value) !== -1) ?
-            '...' : value;
+        strs[i] = (value instanceof intrp.Object &&
+            cycles.indexOf(value) !== -1) ? '...' : value;
       }
     } finally {
       cycles.pop();

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1084,6 +1084,14 @@ module.exports = [
     `,
     expected: true },
 
+  { name: 'ArrayPrototypeToStringCycleDetection', src: `
+    var a = [1, , 3];
+    a[1] = a;
+    a.toString();
+    "Didn't crash!";
+    `,
+    expected: "Didn't crash!" },
+
   /******************************************************************/
   // Boolean
   { name: 'Boolean', src: `


### PR DESCRIPTION
Not sure how this one escaped notice previously, but since
intrp.Object.prototype.toString was gone there was actually a crash
bug.  Test added.