### PR TITLE
Improve State and rewrite step functions

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4615,15 +4615,16 @@ stepFuncs_['CallExpression'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['CatchClause'] = function (stack, state, node) {
-  if (!state.done_) {
-    state.done_ = true;
+  if (state.step_ === 0) {
+    state.step_ = 1;
     // Create an empty scope.
     var scope = new Interpreter.Scope(state.scope.perms, state.scope);
-    // Add the argument.
-    this.addVariableToScope(scope, node['param']['name'], state.throwValue);
+    // Add the argument.  The .value actually supplied by parent TryStatement.
+    this.addVariableToScope(scope, node['param']['name'], state.value);
     // Execute catch clause.
     return new Interpreter.State(node['body'], scope);
   }
+  // state.step_ === 1:
   stack.pop();
 };
 
@@ -5209,7 +5210,7 @@ stepFuncs_['TryStatement'] = function (stack, state, node) {
       !state.doneHandler_ && node['handler']) {
     state.doneHandler_ = true;
     var nextState = new Interpreter.State(node['handler'], state.scope);
-    nextState.throwValue = state.cv.value;
+    nextState.value = state.cv.value;
     state.cv = undefined;  // This error has been handled, don't rethrow.
     return nextState;
   }

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4918,7 +4918,7 @@ stepFuncs_['FunctionExpression'] = function (stack, state, node) {
  */
 stepFuncs_['Identifier'] = function (stack, state, node) {
   stack.pop();
-  var name = node['name'];
+  var /** string */ name = node['name'];
   if (state.wantRef_) {
     stack[stack.length - 1].ref = [Interpreter.SCOPE_REFERENCE, name];
   } else {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5302,25 +5302,24 @@ stepFuncs_['UnaryExpression'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['UpdateExpression'] = function (stack, state, node) {
-  if (!state.doneLeft_) {
-    state.doneLeft_ = true;
-    // Get Reference to argument.
+  if (state.step_ === 0) {  // Get Reference to argument.
+    state.step_ = 1;
     return new Interpreter.State(node['argument'], state.scope, true);
   }
   if (!state.ref) throw TypeError('argument not an LVALUE??');
   var value = Number(this.getValue(state.scope, state.ref, state.scope.perms));
-  var newValue;
+  var prefix = Boolean(node['prefix']);
+  var /** Interpreter.Value */ rval;
   if (node['operator'] === '++') {
-    newValue = value + 1;
+    rval = (prefix ? ++value : value++);
   } else if (node['operator'] === '--') {
-    newValue = value - 1;
+    rval = (prefix ? --value : value--);
   } else {
     throw SyntaxError('Unknown update expression: ' + node['operator']);
   }
-  this.setValue(state.scope, state.ref, newValue, state.scope.perms);
+  this.setValue(state.scope, state.ref, value, state.scope.perms);
   stack.pop();
-  stack[stack.length - 1].value = (node['prefix'] ? newValue : value);
-
+  stack[stack.length - 1].value = rval;
 };
 
 /**

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2421,8 +2421,14 @@ Interpreter.State = function(node, scope, wantRef) {
 
   /** @type {Interpreter.Value} */
   this.value = undefined;
-  /** @type {!Array|undefined} */
-  this.ref = undefined;
+  /** @type {?Array} */
+  this.ref = null;
+  /** @type {?Array<string>} */
+  this.labels = null;
+  /** @type {boolean} */
+  this.isLoop = false;
+  /** @type {boolean} */
+  this.isSwitch = false;
 
   /** @private @type {number} */
   this.step_ = 0;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5109,8 +5109,8 @@ stepFuncs_['ReturnStatement'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['SequenceExpression'] = function (stack, state, node) {
-  var n = state.n_ || 0;
-  var expression = node['expressions'][n];
+  var n = state.n_;
+  var /** ?Interpreter.Node */ expression = node['expressions'][n];
   if (expression) {
     state.n_ = n + 1;
     return new Interpreter.State(expression, state.scope);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5077,8 +5077,8 @@ stepFuncs_['ObjectExpression'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['Program'] = function (stack, state, node) {
-  var n = state.n_ || 0;
-  var expression = node['body'][n];
+  var n = state.n_;
+  var /** ?Interpreter.Node */ expression = node['body'][n];
   if (expression) {
     state.n_ = n + 1;
     return new Interpreter.State(expression, state.scope);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5135,6 +5135,7 @@ stepFuncs_['SwitchStatement'] = function (stack, state, node) {
     state.test_ = 2;
     // Preserve switch value between case tests.
     state.switchValue_ = state.value;
+    state.defaultCase_ = -1;
   }
 
   while (true) {
@@ -5147,7 +5148,7 @@ stepFuncs_['SwitchStatement'] = function (stack, state, node) {
       state.index_ = index + 1;
       continue;
     }
-    if (!switchCase && !state.matched_ && state.defaultCase_) {
+    if (!switchCase && !state.matched_ && state.defaultCase_ !== -1) {
       // Ran through all cases, no match.  Jump to the default.
       state.matched_ = true;
       state.index_ = state.defaultCase_;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4942,13 +4942,13 @@ stepFuncs_['IfStatement'] = stepFuncs_['ConditionalExpression'];
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['LabeledStatement'] = function (stack, state, node) {
-  // No need to hit this node again on the way back up the stack.
-  stack.pop();
   // Note that a statement might have multiple labels.
-  var labels = state.labels || [];
+  var /** !Array<string> */ labels = state.labels || [];
   labels.push(node['label']['name']);
   var nextState = new Interpreter.State(node['body'], state.scope);
   nextState.labels = labels;
+  // No need to hit LabelStatement node again on the way back up the stack.
+  stack.pop();
   return nextState;
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4736,8 +4736,8 @@ stepFuncs_['EmptyStatement'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['EvalProgram_'] = function (stack, state, node) {
-  var n = state.n_ || 0;
-  var expression = node['body'][n];
+  var n = state.n_;
+  var /** ?Interpreter.Node */ expression = node['body'][n];
   if (expression) {
     state.n_ = n + 1;
     return new Interpreter.State(expression, state.scope);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5255,13 +5255,12 @@ stepFuncs_['TryStatement'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['UnaryExpression'] = function (stack, state, node) {
-  if (!state.done_) {
-    state.done_ = true;
+  if (state.step_ === 0) {
+    state.step_ = 1;
     // Get argument - need Reference if operator is 'delete':
     return new Interpreter.State(
         node['argument'], state.scope, node['operator'] === 'delete');
   }
-  stack.pop();
   var value = state.value;
   if (node['operator'] === '-') {
     value = -value;
@@ -5291,6 +5290,7 @@ stepFuncs_['UnaryExpression'] = function (stack, state, node) {
   } else {
     throw SyntaxError('Unknown unary operator: ' + node['operator']);
   }
+  stack.pop();
   stack[stack.length - 1].value = value;
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3417,7 +3417,7 @@ Interpreter.prototype.installTypes = function() {
    * @param {?Interpreter.prototype.Object=} proto Prototype object or null.
    */
   intrp.UserFunction = function(node, scope, src, owner, proto) {
-    if (!node) { // Deserializing
+    if (!node) {  // Deserializing
       return;
     }
     intrp.Function.call(/** @type {?} */ (this), owner, proto);
@@ -3603,7 +3603,7 @@ Interpreter.prototype.installTypes = function() {
    * @param {?Interpreter.prototype.Object=} proto Prototype object or null.
    */
   intrp.OldNativeFunction = function(impl, legalConstructor, owner, proto) {
-    if (!impl) { // Deserializing
+    if (!impl) {  // Deserializing
       return;
     }
     intrp.NativeFunction.call(/** @type {?} */ (this),
@@ -4547,14 +4547,14 @@ stepFuncs_['CallExpression'] = function (stack, state, node) {
     // Get refernce for calee, because we need to get value of 'this'.
     return new Interpreter.State(node['callee'], state.scope, true);
   }
-  if (state.step_ === 1) { // Evaluated callee, possibly got a reference.
+  if (state.step_ === 1) {  // Evaluated callee, possibly got a reference.
     // Determine value of the function.
     state.step_ = 2;
     var info = {callee: undefined,
                 this: undefined,  // Since we have no global object.
                 directEval: false,
                 arguments: []};
-    if (state.ref) { // Callee was MemberExpression or Identifier.
+    if (state.ref) {  // Callee was MemberExpression or Identifier.
       info.callee = this.getValue(state.scope, state.ref, state.scope.perms);
       if (state.ref[0] === Interpreter.SCOPE_REFERENCE) {
         // (Globally or locally) named function - maybe named 'eval'?
@@ -4563,7 +4563,7 @@ stepFuncs_['CallExpression'] = function (stack, state, node) {
         // Method call; save 'this' value.
         info.this =  state.ref[0];
       }
-    } else { // Callee already fully evaluated.
+    } else {  // Callee already fully evaluated.
       info.callee = state.value;
     }
     state.info_ = info;
@@ -4804,7 +4804,7 @@ stepFuncs_['ForInStatement'] = function (stack, state, node) {
         var iter = new Interpreter.PropertyIterator(obj, state.scope.perms);
         state.info_ = {iter: iter, key: ''};
         // FALL THROUGH
-      case 2: // Find the property name for this iteration; do node.left.
+      case 2:  // Find the property name for this iteration; do node.left.
         var key = state.info_.iter.next();
         if (key === undefined) {
           // Done; exit loop.
@@ -4859,16 +4859,16 @@ stepFuncs_['ForStatement'] = function (stack, state, node) {
           return new Interpreter.State(node['init'], state.scope);
         }
         // FALL THROUGH
-      case 1: // Eval test expression.
+      case 1:  // Eval test expression.
         state.step_ = 2;
         if (node['test']) {
           return new Interpreter.State(node['test'], state.scope);
         }
         // FALL THROUGH
-      case 2: // Eval body.
+      case 2:  // Eval body.
         state.step_ = 3;
         return new Interpreter.State(node['body'], state.scope);
-      case 3: // Eval update expression.
+      case 3:  // Eval update expression.
         state.step_ = 1;
         if (node['update']) {
           return new Interpreter.State(node['update'], state.scope);
@@ -4975,7 +4975,7 @@ stepFuncs_['LogicalExpression'] = function (stack, state, node) {
     state.step_ = 1;
     return new Interpreter.State(node['left'], state.scope);
   }
-  if (state.step_ == 1) { // Check for short-circuit; eval right.
+  if (state.step_ == 1) {  // Check for short-circuit; eval right.
     var /** string */ op = node['operator'];
     if (op !== '&&' && op !== '||') {
       throw SyntaxError("Unknown logical operator '" + op + "'");
@@ -5008,7 +5008,7 @@ stepFuncs_['MemberExpression'] = function (stack, state, node) {
       return new Interpreter.State(node['property'], state.scope);
     }
     var /** string */ key = node['property']['name'];
-  } else { // state.step_ === 2
+  } else {  // state.step_ === 2
     key = String(state.value);
   }
   stack.pop();
@@ -5129,7 +5129,7 @@ stepFuncs_['SwitchStatement'] = function (stack, state, node) {
     state.step_ = 3;
   }
   switch (state.step_) {
-    case 0: // Start by evaluating discriminant.
+    case 0:  // Start by evaluating discriminant.
       state.step_ = 1;
       return new Interpreter.State(node['discriminant'], state.scope);
     case 1:  // Got evaluated discriminant.  Save it.
@@ -5228,7 +5228,7 @@ stepFuncs_['TryStatement'] = function (stack, state, node) {
         return new Interpreter.State(handler['body'], scope);
       }
       // FALL THROUGH
-    case 2: // Done 'try' and 'catch'.  Do 'finally'?
+    case 2:  // Done 'try' and 'catch'.  Do 'finally'?
       if (node['finalizer']) {
         state.step_ = 3;
         return new Interpreter.State(node['finalizer'], state.scope);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5331,25 +5331,23 @@ stepFuncs_['UpdateExpression'] = function (stack, state, node) {
  */
 stepFuncs_['VariableDeclaration'] = function (stack, state, node) {
   var declarations = node['declarations'];
-  var n = state.n_ || 0;
-  var declarationNode = declarations[n];
-  if (state.init_ && declarationNode) {
+  var n = state.n_;
+  var decl = declarations[n];
+  if (state.step_ === 1) {
     // Note that this is setting the init value, not defining the variable.
     // Variable definition (addVariableToScope) is done when scope is populated.
-    this.setValueToScope(state.scope, declarationNode['id']['name'],
-        state.value);
-    state.init_ = false;
-    declarationNode = declarations[++n];
+    this.setValueToScope(state.scope, decl['id']['name'], state.value);
+    decl = declarations[++n];
   }
-  while (declarationNode) {
+  while (decl) {
     // Skip any declarations that are not initialized.  They have already
     // been defined as undefined in populateScope_.
-    if (declarationNode['init']) {
+    if (decl['init']) {
       state.n_ = n;
-      state.init_ = true;
-      return new Interpreter.State(declarationNode['init'], state.scope);
+      state.step_ = 1;
+      return new Interpreter.State(decl['init'], state.scope);
     }
-    declarationNode = declarations[++n];
+    decl = declarations[++n];
   }
   stack.pop();
 };

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4479,11 +4479,11 @@ stepFuncs_['BinaryExpression'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['BlockStatement'] = function (stack, state, node) {
-  var n = state.n_ || 0;
-  var expression = node['body'][n];
-  if (expression) {
+  var n = state.n_;
+  var /** ?Interpreter.Node */ statement = node['body'][n];
+  if (statement) {
     state.n_ = n + 1;
-    return new Interpreter.State(expression, state.scope);
+    return new Interpreter.State(statement, state.scope);
   }
   stack.pop();
 };

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4516,6 +4516,7 @@ stepFuncs_['BreakStatement'] = function (stack, state, node) {
 };
 
 /**
+ * ConditionalExpression AND IfStatement
  * @this {!Interpreter}
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
@@ -4636,12 +4637,11 @@ stepFuncs_['CatchClause'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['ConditionalExpression'] = function (stack, state, node) {
-  var step = state.step_ || 0;
-  if (step === 0) {
+  if (state.step_ === 0) {
     state.step_ = 1;
     return new Interpreter.State(node['test'], state.scope);
   }
-  if (step === 1) {
+  if (state.step_ === 1) {
     state.step_ = 2;
     var value = Boolean(state.value);
     if (value && node['consequent']) {
@@ -4655,6 +4655,7 @@ stepFuncs_['ConditionalExpression'] = function (stack, state, node) {
     // eval('1;if(false){2}') -> undefined
     this.value = undefined;
   }
+  // state.step_ === 2:
   stack.pop();
   if (node['type'] === 'ConditionalExpression') {
     stack[stack.length - 1].value = state.value;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3693,7 +3693,9 @@ Interpreter.prototype.installTypes = function() {
         node['type'] = 'ThrowStatement';
         var throwState = new Interpreter.State(node,
             thread.stateStack_[thread.stateStack_.length - 1].scope);
-        throwState.done_ = true;
+        // TODO(cpcallen): this shouldn't rely on internal details of
+        // the ThrowStatement step function.
+        throwState.step_ = 1;
           throwState.value = value;
         thread.stateStack_.push(throwState);
         thread.status = Interpreter.Thread.Status.READY;
@@ -5209,8 +5211,8 @@ stepFuncs_['ThisExpression'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['ThrowStatement'] = function (stack, state, node) {
-  if (!state.done_) {
-    state.done_ = true;
+  if (state.step_ === 0) {
+    state.step_ = 1;
     return new Interpreter.State(node['argument'], state.scope);
   }
   throw state.value;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4960,13 +4960,15 @@ stepFuncs_['LabeledStatement'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['Literal'] = function (stack, state, node) {
-  stack.pop();
-  var value = node['value'];
-  if (value instanceof RegExp) {
-    var pseudoRegexp = new this.RegExp(state.scope.perms);
-    pseudoRegexp.populate(value);
-    value = pseudoRegexp;
+  var /** (null|boolean|number|string|!RegExp) */ literal = node['value'];
+  var /** Interpreter.Value */ value;
+  if (literal instanceof RegExp) {
+    value = new this.RegExp(state.scope.perms);
+    value.populate(literal);
+  } else {
+    value = literal;
   }
+  stack.pop();
   stack[stack.length - 1].value = value;
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4754,10 +4754,11 @@ stepFuncs_['EvalProgram_'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['ExpressionStatement'] = function (stack, state, node) {
-  if (!state.done_) {
-    state.done_ = true;
+  if (state.step_ === 0) {
+    state.step_ = 1;
     return new Interpreter.State(node['expression'], state.scope);
   }
+  // state.step_ === 1:
   stack.pop();
   // Save this value to interpreter.value for use as a return value if
   // this code is inside an eval function.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4687,6 +4687,7 @@ stepFuncs_['DebuggerStatement'] = function (stack, state, node) {
 };
 
 /**
+ * DoWhileStatement AND WhileStatement.
  * @this {!Interpreter}
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
@@ -4694,19 +4695,23 @@ stepFuncs_['DebuggerStatement'] = function (stack, state, node) {
  * @return {!Interpreter.State|undefined}
  */
 stepFuncs_['DoWhileStatement'] = function (stack, state, node) {
-  if (node['type'] === 'DoWhileStatement' && state.test_ === undefined) {
-    // First iteration of do/while executes without checking test.
-    state.value = true;
-    state.test_ = true;
+  if (state.step_ === 0) {
+    state.step_ = 1;
+    if (node['type'] === 'DoWhileStatement') {
+      // First iteration of do/while executes without checking test.
+      state.value = true;
+      state.step_ = 2;
+    }
   }
-  if (!state.test_) {
-    state.test_ = true;
+  if (state.step_ === 1) {  // Evaluate condition.
+    state.step_ = 2;
     return new Interpreter.State(node['test'], state.scope);
   }
+  // state.step_ === 2:
   if (!state.value) {  // Done, exit loop.
     stack.pop();
   } else if (node['body']) {  // Execute the body.
-    state.test_ = false;
+    state.step_ = 1;
     state.isLoop = true;
     return new Interpreter.State(node['body'], state.scope);
   }

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -899,7 +899,38 @@ tests.forInNullUndefined = function() {
   for (f().foo in undefined) { x++; }
   console.assert(x === 0, 'forInNullUndefined');
 };
-  
+
+tests.switchDefaultFirst = function() {
+  var r;
+  switch ('not found') {
+    default: 
+      r = 'OK';
+      break;
+    case 'decoy':
+      r = 'fail';
+  };
+  console.assert(r === 'OK', 'switchDefaultFirst');
+}
+
+tests.switchDefaultOnly = function() {
+  var r;
+  switch ('not found') {
+    default: 
+      r = 'OK';
+      break;
+  };
+  console.assert(r === 'OK', 'switchDefaultOnly');
+}
+
+tests.switchEmptyToEnd = function() {
+  switch ('foo') {
+    default: 
+      console.assert(false, 'switchEmptyToEnd');
+    case 'foo':
+    case 'bar':
+  }
+};
+
 tests.thisInMethod = function() {
   var o = {
     f: function() { return this.foo; },

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -414,6 +414,36 @@ module.exports = [
     `,
     expected: 0 },
 
+  { name: 'switchDefaultFirst', src: `
+    switch ('not found') {
+      default: 
+        'OK';
+        break;
+      case 'decoy':
+        'fail';
+    };
+    `,
+    expected: 'OK' },
+
+  { name: 'switchDefaultOnly', src: `
+    switch ('not found') {
+      default: 
+        'OK';
+    };
+    `,
+    expected: 'OK' },
+
+  { name: 'switchEmptyToEnd', src: `
+    'ok';
+    switch ('foo') {
+      default: 
+        'fail';
+      case 'foo':
+      case 'bar':
+    };
+    `,
+    expected: 'ok' },
+
   { name: 'thisInMethod', src: `
     var o = {
       f: function() { return this.foo; },


### PR DESCRIPTION
The impetus was to improve improve type safety in step functions by making sure all State instance properties were declared.  All the step functions were rewritten to avoid mutating the shape of State instances, and improve typing and readability.

A performance improvement was expected, but that it turns out to be about 20% is a bonus.

Before:
```
WARMUP	fibonacci10k...
WARMUP	fibonacci10k: 3553 ms
RUN 1	fibonacci10k...
RUN 1	fibonacci10k: 3495 ms
RUN 2	fibonacci10k...
RUN 2	fibonacci10k: 3452 ms
RUN 3	fibonacci10k...
RUN 3	fibonacci10k: 3428 ms
WARMUP	ressurrectedFibonacci10k...
WARMUP	ressurrectedFibonacci10k: 3536 ms
RUN 1	ressurrectedFibonacci10k...
RUN 1	ressurrectedFibonacci10k: 3634 ms
RUN 2	ressurrectedFibonacci10k...
RUN 2	ressurrectedFibonacci10k: 3468 ms
RUN 3	ressurrectedFibonacci10k...
RUN 3	ressurrectedFibonacci10k: 3510 ms
```
After:
```
WARMUP	fibonacci10k...
WARMUP	fibonacci10k: 2787 ms
RUN 1	fibonacci10k...
RUN 1	fibonacci10k: 2755 ms
RUN 2	fibonacci10k...
RUN 2	fibonacci10k: 2856 ms
RUN 3	fibonacci10k...
RUN 3	fibonacci10k: 2740 ms
WARMUP	ressurrectedFibonacci10k...
WARMUP	ressurrectedFibonacci10k: 2824 ms
RUN 1	ressurrectedFibonacci10k...
RUN 1	ressurrectedFibonacci10k: 2816 ms
RUN 2	ressurrectedFibonacci10k...
RUN 2	ressurrectedFibonacci10k: 2859 ms
RUN 3	ressurrectedFibonacci10k...
RUN 3	ressurrectedFibonacci10k: 2839 ms
```