### PR TITLE
Fix try/catch/finally vs. break / continue / return / throw

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2085,9 +2085,8 @@ Interpreter.prototype.setValue = function(scope, ref, value) {
 
 /**
  * Throw an exception in the interpreter that can be handled by a
- * interpreter try/catch statement.  If unhandled, a real exception will
- * be thrown.  Can be called with either an error class and a message, or
- * with an actual object to be thrown.
+ * interpreter try/catch statement.  Can be called with either an
+ * error class and a message, or with an actual object to be thrown.
  * @param {Interpreter.Value} value Value to be thrown.  If message is
  *     provided a new error object is created using value as the
  *     prototype; if not it is used directly.
@@ -2109,9 +2108,9 @@ Interpreter.prototype.throwException = function(value, opt_message) {
 };
 
 /**
- * Throw an exception in the interpreter that can be handled by an
- * interpreter try/catch statement.  If unhandled, a real exception will
- * be thrown.
+ * Execute an exception by unwinding the stack to the innermost
+ * enclosing TryStatement.  If none is found, the current thread will
+ * be terminated and an unhandled exception logged.
  * @param {Interpreter.Value} error Value being thrown.
  */
 Interpreter.prototype.executeException = function(error) {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2184,6 +2184,8 @@ Interpreter.prototype.unwind = function(type, value, label) {
       // TODO(cpcallen): log toSource(error), for clarity?
       console.log('Unhandled exception with value:', value);
     }
+  } else {
+    throw Error('Unsynatctic break/continue/return not rejected by acorn');
   }
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2125,8 +2125,8 @@ Interpreter.prototype.throwException = function(value, opt_message) {
  * the stack being completely unwound the thread will be terminated
  * and an appropriate error being logged.
  * @param {Interpreter.Completion} type Completion type.
- * @param {Interpreter.Value=} error Value computed, returned or thrown.
- * @param {Interpreter.String=} label Target label for break or return.
+ * @param {Interpreter.Value=} value Value computed, returned or thrown.
+ * @param {string=} label Target label for break or return.
  */
 Interpreter.prototype.unwind = function(type, value, label) {
   if (type === Interpreter.Completion.NORMAL) {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2092,8 +2092,8 @@ Interpreter.Completion = {
   BREAK: 1,
   CONTINUE: 2,
   RETURN: 3,
-  THROW: 4,
-}
+  THROW: 4
+};
 
 /**
  * Throw an exception in the interpreter that can be handled by a
@@ -2130,7 +2130,7 @@ Interpreter.prototype.throwException = function(value, opt_message) {
  */
 Interpreter.prototype.unwind = function(type, value, label) {
   if (type === Interpreter.Completion.NORMAL) {
-    throw TypeError('Should not unwind for NORMAL completions.');
+    throw TypeError('Should not unwind for NORMAL completions');
   }
 
   for (var stack = this.thread.stateStack; stack.length > 0; stack.pop()) {
@@ -2144,7 +2144,7 @@ Interpreter.prototype.unwind = function(type, value, label) {
         switch (type) {
           case Interpreter.Completion.BREAK:
           case Interpreter.Completion.CONTINUE:
-            throw Error('Unsynatctic break/continue not rejected by acorn');
+            throw Error('Unsynatctic break/continue not rejected by Acorn');
           case Interpreter.Completion.RETURN:
             state.value = value;
             return;
@@ -2152,16 +2152,14 @@ Interpreter.prototype.unwind = function(type, value, label) {
         break;
     }
     if (type === Interpreter.Completion.BREAK) {
-      if (label === undefined ?
-          (state.isLoop || state.isSwitch) :
-          (state.labels && state.labels.indexOf(label) !== -1)) {
+      if (label ? (state.labels && state.labels.indexOf(label) !== -1) :
+          (state.isLoop || state.isSwitch)) {
         stack.pop();
         return;
       }
     } else if (type === Interpreter.Completion.CONTINUE) {
-      if (label == undefined ?
-          state.isLoop : 
-          (state.labels && state.labels.indexOf(label) !== -1)) {
+      if (label ? (state.labels && state.labels.indexOf(label) !== -1) : 
+          state.isLoop) {
         return;
       }
     }
@@ -2185,7 +2183,7 @@ Interpreter.prototype.unwind = function(type, value, label) {
       console.log('Unhandled exception with value:', value);
     }
   } else {
-    throw Error('Unsynatctic break/continue/return not rejected by acorn');
+    throw Error('Unsynatctic break/continue/return not rejected by Acorn');
   }
 };
 
@@ -2894,11 +2892,8 @@ Interpreter.prototype['stepBlockStatement'] = function(stack, state, node) {
 };
 
 Interpreter.prototype['stepBreakStatement'] = function(stack, state, node) {
-  var label = undefined;
-  if (node['label']) {
-    label = node['label']['name'];
-  }
-  this.unwind(Interpreter.Completion.BREAK, undefined, label);
+  this.unwind(Interpreter.Completion.BREAK, undefined,
+              node['label'] ? node['label']['name'] : undefined);
 };
 
 Interpreter.prototype['stepCallExpression'] = function(stack, state, node) {
@@ -3084,11 +3079,8 @@ Interpreter.prototype['stepConditionalExpression'] =
 };
 
 Interpreter.prototype['stepContinueStatement'] = function(stack, state, node) {
-  var label = undefined;
-  if (node['label']) {
-    label = node['label']['name'];
-  }
-  this.unwind(Interpreter.Completion.CONTINUE, undefined, label);
+  this.unwind(Interpreter.Completion.CONTINUE, undefined,
+              node['label'] ? node['label']['name'] : undefined);
 };
 
 Interpreter.prototype['stepDebuggerStatement'] = function(stack, state, node) {
@@ -3613,7 +3605,7 @@ module.exports = Interpreter;
 ///////////////////////////////////////////////////////////////////////////////
 // AST Node
 ///////////////////////////////////////////////////////////////////////////////
-// This is mainly to assist the serializer getting access to the acorn
+// This is mainly to assist the serializer getting access to the Acorn
 // AST node constructor, but we also use it to create a fake AST nodes
 // for 'eval', and may in future use it for Closure Compiler type
 // checking.

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -689,6 +689,16 @@ tests.throwCatch = function() {
   console.assert(result === 52, 'throwCatch');
 };
 
+tests.throwCatchFalsey = function() {
+  var result;
+  try {
+    throw null;
+  } catch (e) {
+    result = 'caught ' + String(e);
+  }
+  console.assert(result === 'caught null', 'throwCatchFalsey');
+};
+
 tests.seqExpr = function() {
   console.assert((51, 52, 53) === 53, 'seqExpr');
 };

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -177,6 +177,15 @@ module.exports = [
     `,
     expected: 52 },
 
+  { name: 'throwCatchFalsey', src: `
+    try {
+      throw null;
+    } catch (e) {
+      'caught ' + String(e);
+    }
+    `,
+    expected: 'caught null' },
+
   // N.B.: This and next tests have no equivalent in the test DB.
   { name: 'throwUnhandledError', src: `
     throw Error('not caught');

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -197,6 +197,22 @@ module.exports = [
     `,
     expected: undefined },
 
+  { name: 'throwUnhandledErrorWithFinally', src: `
+    try {
+      throw Error('not caught');
+    } finally {
+    }
+    `,
+    expected: undefined },
+
+  { name: 'throwUnhandledExceptionWithFinally', src: `
+    try {
+      throw 'not caught';
+    } finally {
+    }
+    `,
+    expected: undefined },
+
   { name: 'seqExpr', src: `
     51, 52, 53;
     `,


### PR DESCRIPTION
We unify the handling of break, continue, return and throw into a single function, .unwind(), which unwinds the stack back either to the target of the break or continue, or to the enclosing CallExpression (for return), but stops if a TryStatement is found.  A completion value (as described in §8.9 of the ES5.1 spec) is stored in state.cv.

If the abrupt completion is still pending when stepTryStatement has finished evaluating its subtrees it is dealt with by re-invoking .unwind() to continue propagating it up the stack.