### PR TITLE
Introduce threads

### DIFF
--- a/server/externs.js
+++ b/server/externs.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Code City: Closure Compiler externs for node.js
+ *
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Closure Compiler externs for node.js
+ * @author cpcallend@google.com (Christopher Allen)
+ * @externs
+ */
+
+/**
+ * @param name
+ * @return {*}
+ */
+var require = function(name) {}
+
+/**
+ * @type {Object}
+ */
+var module = {};

--- a/server/externs.js
+++ b/server/externs.js
@@ -19,7 +19,7 @@
 
 /**
  * @fileoverview Closure Compiler externs for node.js
- * @author cpcallend@google.com (Christopher Allen)
+ * @author cpcallen@google.com (Christopher Allen)
  * @externs
  */
 
@@ -27,7 +27,7 @@
  * @param name
  * @return {*}
  */
-var require = function(name) {}
+var require = function(name) {};
 
 /**
  * @type {Object}

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1013,7 +1013,7 @@ Interpreter.prototype.initDate = function(scope) {
     })(functions[i]);
     this.DATE.addNativeMethod(functions[i], wrapper);
   }
-  functions = ['toLocaleDateString', 'toLocaleString',
+  var functions = ['toLocaleDateString', 'toLocaleString',
                'toLocaleTimeString'];
   for (var i = 0; i < functions.length; i++) {
     wrapper = (function(nativeFunc) {
@@ -1375,7 +1375,7 @@ Interpreter.prototype.pseudoToNative = function(pseudoObj, opt_cycles) {
   if (pseudoObj instanceof this.Array) {  // Array.
     nativeObj = [];
     cycles.native.push(nativeObj);
-    for (i = 0; i < pseudoObj.length; i++) {
+    for (var i = 0; i < pseudoObj.length; i++) {
       nativeObj[i] = this.pseudoToNative(pseudoObj.properties[i], cycles);
     }
   } else {  // Object.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1844,6 +1844,19 @@ Interpreter.prototype.Thread = function() {
   throw Error('Inner class constructor not callable on prototype');
 };
 
+/** 
+ * Legal thread states.
+ * @enum {number}
+ */
+Interpreter.prototype.Thread.State = {
+  /** Execution of the thread has terminated. */
+  ZOMBIE: 0,
+  /** The thread is ready to run (or is running). */
+  READY: 1,
+  /** The thread is blocked, awaiting an external event (e.g. callback). */
+  BLOCKED: 2,
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 /**

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -154,19 +154,15 @@ Interpreter.prototype.schedule = function() {
  * @return {boolean} True if a step was executed, false if no more instructions.
  */
 Interpreter.prototype.step = function() {
-  var stack = this.thread.stateStack;
+  var thread = this.thread;
+  if (thread.state !== this.Thread.State.READY) {
+    return false;
+  }
+  var stack = thread.stateStack;
   var state = stack[stack.length - 1];
-  if (!state) {
-    return false;
-  }
-  var node = state.node, type = node['type'];
-  if (type === 'Program' && state.done) {
-    return false;
-  } else if (this.thread.state === this.Thread.State.BLOCKED) {
-    return true;
-  }
+  var node = state.node;
   try {
-    this.functionMap_[type](stack, state, node);
+    this.functionMap_[node['type']](stack, state, node);
   } catch (e) {
     // Eat any step errors.  They have been thrown on the stack.
     if (e !== Interpreter.STEP_ERROR) {
@@ -183,19 +179,13 @@ Interpreter.prototype.step = function() {
  *     false if no more instructions.
  */
 Interpreter.prototype.run = function() {
-  var stack = this.thread.stateStack;
-  while (true) {
+  var thread = this.thread;
+  var stack = thread.stateStack;
+  while (thread.state === this.Thread.State.READY) {
     var state = stack[stack.length - 1];
-    if (!state) {
-      break;
-    }
-    var node = state.node, type = node['type'];
-    if (type === 'Program' && state.done ||
-        this.thread.state === this.Thread.State.BLOCKED) {
-      break;
-    }
+    var node = state.node;
     try {
-      this.functionMap_[type](stack, state, node);
+      this.functionMap_[node['type']](stack, state, node);
     } catch (e) {
       // Eat any step errors.  They have been thrown on the stack.
       if (e !== Interpreter.STEP_ERROR) {

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -186,7 +186,7 @@ Serializer.serialize = function(intrp) {
 
   // Properties on Interpreter instances to ignore.
   var skipList = ['Object', 'Function', 'Array', 'Date', 'RegExp', 'Error',
-                  'functionMap_', 'functionCounter_'];
+                  'Thread', 'functionMap_', 'functionCounter_'];
   // Find all objects.
   var objectList = [];
   Serializer.objectHunt_(intrp, objectList, skipList);
@@ -296,13 +296,14 @@ Serializer.getTypesDeserialize_ = function (intrp) {
   return {
     'Interpreter': Interpreter,
     'Scope': Interpreter.Scope,
+    'Thread': intrp.Thread,
     'PseudoObject': intrp.Object,
     'PseudoFunction': intrp.Function,
     'PseudoArray': intrp.Array,
     'PseudoDate': intrp.Date,
     'PseudoRegExp': intrp.RegExp,
     'PseudoError': intrp.Error,
-    'Node': intrp.stateStack[0].node.constructor,
+    'Node': intrp.thread.stateStack[0].node.constructor,
   };
 };
 

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -303,7 +303,7 @@ Serializer.getTypesDeserialize_ = function (intrp) {
     'PseudoDate': intrp.Date,
     'PseudoRegExp': intrp.RegExp,
     'PseudoError': intrp.Error,
-    'Node': intrp.thread.stateStack[0].node.constructor,
+    'Node': Interpreter.Node,
   };
 };
 

--- a/server/tests/interpreter_bench.js
+++ b/server/tests/interpreter_bench.js
@@ -38,12 +38,12 @@ var autoexec = require('../autoexec');
 function runBench(b, name, src) {
   for (var i = 0; i < 4; i++) {
     var interpreter = new Interpreter();
-    interpreter.appendCode(autoexec);
+    interpreter.createThread(autoexec);
     interpreter.run();
 
     var err = undefined;
     try {
-      interpreter.appendCode(src);
+      interpreter.createThread(src);
       b.start(name, i);
       interpreter.run();
       b.end(name, i);

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -50,14 +50,14 @@ var testcases = require('./testcases');
  */
 function runTest(t, name, src, expected, initFunc, asyncFunc) {
   var interpreter = new Interpreter();
-  interpreter.appendCode(autoexec);
+  interpreter.createThread(autoexec);
   interpreter.run();
   if (initFunc) {
     initFunc(interpreter);
   }
 
   try {
-    interpreter.appendCode(src);
+    interpreter.createThread(src);
     while (interpreter.run()) {
       if (asyncFunc) {
         asyncFunc();

--- a/server/tests/serialize_bench.js
+++ b/server/tests/serialize_bench.js
@@ -40,12 +40,12 @@ const Serializer = require('../serialize');
 function runInterpreterBench(b, name, src) {
   for (var i = 0; i < 4; i++) {
     var intrp1 = new Interpreter;
-    intrp1.appendCode(autoexec);
+    intrp1.createThread(autoexec);
     intrp1.run();
 
     var err = undefined;
     try {
-      intrp1.appendCode(src);
+      intrp1.createThread(src);
       var json = Serializer.serialize(intrp1);
       var intrp2 = new Interpreter;
       Serializer.deserialize(json, intrp2);

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -51,10 +51,10 @@ const Serializer = require('../serialize');
 function runTest(t, name, src1, src2, expected, steps) {
   try {
     var intrp1 = new Interpreter;
-    intrp1.appendCode(autoexec);
+    intrp1.createThread(autoexec);
     intrp1.run();
     if (src1) {
-      intrp1.appendCode(src1);
+      intrp1.createThread(src1);
       if (steps !== undefined) {
         for (var i = 0; i < steps; i++) {
           intrp1.step();
@@ -86,7 +86,7 @@ function runTest(t, name, src1, src2, expected, steps) {
   try {
     intrp2.run();
     if (src2) {
-      intrp2.appendCode(src2);
+      intrp2.createThread(src2);
       intrp2.run();
     }
   } catch (e) {


### PR DESCRIPTION
Introduce multiple threads and a (very) simplistic scheduler.

This implementation imposes a 10-15% performance penalty (mostly due to the extra cost of resolving this.thread.stateStack instead of this.stateStack in pushNode_) but a fix is in hand and will follow in a subsequent PR.