### PR TITLE
Fix issue with CatchClause

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2654,14 +2654,12 @@ Interpreter.prototype['stepCallExpression'] = function(stack, state, node) {
 Interpreter.prototype['stepCatchClause'] = function(stack, state, node) {
   if (!state.done_) {
     state.done_ = true;
-    var scope;
-    if (node['param']) {
-      // Create an empty scope.
-      scope = new Interpreter.Scope(state.scope);
-      // Add the argument.
-      var paramName = node['param']['name'];
-      this.addVariableToScope(scope, paramName, state.throwValue);
-    }
+    // Create an empty scope.
+    var scope = new Interpreter.Scope(state.scope);
+    // Add the argument.
+    var paramName = node['param']['name'];
+    this.addVariableToScope(scope, paramName, state.throwValue);
+    // Execute catch clause
     return new Interpreter.State(node['body'], scope);
   } else {
     stack.pop();


### PR DESCRIPTION
The compiler caught an issue with CatchClause: if there was no param
given, the body would get executed with no scope (none at all).

Fortunately the catch clause param is not optional, so to fix the
compiler warning we need merely remove the if statement surrounding the
code that sets up the inner scope.