### PR TITLE
Exceptions refactor

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2857,6 +2857,18 @@ Interpreter.prototype.installTypes = function() {
   };
 
   /**
+   * Add a .name property to this function object.  Partially
+   * implements SetFunctionName from §9.2.11 of the ES6 spec.
+   * @param {string} name Name of function.
+   */
+  intrp.Function.prototype.setName = function(name) {
+    if (Object.getOwnPropertyDescriptor(this.properties, 'name')) {
+      throw Error('Function alreay has name??');
+    }
+    intrp.setProperty(this, 'name', name, Descriptor.c);
+  };
+
+  /**
    * The [[Call]] internal method defined by §13.2.1 of the ES5.1 spec.
    * Generic functions (neither native nor user) can't be called.
    * @param {!Interpreter} intrp The interpreter.
@@ -2936,18 +2948,6 @@ Interpreter.prototype.installTypes = function() {
 
   intrp.UserFunction.prototype = Object.create(intrp.Function.prototype);
   intrp.UserFunction.prototype.constructor = intrp.UserFunction;
-
-  /**
-   * Add a .name property to this function object.  Partially
-   * implements SetFunctionName from §9.2.11 of the ES6 spec.
-   * @param {string} name Name of function.
-   */
-  intrp.Function.prototype.setName = function(name) {
-    if (Object.getOwnPropertyDescriptor(this.properties, 'name')) {
-      throw Error('Function alreay has name??');
-    }
-    intrp.setProperty(this, 'name', name, Descriptor.c);
-  };
 
   /**
    * The [[Call]] internal method defined by §13.2.1 of the ES5.1 spec.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -308,9 +308,8 @@ Interpreter.prototype.step = function() {
     if (e instanceof Error) {
       // Uh oh.  This is a real error in the interpreter.  Rethrow.
       throw e;
-    } else if (typeof e !== 'boolean' && typeof e !== 'number' &&
-        typeof e !== 'string' && e !== undefined && e !== null &&
-        !(e instanceof this.Object)) {
+    } else if (!(e instanceof this.Object) && e !== null &&
+        (typeof e === 'object' || typeof e === 'function')) {
       throw TypeError('Unexpected exception value ' + String(e));
     }
     this.unwind_(Interpreter.Completion.THROW, e, undefined);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -551,7 +551,6 @@ Interpreter.prototype.initBuiltins_ = function() {
         // eval(Array) -> Array
         return code;
       }
-      code = String(code);
       try {
         var ast = acorn.parse(code, Interpreter.PARSE_OPTIONS);
       } catch (e) {
@@ -699,7 +698,7 @@ Interpreter.prototype.initObject_ = function() {
         throw new intrp.Error(state.scope.perms, intrp.TYPE_ERROR,
             'Object.defineProperty called on non-object');
       }
-      prop = String(prop)
+      prop = String(prop);
       if (!(descriptor instanceof intrp.Object)) {
         throw new intrp.Error(state.scope.perms, intrp.TYPE_ERROR,
             'Property description must be an object');
@@ -1526,7 +1525,7 @@ Interpreter.prototype.initError_ = function() {
   // Error constructor.
   var wrapper = function(message) {
     var newError = new intrp.Error(intrp.thread.perms());
-    if (message) {
+    if (message !== undefined) {
       intrp.setProperty(newError, 'message', String(message), Descriptor.wc);
     }
     return newError;
@@ -1540,9 +1539,10 @@ Interpreter.prototype.initError_ = function() {
     var prototype = new intrp.Error(intrp.ROOT);
     intrp.builtins_[name + '.prototype'] = prototype;
 
+    // TODO(cpcallen): Constructors can (probably) be polyfills.
     wrapper = function(message) {
       var newError = new intrp.Error(intrp.thread.perms(), prototype);
-      if (message) {
+      if (message !== undefined) {
         intrp.setProperty(newError, 'message', String(message), Descriptor.wc);
       }
       return newError;
@@ -4405,7 +4405,7 @@ stepFuncs_['ObjectExpression'] = function (stack, state, node) {
   if (property) {
     if (property['kind'] !== 'init') {
       throw new this.Error(state.scope.perms, this.SYNTAX_ERROR,
-          "Object kind: '" + property['kind'] + 
+          "Object kind: '" + property['kind'] +
           "'.  Getters and setters are not supported.");
     }
     return new Interpreter.State(property['value'], state.scope);

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1666,18 +1666,28 @@ tests.ObjectPrototypeHasOwnProperty = function() {
 // Function and Function.prototype
 
 tests.FunctionConstructor = function() {
-  var f = new Function('return 42;');
-  console.assert(f() === 42, 'FunctionConstructorNoArgs');
-  var expected = 'function() {return 42;}';
+  var f = new Function;
+  console.assert(f() === undefined, 'FunctionConstructorNoArgsExec');
+  console.assert(f.length === 0, 'FunctionConstructorNoArgsLength');
   var actual = String(f);
-  console.assert(actual === expected, 'FunctionConstructorNoArgs Actual: "'
+  var expected = 'function() {}';
+  console.assert(actual === expected, 'FunctionConstructorNoArgsSrc Actual: "'
       + actual + '" Expected: "' + expected + '"');
 
-  var f = new Function('a, b', 'c', 'return a + b * c;');
-  console.assert(f(2, 3, 10) === 32, 'FunctionConstructorArgs');
-  var expected = 'function(a, b, c) {return a + b * c;}';
-  var actual = String(f);
-  console.assert(actual === expected, 'FunctionConstructorArgs Actual: "'
+  f = new Function('return 42;');
+  console.assert(f() === 42, 'FunctionConstructorSimpleExec');
+  console.assert(f.length === 0, 'FunctionConstructorSimpleLength');
+  actual = String(f);
+  expected = 'function() {return 42;}';
+  console.assert(actual === expected, 'FunctionConstructorSimpleSrc Actual: "'
+      + actual + '" Expected: "' + expected + '"');
+
+  f = new Function('a, b', 'c', 'return a + b * c;');
+  console.assert(f(2, 3, 10) === 32, 'FunctionConstructorWithArgsExec');
+  console.assert(f.length === 3, 'FunctionConstructorWithArgsLength');
+  actual = String(f);
+  expected = 'function(a, b, c) {return a + b * c;}';
+  console.assert(actual === expected, 'FunctionConstructorWithArgsSrc Actual: "'
       + actual + '" Expected: "' + expected + '"');
 };
 

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -691,7 +691,7 @@ module.exports = [
     expected: 5 },
 
   { name: 'deleteNonexistentFromPrimitive', src: `
-    (delete false.nonexistent) && 
+    (delete false.nonexistent) &&
     (delete (42).toString);
     `,
     expected: true },
@@ -920,7 +920,7 @@ module.exports = [
     r;
     `,
     expected: 'fabc' },
-  
+
   { name: 'callEvalArgsBeforeCallability', src: `
     try {
       var invalid = undefined;
@@ -1250,10 +1250,54 @@ module.exports = [
     r;
     `,
     expected: 83 },
-    
 
   /******************************************************************/
   // Function and Function.prototype
