### PR TITLE
Encapsulate .properties

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3015,7 +3015,7 @@ Interpreter.prototype.installTypes = function() {
    * substantial adaptations for Code City including added perms
    * checks.
    * @param {!Interpreter.Owner} perms Who is trying to check?
-   * @return {boolean} Is the object extensible? 
+   * @return {boolean} Is the object extensible?
    */
   intrp.Object.prototype.isExtensible = function(perms) {
     if (perms === null) throw TypeError("null can't check extensibility");
@@ -3028,7 +3028,7 @@ Interpreter.prototype.installTypes = function() {
    * substantial adaptations for Code City including added perms
    * checks.
    * @param {!Interpreter.Owner} perms Who is trying to prevent extensions?
-   * @return {boolean} Is the object extensible afterwards? 
+   * @return {boolean} Is the object extensible afterwards?
    */
   intrp.Object.prototype.preventExtensions = function(perms) {
     if (perms === null) throw TypeError("null can't prevent extensibions");

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -651,7 +651,7 @@ Interpreter.prototype.initObject_ = function() {
     call: function(intrp, thread, state, thisVal, args) {
       var obj = args[0];
       throwIfNullUndefined(obj);
-      if(obj instanceof intrp.Object) {
+      if (obj instanceof intrp.Object) {
         var keys = obj.ownKeys(state.scope.perms);
       } else {  // obj is actually a primitive.
         // N.B.: ES6 definition.  ES5.1 would throw TypeError.
@@ -2287,14 +2287,14 @@ Interpreter.prototype.unwind_ = function(type, value, label) {
   if (type === Interpreter.Completion.THROW) {
     // Log exception and stack trace.
     if (value instanceof this.Error) {
-      console.log('Unhandled %s', value.toString());
+      console.log('Unhandled %s', value);
       var stackTrace = value.get('stack', this.ROOT);
       if (stackTrace) {
         console.log(stackTrace);
       }
     } else {
-      // TODO(cpcallen): log toSource(error), for clarity?
-      console.log('Unhandled exception with value:', value);
+      var native = this.pseudoToNative(value);
+      console.log('Unhandled exception with value: %o', native);
     }
   } else {
     throw Error('Unsynatctic break/continue/return not rejected by Acorn');
@@ -2418,7 +2418,7 @@ Interpreter.Thread.Status = {
  * @param {!Interpreter.Owner} perms Who is doing the iteration?
  */
 Interpreter.PropertyIterator = function(obj, perms) {
-  if(obj === undefined) {  // Deserializing
+  if (obj === undefined) {  // Deserializing
     return;
   }
   /** @private @type {?Interpreter.ObjectLike} */
@@ -3151,7 +3151,7 @@ Interpreter.prototype.installTypes = function() {
    *
    * TODO(cpcallen:perms): decide whether null user can read
    * properties.  (At the moment this is forbidden redundantly by type
-   * siganture an runtime check; one or both should be removed.)
+   * signature an runtime check; one or both should be removed.)
    * @param {!Interpreter.Owner} perms Who is trying to get it?
    * @return {!Array<string>} An array of own property keys.
    */
@@ -3954,12 +3954,12 @@ Interpreter.prototype.installTypes = function() {
   intrp.Box = function(prim) {
     /** @private @type {(undefined|null|boolean|number|string)} */
     this.primitive_ = prim;
-    if(typeof prim === 'boolean') {
+    if (typeof prim === 'boolean') {
       /** @type {!Interpreter.prototype.Object} */
       this.proto = intrp.BOOLEAN;
-    } else if(typeof prim === 'number') {
+    } else if (typeof prim === 'number') {
       this.proto = intrp.NUMBER;
-    } else if(typeof prim === 'string') {
+    } else if (typeof prim === 'string') {
       this.proto = intrp.STRING;
     } else {
       throw Error('Invalid type in Box');

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -690,34 +690,35 @@ Interpreter.prototype.initObject_ = function() {
       var obj = args[0];
       var key = args[1];
       var attr = args[2];
+      var perms = state.scope.perms;
       if (!(obj instanceof intrp.Object)) {
-        throw new intrp.Error(state.scope.perms, intrp.TYPE_ERROR,
+        throw new intrp.Error(perms, intrp.TYPE_ERROR,
             'Object.defineProperty called on non-object');
       }
       key = String(key);
       if (!(attr instanceof intrp.Object)) {
-        throw new intrp.Error(state.scope.perms, intrp.TYPE_ERROR,
+        throw new intrp.Error(perms, intrp.TYPE_ERROR,
             'Property description must be an object');
       }
       if (!obj.properties[key] && obj.preventExtensions) {
-        throw new intrp.Error(state.scope.perms, intrp.TYPE_ERROR,
+        throw new intrp.Error(perms, intrp.TYPE_ERROR,
             "Can't define property '" + key + "', object is not extensible");
       }
       // Can't just use pseudoToNative since descriptors can inherit properties.
       var desc = new Descriptor;
-      if (intrp.hasProperty(attr, 'configurable')) {
-        desc.configurable = !!attr.get('configurable', state.scope.perms);
+      if (attr.has('configurable', perms)) {
+        desc.configurable = !!attr.get('configurable', perms);
       }
-      if (intrp.hasProperty(attr, 'enumerable')) {
-        desc.enumerable = !!attr.get('enumerable', state.scope.perms);
+      if (attr.has('enumerable', perms)) {
+        desc.enumerable = !!attr.get('enumerable', perms);
       }
-      if (intrp.hasProperty(attr, 'writable')) {
-        desc.writable = !!attr.get('writable', state.scope.perms);
+      if (attr.has('writable', perms)) {
+        desc.writable = !!attr.get('writable', perms);
       }
-      if (intrp.hasProperty(attr, 'value')) {
-        desc.value = attr.get('value', state.scope.perms);
+      if (attr.has('value', perms)) {
+        desc.value = attr.get('value', perms);
       }
-      obj.defineProperty(key, desc, state.scope.perms);
+      obj.defineProperty(key, desc, perms);
       return obj;
     }
   });

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3767,16 +3767,43 @@ FunctionResult.CallAgain = new FunctionResult;
 var NativeFunctionOptions;
 
 /**
- * Class for property descriptors, with commonly-used examples.
+ * Class for property descriptors, with commonly-used examples and a
+ * function to easily create new descriptors from a prototype.
  * @constructor
  * @param {boolean=} writable Is the property writable?
  * @param {boolean=} enumerable Is the property enumerable?
  * @param {boolean=} configurable Is the property configurable?
  */
 var Descriptor = function(writable, enumerable, configurable) {
-  this.writable = writable;
-  this.enumerable = enumerable;
-  this.configurable = configurable;
+  if (writable !== undefined) this.writable = writable;
+  if (enumerable !== undefined) this.enumerable = enumerable;
+  if (configurable !== undefined) this.configurable = configurable;
+};
+
+/* Type declaration for the properties that
+ * intrp.Object.prototype.defineProperty expects to see on a
+ * descriptor.  We use "|undefined)", but what we really mean is "|not
+ * defined)" because unfortunately closure-compiler's type system has
+ * no way to represent the latter.
+ */
+/** @type {(Interpreter.Value|undefined)} */
+Descriptor.prototype.value;
+/** @type {boolean|undefined} */
+Descriptor.prototype.writable;
+/** @type {boolean|undefined} */
+Descriptor.prototype.enumerable;
+/** @type {boolean|undefined} */
+Descriptor.prototype.configurable;
+
+/**
+ * Returns a new descriptor with the same properties as this one, with
+ * the addition of a value: member with the given value.
+ * @param{Interpreter.Value} value Value for the new descriptor.
+ */
+Descriptor.prototype.withValue = function(value) {
+  var desc = Object.create(this);
+  desc.value = value;
+  return desc;
 };
 
 /** @const */ Descriptor.wec = new Descriptor(true, true, true);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2093,8 +2093,8 @@ Interpreter.prototype.getProperty = function(obj, name) {
  */
 Interpreter.prototype.getValueFromScope = function(scope, name) {
   for (var s = scope; s; s = s.outerScope) {
-    if (name in s.properties) {
-      return s.properties[name];
+    if (name in s.vars) {
+      return s.vars[name];
     }
   }
   // Typeof operator is unique: it can safely look at non-defined variables.
@@ -2116,14 +2116,14 @@ Interpreter.prototype.getValueFromScope = function(scope, name) {
  */
 Interpreter.prototype.setValueToScope = function(scope, name, value) {
   for (var s = scope; s; s = s.outerScope) {
-    if (name in s.properties) {
+    if (name in s.vars) {
       if (s.notWritable.has(name)) {
         // TODO(cpcallen:perms): we have a scope here, but scope.perms
         // is probably not the right value for owner of new error.
         throw new this.Error(this.thread.perms(), this.TYPE_ERROR,
             'Assignment to constant variable: ' + name);
       }
-      s.properties[name] = value;
+      s.vars[name] = value;
       return;
     }
   }
@@ -2141,8 +2141,8 @@ Interpreter.prototype.setValueToScope = function(scope, name, value) {
 Interpreter.prototype.addVariableToScope =
     function(scope, name, value, notWritable) {
   name = String(name);
-  if (!(name in scope.properties)) {
-    scope.properties[name] = value;
+  if (!(name in scope.vars)) {
+    scope.vars[name] = value;
   }
   if (notWritable) {
     scope.notWritable.add(name);
@@ -2339,7 +2339,7 @@ Interpreter.Scope = function(perms, outerScope) {
   /** @type {!Interpreter.Owner} */
   this.perms = perms;
   /** @const {!Object<string, Interpreter.Value>} */
-  this.properties = Object.create(null);
+  this.vars = Object.create(null);
   this.notWritable = new Set();
 };
 

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -226,6 +226,7 @@ Serializer.serialize = function(intrp) {
                  'Error',
                  'Thread',
                  'Server',
+                 'Box',
                  'PropertyIterator'];
   // Find all objects.
   var objectList = [];
@@ -383,6 +384,7 @@ Serializer.getTypesDeserialize_ = function (intrp) {
     'PseudoRegExp': intrp.RegExp,
     'PseudoError': intrp.Error,
     'Server': intrp.Server,
+    'Box': intrp.Box,
     'PropertyIterator': intrp.PropertyIterator,
     'Node': Interpreter.Node
   };

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -226,8 +226,7 @@ Serializer.serialize = function(intrp) {
                  'Error',
                  'Thread',
                  'Server',
-                 'Box',
-                 'PropertyIterator'];
+                 'Box'];
   // Find all objects.
   var objectList = [];
   Serializer.objectHunt_(intrp, objectList, Serializer.excludeTypes, exclude);
@@ -373,6 +372,7 @@ Serializer.getTypesDeserialize_ = function (intrp) {
     'Sentinel': Interpreter.Sentinel,
     'State': Interpreter.State,
     'Thread': Interpreter.Thread,
+    'PropertyIterator': Interpreter.PropertyIterator,
     'PseudoObject': intrp.Object,
     'PseudoFunction': intrp.Function,
     'PseudoUserFunction': intrp.UserFunction,
@@ -385,7 +385,6 @@ Serializer.getTypesDeserialize_ = function (intrp) {
     'PseudoError': intrp.Error,
     'Server': intrp.Server,
     'Box': intrp.Box,
-    'PropertyIterator': intrp.PropertyIterator,
     'Node': Interpreter.Node
   };
 };

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1702,7 +1702,36 @@ tests.ObjectPrototypeGetPrototypeOf = function() {
   console.assert(!o.isPrototypeOf(g),
                  'ObjectPrototypeGetPrototypeOfGrandparent');
 };
-  
+
+tests.ObjectPrototypePropertyIsEnumerable = function() {
+  try {
+    Object.prototype.propertyIsEnumerable.call(null, '');
+    console.assert(false, 'ObjectPrototypePropertyIsEnumerableNullThrows');
+  } catch (e) {
+    console.assert(e.name === 'TypeError',
+                   'ObjectPrototypePropertyIsEnumerableNullThrowsError');
+  }
+  try {
+    Object.prototype.propertyIsEnumerable.call(undefined, '');
+    console.assert(false, 'ObjectPrototypePropertyIsEnumerableUndefinedThrows');
+  } catch (e) {
+    console.assert(e.name === 'TypeError',
+                   'ObjectPrototypePropertyIsEnumerableUndefinedThrowsError');
+  }
+  var OppIE = Object.prototype.propertyIsEnumerable;
+  console.assert(OppIE.call('foo', '0'),
+                 'ObjectPrototypePropertyIsEnumerablePrimitiveTrue');
+  console.assert(!OppIE.call('foo', 'length'),
+                 'ObjectPrototypePropertyIsEnumerablePrimitiveFalse');
+  var o = {foo: 'foo'};
+  Object.defineProperty(o, 'bar', {value: 'bar', enumerable: false});
+  console.assert(o.propertyIsEnumerable('foo'),
+                 'ObjectPrototypePropertyIsEnumerableTrue');
+  console.assert(!o.propertyIsEnumerable('bar'),
+                 'ObjectPrototypePropertyIsEnumerableFalse');
+  console.assert(!o.propertyIsEnumerable('baz'),
+                 'ObjectPrototypePropertyIsEnumerableFalse');
+};
 
 //////////////////////////////////////////////////////////////
 // Function and Function.prototype

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -664,6 +664,16 @@ tests.propertyAssignment = function() {
   console.assert(o.foo == 45, 'propertyAssignment');
 };
 
+tests.propertyOnPrimitive = function() {
+  console.assert('foo'.length === 3, 'propertyOnPrimitiveGet');
+  try {
+    'foo'.bar = 42;
+    console.assert('foo'.length === 3, 'propertyOnPrimitiveSet');
+  } catch (e) {
+    console.assert(e.name === 'TypeError', 'propertyOnPrimitiveSetError');
+  }
+};
+
 tests.increment = function() {
   var postincrement = 45;
   postincrement++;

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -273,7 +273,7 @@ exports.testRoundtripSimple = function(t) {
 
 /**
  * Run a round trip of serializing the Interpreter.SCOPE_REFERENCE
- * sentinel and and an Interpreter.prototype.PropertyIterator.
+ * sentinel and and an Interpreter.PropertyIterator.
  * @param {!T} t The test runner object.
  */
 exports.testRoundtripScopeRefAndPropIter = function(t) {

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -291,7 +291,37 @@ exports.testRoundtripScopeRefAndPropIter = function(t) {
  * @param {!T} t The test runner object.
  */
 exports.testRoundtripDetails = function(t) {
-  runTest(t, 'testRoundtripDetails', `
+  runTest(t, 'testRoundtripPropertyAttributes', `
+    var obj = {};
+    for (var i = 0; i < 8; i++) {
+      var desc = {value: i,
+                  writable: !!(i & 0x1),
+                  enumerable: !!(i & 0x2),
+                  configurable: !!(i & 0x4)};
+      Object.defineProperty(obj, i, desc);
+    }
+  `, '', `
+    for (var i = 0; i < 8; i++) {
+      desc = Object.getOwnPropertyDescriptor(obj, i);
+      if (desc.value !== i ||
+          desc.writable !== !!(i & 0x1) ||
+          desc.enumerable !== !!(i & 0x2) ||
+          desc.configurable !== !!(i & 0x4)) {
+        throw Error('Roundtrip failure for property ' + i);
+      }
+    }
+    'All good';
+  `, 'All good');
+
+  runTest(t, 'testRoundtripObjectExtensibility', `
+    var ext = {};
+    var nonExt = {};
+    Object.preventExtensions(nonExt);
+  `, '', `
+    Object.isExtensible(ext) && !Object.isExtensible(nonExt);
+  `, true);
+
+  runTest(t, 'testRoundtripBuiltinPrototypes', `
       var objProto = Object.getPrototypeOf({}),
           arrProto = Object.getPrototypeOf([]),
           reProto = Object.getPrototypeOf(/foo/),

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -94,6 +94,20 @@ module.exports = [
     `,
     expected: 45 },
 
+  { name: 'getPropertyOnPrimitive', src: `
+    "foo".length;
+    `,
+    expected: 3 },
+
+  { name: 'setPropertyOnPrimitive', src: `
+    try {
+      "foo".bar = 42;
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
   { name: 'postincrement', src: `
     var x = 45;
     x++;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1265,19 +1265,51 @@ module.exports = [
     `,
     expected: 83 },
 
-  { name: 'ObjectProtoypeGetPrototypeOfSelf', src: `
+  { name: 'ObjectProtoypeIsPrototypeOfSelf', src: `
     var o = {};
     o.isPrototypeOf(o);
     `,
     expected: false },
 
-  { name: 'ObjectProtoypeGetPrototypeOfRelated', src: `
+  { name: 'ObjectProtoypeIsPrototypeOfRelated', src: `
     var g = {};
     var p = Object.create(g);
     var o = Object.create(p);
     !o.isPrototypeOf({}) &&
     g.isPrototypeOf(o) && p.isPrototypeOf(o) &&
     !o.isPrototypeOf(p) && !o.isPrototypeOf(g);
+    `,
+    expected: true },
+
+  { name: 'ObjectProtoypePropertyIsEnumerableNull', src: `
+    try {
+      Object.prototype.propertyIsEnumerable.call(null, '');
+    } catch(e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
+  { name: 'ObjectProtoypePropertyIsEnumerableUndefined', src: `
+    try {
+      Object.prototype.propertyIsEnumerable.call(undefined, '');
+    } catch(e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
+  { name: 'ObjectProtoypePropertyIsEnumerablePrimitives', src: `
+    var OppIE = Object.prototype.propertyIsEnumerable;
+    OppIE.call('foo', '0') && !OppIE.call('foo', 'length');
+    `,
+    expected: true },
+
+  { name: 'ObjectProtoypePropertyIsEnumerable', src: `
+    var o = {foo: 'foo'};
+    Object.defineProperty(o, 'bar', {value: 'bar', enumerable: false});
+    o.propertyIsEnumerable('foo') && !o.propertyIsEnumerable('bar') &&
+        !o.propertyIsEnumerable('baz');
     `,
     expected: true },
 


### PR DESCRIPTION
Encapsulate access to the .properties of interpreter object via methods on Interpreter.prototype.Object whose names and behaviour mirror those of [the JS Proxy handler API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy), except:

* All methods take an additional `perms` parameter to specify which user is attempting the operation (for permission-checking purposes, though checks not yet implemented), and
* Only the immediately useful parts of that API are implemented; notably, Object's `.__proto__` is available via `.proto` rather than a call to `.getPrototype`

Also introduce a type `Box`, representing boxed primitives, and an interface `ObjectLike` implemented by both `Box` and `Object` with a subset of the `Object` 'proxy' API, for use in (e.g.) built-in functions that can take either an object or a primitive and are specced as doing a ToObject() on primitives.  Note, however, that the behaviour of Box corresponds with how those functions would behave on actual primitives, rather than boxed primitives, where the two differ—for example, `"foo".bar = 42;` throws `TypeError` rather than performing a non-observable property set on a temporary `String` object.

Finally, rewrite most parts of the interpreter that previously used direct access to `.properties` and/or `.preventExtensions` to instead use the new Object API.  Only the Array built-in methods have not yet been converted.