### PR TITLE
Fix bugs in networking implementation

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1431,11 +1431,13 @@ Interpreter.prototype.initNetwork = function(scope) {
             intrp.createThreadForFuncCall(func, obj, []);
           }
 
-          // Handle incoming data from clients.
+          // Handle incoming data from clients.  N.B. that data is a
+          // node buffer object, so we must convert it to a string
+          // before passing it to user code.
           socket.on('data', function (data) {
             var func = intrp.getProperty(obj, 'onReceive');
             if (func instanceof intrp.Function) {
-              intrp.createThreadForFuncCall(func, obj, [data]);
+              intrp.createThreadForFuncCall(func, obj, [String(data)]);
             }
           });
 
@@ -1492,15 +1494,15 @@ Interpreter.prototype.initNetwork = function(scope) {
         if (!(obj instanceof intrp.Object) || !obj.socket) {
           intrp.throwException(intrp.TYPE_ERROR, 'object is not connected');
         }
-        obj.socket.write(data);
+        obj.socket.write(String(data));
       }, false));
 
   this.addVariableToScope(scope, 'connectionClose', this.createNativeFunction(
-      'connectionClose', function(obj, data) {
+      'connectionClose', function(obj) {
         if (!(obj instanceof intrp.Object) || !obj.socket) {
           intrp.throwException(intrp.TYPE_ERROR, 'object is not connected');
         }
-        obj.socket.end(data);
+        obj.socket.end();
       }, false));
 };
 

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -24,6 +24,7 @@
 'use strict';
 
 var Interpreter = require('./interpreter');
+var net = require('net');
 
 var Serializer = {};
 
@@ -71,7 +72,7 @@ Serializer.deserialize = function(json, intrp) {
   // Find all native functions in existing interpreter.
   // Find all native functions to get id => func mappings.
   var objectList = [];
-  Serializer.objectHunt_(intrp, objectList);
+  Serializer.objectHunt_(intrp, objectList, Serializer.excludeTypes);
   var functionHash = Object.create(null);
   for (var i = 0; i < objectList.length; i++) {
     if (typeof objectList[i] === 'function') {
@@ -187,11 +188,9 @@ Serializer.serialize = function(intrp) {
   // Properties on Interpreter instances to ignore.
   var exclude = ['Object', 'Function', 'Array', 'Date', 'RegExp', 'Error',
                  'Thread', 'stepFunctions_', 'runner_', 'listeners'];
-  // Properties to ingore on all objects.
-  var excludeAll = ['socket'];
   // Find all objects.
   var objectList = [];
-  Serializer.objectHunt_(intrp, objectList, excludeAll, exclude);
+  Serializer.objectHunt_(intrp, objectList, Serializer.excludeTypes, exclude);
   // Get types.
   var types = this.getTypesSerialize_(intrp);
   // Serialize every object.
@@ -252,8 +251,7 @@ Serializer.serialize = function(intrp) {
     var names = Object.getOwnPropertyNames(obj);
     for (var j = 0; j < names.length; j++) {
       var name = names[j];
-      if ((obj !== intrp || exclude.indexOf(name) === -1) &&
-          excludeAll.indexOf(name) === -1) {
+      if (obj !== intrp || exclude.indexOf(name) === -1) {
         props[name] = encodeValue(obj[name]);
       }
     }
@@ -268,11 +266,14 @@ Serializer.serialize = function(intrp) {
  * Recursively search the stack to find all non-primitives.
  * @param {*} node JavaScript value to search.
  * @param {!Array<!Object>} objectList Array to add objects to.
- * @param {!Array<string>} skipList List of properties not to spider.
+ * @param {!Set<!Object>} excludeTypes Set of prototypes not to spider.
+ * @param {!Array<string>} exclude List of properties not to spider.
  */
-Serializer.objectHunt_ = function(node, objectList, excludeAll, exclude) {
+Serializer.objectHunt_ = function(node, objectList, excludeTypes, exclude) {
   if (node && (typeof node === 'object' || typeof node === 'function')) {
-    if (objectList.indexOf(node) !== -1) {
+    if (((typeof node === 'object' || typeof node === 'function') &&
+        excludeTypes.has(Object.getPrototypeOf(node))) ||
+        objectList.indexOf(node) !== -1) {
       return;
     }
     objectList.push(node);
@@ -280,10 +281,9 @@ Serializer.objectHunt_ = function(node, objectList, excludeAll, exclude) {
       var names = Object.getOwnPropertyNames(node);
       for (var i = 0; i < names.length; i++) {
         var name = names[i];
-        if ((!excludeAll || excludeAll.indexOf(name) === -1) &&
-            (!exclude || exclude.indexOf(name) === -1)) {
+        if (!exclude || exclude.indexOf(name) === -1) {
           // Don't pass exclude; it's only for top-level property keys.
-          Serializer.objectHunt_(node[names[i]], objectList, excludeAll);
+          Serializer.objectHunt_(node[names[i]], objectList, excludeTypes);
         }
       }
     }
@@ -330,5 +330,7 @@ Serializer.getTypesSerialize_ = function (intrp) {
   }
   return map;
 };
+
+Serializer.excludeTypes = new Set([net.Socket.prototype, net.Server.prototype]);
 
 module.exports = Serializer;

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -1028,7 +1028,7 @@ exports.testNetworking = async function(t) {
       conn.onReceive = function(d) {
         data += d;
       };
-      conn.onEnd = function(d) {
+      conn.onEnd = function() {
         connectionUnlisten(8888);
         resolve(data);
       };


### PR DESCRIPTION
- Convert incoming data buffer to string before passing to user code.
- Convert outgoing data to string before passing to socket.write().
- Don't try to serialise open network connections.
- Remove data param from connectionClose (since it's not in our spec).