+
+  { name: 'FunctionConstructorNoArgsExec', src: `
+    (new Function)();
+    `,
+    expected: undefined },
+
+  { name: 'FunctionConstructorNoArgsLength', src: `
+    (new Function).length;
+    `,
+    expected: 0 },
+
+  { name: 'FunctionConstructorNoArgsToString', src: `
+    String(new Function)
+    `,
+    expected: 'function() {}' },
+
+  { name: 'FunctionConstructorSimpleExec', src: `
+    (new Function('return 42;'))();
+    `,
+    expected: 42 },
+
+  { name: 'FunctionConstructorSimpleLength', src: `
+    (new Function('return 42;')).length;
+    `,
+    expected: 0 },
+
+  { name: 'FunctionConstructorSimpleToString', src: `
+    String(new Function('return 42;'))
+    `,
+    expected: 'function() {return 42;}' },
+
+  { name: 'FunctionConstructorWithArgsExec', src: `
+    (new Function('a, b', 'c', 'return a + b * c;'))(2, 3, 10);
+    `,
+    expected: 32 },
+
+  { name: 'FunctionConstructorWithArgsLength', src: `
+    (new Function('a, b', 'c', 'return a + b * c;')).length;
+    `,
+    expected: 3 },
+
+  { name: 'FunctionConstructorWithArgsToString', src: `
+    String(new Function('a, b', 'c', 'return a + b * c;'))
+    `,
+    expected: 'function(a, b, c) {return a + b * c;}' },
 
   { name: 'FunctionPrototypeHasNoPrototype', src: `
     Function.prototype.hasOwnProperty('prototype');


### PR DESCRIPTION
Make sure that when a user exception is thrown it will have the correct owner and be handled by the correct thread:

- Actually throw user exceptions.
- Handle unwinding the stack in `step()` and `run()`.
- Ensure that errors created by methods on intrp.Object (and descendants) all use a valid owner, requiring one to be passed in if necessary.
- Make sure that `.thread.perms()` is only called from old-style native functions (and a few other internal methods that will soon go away, e.g. getProperty).

Along the way:

- Abolish `throwError()` in favour of `throw new intrp.Error`
- Convert several more native functions to use `new intrp.NativeFunction`
- Various other minor fixes, `TODO`s (added), etc.