### PR TITLE
Lost commits, including improvments to pseudoToNative

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1574,8 +1574,8 @@ Interpreter.prototype.initNetwork = function(scope) {
     intrp.listeners[port] = server;
     server.listen(function() {
       res();
-    }, function(error) {
-      rej(intrp.nativeToPseudo(error));
+    }, function(e) {
+      rej(intrp.nativeToPseudo(e));
     });
   });
 
@@ -1783,8 +1783,9 @@ Interpreter.prototype.callAsyncFunction = function(state) {
  * object.  Can handle JSON-style values plus regexps and errors (of
  * all standard native types), and handles additional properties on
  * arrays, regexps and errors (just as for plain objects).  Ignores
- * inherited properties.  Efficiently handles sparse arrays.  Does NOT
- * handle cyclic data.
+ * prototype and inherited properties; ignores property attributes
+ * (but this may change in a future version).  Efficiently handles
+ * sparse arrays.  Does NOT handle cyclic data.
  * @param {*} nativeObj The native JS object to be converted.
  * @return {Interpreter.Value} The equivalent JS interpreter object.
  */
@@ -1831,7 +1832,7 @@ Interpreter.prototype.nativeToPseudo = function(nativeObj) {
     var key = keys[i];
     var desc = Object.getOwnPropertyDescriptor(nativeObj, key);
     desc.value = this.nativeToPseudo(desc.value);
-    // TODO(cpcallen): use this when setProperty fixed:
+    // TODO(cpcallen): use this when setProperty fixed (update docs above!):
     // this.setProperty(pseudoObj, key, Interpreter.VALUE_IN_DESCRIPTOR, desc);
     this.setProperty(pseudoObj, key, desc.value);
   }

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1789,7 +1789,6 @@ Interpreter.prototype.callAsyncFunction = function(state) {
  * @return {Interpreter.Value} The equivalent JS interpreter object.
  */
 Interpreter.prototype.nativeToPseudo = function(nativeObj) {
-  console.log('>>>', nativeObj);
   if ((typeof nativeObj !== 'object' && typeof nativeObj !== 'function') ||
       nativeObj === null) {
     return nativeObj;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1779,38 +1779,62 @@ Interpreter.prototype.callAsyncFunction = function(state) {
 };
 
 /**
- * Converts from a native JS object or value to a JS interpreter object.
- * Can handle JSON-style values.
+ * Converts from a native JS object or value to a JS interpreter
+ * object.  Can handle JSON-style values plus regexps and errors (of
+ * all standard native types), and handles additional properties on
+ * arrays, regexps and errors (just as for plain objects).  Ignores
+ * inherited properties.  Efficiently handles sparse arrays.  Does NOT
+ * handle cyclic data.
  * @param {*} nativeObj The native JS object to be converted.
  * @return {Interpreter.Value} The equivalent JS interpreter object.
  */
 Interpreter.prototype.nativeToPseudo = function(nativeObj) {
-  if (typeof nativeObj === 'boolean' ||
-      typeof nativeObj === 'number' ||
-      typeof nativeObj === 'string' ||
-      nativeObj === null || nativeObj === undefined) {
+  console.log('>>>', nativeObj);
+  if ((typeof nativeObj !== 'object' && typeof nativeObj !== 'function') ||
+      nativeObj === null) {
     return nativeObj;
   }
 
-  if (nativeObj instanceof RegExp) {
-    var pseudoRegexp = new this.RegExp;
-    pseudoRegexp.populate(nativeObj);
-    return pseudoRegexp;
+  var pseudoObj;
+  switch (Object.prototype.toString.apply(nativeObj)) {
+    case '[object Array]':
+      pseudoObj = new this.Array;
+      break;
+    case '[object RegExp]':
+      pseudoObj = new this.RegExp;
+      pseudoObj.populate(nativeObj);
+      break;
+    case '[object Error]':
+      var proto;
+      if (nativeObj instanceof EvalError) {
+        proto = this.EVAL_ERROR;
+      } else if (nativeObj instanceof RangeError) {
+        proto = this.RANGE_ERROR;
+      } else if (nativeObj instanceof ReferenceError) {
+        proto = this.REFERENCE_ERROR;
+      } else if (nativeObj instanceof SyntaxError) {
+        proto = this.SYNTAX_ERROR;
+      } else if (nativeObj instanceof TypeError) {
+        proto = this.TYPE_ERROR;
+      } else if (nativeObj instanceof URIError) {
+        proto = this.URI_ERROR;
+      } else {
+        proto = this.ERROR;
+      }
+      pseudoObj = new this.Error(proto);
+      break;
+    default:
+      pseudoObj = new this.Object;
   }
 
-  var pseudoObj;
-  if (Array.isArray(nativeObj)) {  // Array.
-    pseudoObj = new this.Array;
-    for (var i = 0; i < nativeObj.length; i++) {
-      if (i in nativeObj) {
-        this.setProperty(pseudoObj, i, this.nativeToPseudo(nativeObj[i]));
-      }
-    }
-  } else {  // Object.
-    pseudoObj = new this.Object;
-    for (var key in nativeObj) {
-      this.setProperty(pseudoObj, key, this.nativeToPseudo(nativeObj[key]));
-    }
+  var keys = Object.getOwnPropertyNames(nativeObj);
+  for (var i = 0; i < keys.length; i++) {
+    var key = keys[i];
+    var desc = Object.getOwnPropertyDescriptor(nativeObj, key);
+    desc.value = this.nativeToPseudo(desc.value);
+    // TODO(cpcallen): use this when setProperty fixed:
+    // this.setProperty(pseudoObj, key, Interpreter.VALUE_IN_DESCRIPTOR, desc);
+    this.setProperty(pseudoObj, key, desc.value);
   }
   return pseudoObj;
 };

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1815,6 +1815,17 @@ tests.RegExpPrototypeTestApplyNonRegExpThrows = function() {
 };
 
 //////////////////////////////////////////////////////////////
+// JSON
+
+test.JsonStringify = function () {
+  var obj = {string: 'foo', number: 42, true: true, false: false, null: null,
+       object: { obj: {}, arr: [] }, array: [{}, []] };
+  var str = '{"string":"foo","number":42,"true":true,"false":false,' +
+      '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}';
+  console.assert(JSON.stringify(obj) === str, 'JsonStringify');
+};
+
+//////////////////////////////////////////////////////////////
 // Other tests
 
 tests.newHack = function() {

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -975,7 +975,7 @@ exports.testThreading = function(t) {
  */
 exports.testStartStop = async function(t) {
   function snooze(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+    return new Promise(function(resolve, reject) { setTimeout(resolve, ms); });
   }
   var intrp = new Interpreter;
   var name = 'testStart';

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -1036,10 +1036,10 @@ exports.testStartStop = async function(t) {
  * @param {!T} t The test runner object.
  */
 exports.testNetworking = async function(t) {
-  //  Run a test of connectionListen() and connectionUnlisten(), and
-  //  of the server receving data using the .recieve and .end methods
-  //  on a connection object.
-  var name = 'testNetworkInbound';
+  // Run a test of connectionListen() and connectionUnlisten(), and
+  // of the server receving data using the .recieve and .end methods
+  // on a connection object.
+  var name = 'testServerInbound';
   var src = `
       var data = '', conn = {};
       conn.onReceive = function(d) {
@@ -1065,9 +1065,9 @@ exports.testNetworking = async function(t) {
   };
   await runAsyncTest(t, name, src, 'foobar', initFunc);
 
-  //  Run a test of the connectionListen(), connectionUnlisten(),
-  //  connectionWrite() and connectionClose functions.
-  name = 'testNetworkOutbound';
+  // Run a test of the connectionListen(), connectionUnlisten(),
+  // connectionWrite() and connectionClose functions.
+  name = 'testServerOutbound';
   src = `
       var conn = {};
       conn.onConnect = function() {
@@ -1099,8 +1099,8 @@ exports.testNetworking = async function(t) {
   };
   await runAsyncTest(t, name, src, 'foobar', initFunc);
 
-  //  Check to make sure that connectionListen() throws if attempting
-  //  to bind to an invalid port or rebind a port already in use.
+  // Check to make sure that connectionListen() throws if attempting
+  // to bind to an invalid port or rebind a port already in use.
   name = 'testConnectionListenThrows';
   src = `
       var ports = ['foo', {}, -1, 80.8, 9999, 65536];  // 9999 will be in use.

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1348,6 +1348,17 @@ module.exports = [
     expected: 'TypeError' },
 
   /******************************************************************/
+  // JSON
+
+  { name: 'JSON.stringify', src: `
+    JSON.stringify({
+        string: 'foo', number: 42, true: true, false: false, null: null,
+        object: { obj: {}, arr: [] }, array: [{}, []] });
+    `,
+    expected: '{"string":"foo","number":42,"true":true,"false":false,' +
+        '"null":null,"object":{"obj":{},"arr":[]},"array":[{},[]]}' },
+
+  /******************************************************************/
   // Other tests:
 
   { name: 'newHack', src: `


### PR DESCRIPTION
* Improve pseudoToNative to handle Errors.
   * Plus copy "extra" properties on Arrays and RegExps, just as for plain
Objects.

* Remove one unnecessary use of arrow function.