### PR TITLE
Don't crash on unhandled exceptions.

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2122,26 +2122,18 @@ Interpreter.prototype.executeException = function(error) {
     }
   }
 
-  // Throw a real error.
-  var realError;
+  // Unhandled exception.  Terminate thread.
+  this.thread.status = Interpreter.Thread.Status.ZOMBIE;
+  
+  // Log exception and stack trace.
   if (error instanceof this.Error) {
-    var errorTable = {
-      'EvalError': EvalError,
-      'RangeError': RangeError,
-      'ReferenceError': ReferenceError,
-      'SyntaxError': SyntaxError,
-      'TypeError': TypeError,
-      'URIError': URIError
-    };
     var name = this.getProperty(error, 'name').toString();
     var message = this.getProperty(error, 'message').valueOf();
-    var type = errorTable[name] || Error;
-    realError = type(message + '\n' +
-                     this.getProperty(error, 'stack'));
+    console.log('Unhandled %s: %s', name, message);
+    console.log(this.getProperty(error, 'stack').toString());
   } else {
-    realError = error.toString();
+    console.log('Unhandled exception with value = ' + error.toString());
   }
-  throw realError;
 };
 
 

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -177,6 +177,17 @@ module.exports = [
     `,
     expected: 52 },
 
+  // N.B.: This and next tests have no equivalent in the test DB.
+  { name: 'throwUnhandledError', src: `
+    throw Error('not caught');
+    `,
+    expected: undefined },
+
+  { name: 'throwUnhandledException', src: `
+    throw 'not caught';
+    `,
+    expected: undefined },
+
   { name: 'seqExpr', src: `
     51, 52, 53;
     `,


### PR DESCRIPTION
Log unhandled exceptions rather than throwing a "real" exception, plus:
once a thread stack is empty it must be marked as a zombie; otherwise
further attempts to .run() the interpreter will all crash.