### PR TITLE
Runtime changes in preparation for networking

### DIFF
--- a/server/codecity.js
+++ b/server/codecity.js
@@ -85,12 +85,17 @@ function startup() {
   // TODO: Let the interval be configurable from the database.
   setInterval(checkpoint, 60 * 1000);
 
-  // TODO: Run the interpreter.
+  interpreter.start();
 }
 
 function checkpoint(callback) {
   console.log('Checkpoint started.');
-  var json = Serializer.serialize(interpreter);
+  try {
+    interpreter.stop();
+    var json = Serializer.serialize(interpreter);
+  } finally {
+    interpreter.start();
+  }
   // JSON.stringify(json) would work, but adding linebreaks so that every
   // object is on its own line makes the output more readable.
   var text = [];

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -182,12 +182,14 @@ Interpreter.prototype.createThread = function(runnable, runAt) {
 /**
  * Create a new thread to execute a particular function call.
  * @param {!Interpreter.prototype.Function} fun Function to call.
+ * @param {Interpreter.Value} funcThis value of 'this' in function call.
  * @param {!Array<Interpreter.Value>} args Arguments to pass.
  * @param {number=} runAt Time at which thread should begin execution
  *     (defaults to now).
  * @return {number} thread ID.
  */
-Interpreter.prototype.createThreadForFuncall = function(func, args, runAt) {
+Interpreter.prototype.createThreadForFuncall =
+    function(func, funcThis, args, runAt) {
   if (!(func instanceof this.Function)) {
     this.throwException(this.TYPE_ERROR, func + ' is not a function');
   }
@@ -195,6 +197,7 @@ Interpreter.prototype.createThreadForFuncall = function(func, args, runAt) {
   node['type'] = 'CallExpression';
   var state = new Interpreter.State(node, this.global);
   state.func_ = func;
+  state.funcThis_ = funcThis;
   state.doneCallee_ = 2;
   state.arguments_ = args;
   state.doneArgs_ = true;
@@ -1354,7 +1357,8 @@ Interpreter.prototype.initThreads = function(scope) {
       function(func) {
         var delay = Number(arguments[1]) || 0;
         var args = Array.prototype.slice.call(arguments, 2);
-        return intrp.createThreadForFuncall(func, args, intrp.now() + delay);
+        return intrp.createThreadForFuncall(func, undefined, args,
+                                            intrp.now() + delay);
       }, false);
 
   this.createNativeFunction('clearTimeout',

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -192,7 +192,7 @@ Interpreter.prototype.createThread = function(runnable, runAt) {
  *     (defaults to now).
  * @return {number} thread ID.
  */
-Interpreter.prototype.createThreadForFuncall =
+Interpreter.prototype.createThreadForFuncCall =
     function(func, funcThis, args, runAt) {
   if (!(func instanceof this.Function)) {
     this.throwException(this.TYPE_ERROR, func + ' is not a function');
@@ -341,7 +341,7 @@ Interpreter.prototype.run = function(continuous) {
 };
 
 /**
- * Use setTimout to repeatedly call .run() until there are no more
+ * Use setTimeout to repeatedly call .run() until there are no more
  * sleeping threads.
  */
 Interpreter.prototype.start = function() {
@@ -1363,8 +1363,8 @@ Interpreter.prototype.initThreads = function(scope) {
       function(func) {
         var delay = Number(arguments[1]) || 0;
         var args = Array.prototype.slice.call(arguments, 2);
-        return intrp.createThreadForFuncall(func, undefined, args,
-                                            intrp.now() + delay);
+        return intrp.createThreadForFuncCall(func, undefined, args,
+                                             intrp.now() + delay);
       }, false);
 
   this.createNativeFunction('clearTimeout',

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -62,6 +62,7 @@ var Interpreter = function() {
   this.thread = null;
   this.initUptime();
   this.previousTime_ = 0;
+  this.running = false;
   this.done = true;  // True if any non-ZOMBIE threads exist.
 };
 
@@ -176,6 +177,9 @@ Interpreter.prototype.createThread = function(runnable, runAt) {
   var id = this.threads.length;
   var thread = new Interpreter.Thread(id, runnable, runAt || this.now());
   this.threads.push(thread);
+  if (this.running) {
+    this.start();
+  }
   return id;
 };
 
@@ -352,6 +356,7 @@ Interpreter.prototype.start = function() {
   // Kill any existing runner and restart.
   clearTimeout(this.runner_);
   this.runner_ = setTimeout(repeat, 0);
+  this.running = true;
 };
 
 /**
@@ -360,6 +365,7 @@ Interpreter.prototype.start = function() {
 Interpreter.prototype.stop = function() {
   clearTimeout(this.runner_);
   this.runner_ = undefined;
+  this.running = false;
 };
 
 /**

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -158,9 +158,11 @@ Interpreter.prototype.now = function() {
  * @param {!Interpreter.State|!Interpreter.Node|string} runnable Initial
  *     state, or AST node to construct state from, or raw JavaScript
  *     text to parse into AST.
+ * @param {number=} runAt Time at which thread should begin execution
+ *     (defaults to now).
  * @return {number} thread ID.
  */
-Interpreter.prototype.createThread = function(runnable) {
+Interpreter.prototype.createThread = function(runnable, runAt) {
   if (typeof runnable === 'string') {
     runnable = acorn.parse(runnable, Interpreter.PARSE_OPTIONS);
   }
@@ -172,7 +174,7 @@ Interpreter.prototype.createThread = function(runnable) {
     runnable = new Interpreter.State(runnable, this.global);
   }
   var id = this.threads.length;
-  var thread = new Interpreter.Thread(id, runnable, this.now());
+  var thread = new Interpreter.Thread(id, runnable, runAt || this.now());
   this.threads.push(thread);
   return id;
 };
@@ -1341,7 +1343,7 @@ Interpreter.prototype.initThreads = function(scope) {
         state.doneCallee_ = 2;
         state.arguments_ = args;
         state.doneArgs_ = true;
-        return intrp.createThread(state);
+        return intrp.createThread(state, intrp.now() + delay);
       }, false);
 
   this.createNativeFunction('clearTimeout',

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -805,8 +805,8 @@ exports.testStartStop = async function(t) {
   var src = `
       var x = 0;
       while (true) {
-          suspend(10);
-          x++;
+        suspend(10);
+        x++;
       };
   `;
   intrp.createThread(autoexec);

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -792,3 +792,19 @@ exports.testThreading = function(t) {
   `;
   runTest(t, 'clearTimeout', src, '1235', undefined, wait);
 };
+
+
+exports.demo = function() {
+  var intrp = new Interpreter;
+  intrp.addVariableToScope(intrp.global, 'log',
+      intrp.createNativeFunction(console.log));
+  intrp.createThread(`
+      log('DEMO: Begin.');
+      while (true) {
+          suspend(1000);
+          log('DEMO: "Working"...');
+      }`);
+  intrp.start();
+  setTimeout(function() { console.log('DEMO: End.'); intrp.stop(); }, 2900);
+};
+  

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -761,16 +761,13 @@ exports.testThreading = function(t) {
 
   src = `
       var s = '';
-      setTimeout(function(a, b) {
-          s += a;
-          suspend();
-          s += b;
-      }, 0, 2, 4);
-      s += 1;
-      suspend();
-      s += 3;
-      suspend();
-      s += 5;
+      setTimeout(function(x) { s += '2'; }, 500);
+      setTimeout(function(x) { s += '4'; }, 1500);
+      s += '1';
+      suspend(1000);
+      s += '3';
+      suspend(1000);
+      s += '5';
       s;
   `;
   runTest(t, 'setTimeout', src, '12345', undefined, wait);
@@ -781,13 +778,13 @@ exports.testThreading = function(t) {
           s += a;
           suspend();
           s += b;
-      }, 0, 2, 4);
+      }, 0, '2', '4');
       s += 1;
       suspend();
-      s += 3;
+      s += '3';
       clearTimeout(tid);
       suspend();
-      s += 5;
+      s += '5';
       s;
   `;
   runTest(t, 'clearTimeout', src, '1235', undefined, wait);

--- a/server/tests/run.js
+++ b/server/tests/run.js
@@ -94,13 +94,13 @@ B.prototype.skip = function(name, opt_message) {
  * Run benchmarks.
  * @param {!Array} files Filenames containing benchmarks to run.
  */
-function runBenchmarks(files) {
+async function runBenchmarks(files) {
   for (var i = 0; i < files.length; i++) {
-    var tests = require(files[i]);
+    var benchmarks = require(files[i]);
     var b = new B;
-    for (var k in tests) {
-      if (k.startsWith('bench') && typeof tests[k] === 'function') {
-        tests[k](b);
+    for (var k in benchmarks) {
+      if (k.startsWith('bench') && typeof benchmarks[k] === 'function') {
+        await benchmarks[k](b);
       }
     }
   }
@@ -159,14 +159,14 @@ T.prototype.fail = function(name, opt_message) {
  * Run tests.
  * @param {!Array} files Filenames containing tests to run.
  */
-function runTests(files) {
+async function runTests(files) {
   var t = new T;
   
   for (var i = 0; i < files.length; i++) {
     var tests = require(files[i]);
     for (var k in tests) {
       if (k.startsWith('test') && typeof tests[k] === 'function') {
-        tests[k](t);
+        await tests[k](t);
       }
     }
   }
@@ -191,7 +191,7 @@ function getFiles(pattern) {
       map(function (fn) { return './' + fn; });
 }
 
-runTests(getFiles(/_test.js$/));
-runBenchmarks(getFiles(/_bench.js$/));
-
-require('./interpreter_test').demo();
+(async function main() {
+  await runTests(getFiles(/_test.js$/));
+  await runBenchmarks(getFiles(/_bench.js$/));
+})();

--- a/server/tests/run.js
+++ b/server/tests/run.js
@@ -193,3 +193,5 @@ function getFiles(pattern) {
 
 runTests(getFiles(/_test.js$/));
 runBenchmarks(getFiles(/_bench.js$/));
+
+require('./interpreter_test').demo();


### PR DESCRIPTION
Various changes that are necessary to support networking or just simply continuous operation of the interpreter:

- Run tests asynchronously
- Have start and stop methods on interpreter instances (that do what they say on the tin)
- Ability to specify ‘this’ value when creating a new thread to execute a function call (i.e., can put *method* calls in own thread).