### PR TITLE
Rewrite most built-in Array methods as NativeFunctions

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1882,6 +1882,48 @@ Interpreter.legalArrayIndex = function(x) {
 };
 
 /**
+ * The ToInteger function from ES6 §7.1.4.  The abstract operation
+ * ToInteger converts argument to an integral numeric value.
+ * @param {Interpreter.Value} value
+ * @return {number} An integer if the value can be converted to such;
+ *     0 otherwise.
+ */
+Interpreter.toInteger = function toInteger(value) {
+  var number = Number(value);
+  if (isNaN(number)) {
+    return 0;
+  } else if (number === 0 || number === Infinity || number === -Infinity) {
+    return number;
+  }
+  return Math.trunc(number);
+};
+
+/**
+ * The ToUint32 function from ES6 §7.1.6.  The abstract operation
+ * ToUint32 converts argument to one of 2**32 integer values in the
+ * range 0 through 2**32−1, inclusive.
+ * @param {Interpreter.Value} value
+ * @return {number} A non-negative integer less than 2**32.
+ */
+Interpreter.toUint32 = function toUint32(value) {
+  return Interpreter.toInteger(value) >>> 0;
+};
+
+/**
+ * The ToLength function from ES6 §7.1.15.  Note that this does NOT
+ * enforce the actual array length limit of 2^32-1, but deals with
+ * lengths up to 2^53-1, which is correct for the polymorphic
+ * Array.prototype methods.
+ * @param {Interpreter.Value} value
+ * @return {number} A non-negative integer less than 2**53.
+ */
+Interpreter.toLength = function toLength(value) {
+  var len = Interpreter.toInteger(value);
+  if (len <= 0) return 0;
+  return Math.min(len, Number.MAX_SAFE_INTEGER);  // Handles len === Infinity.
+};
+
+/**
  * Create a new native function.  Function will be owned by root.
  * @param {string} name Name of new function.
  * @param {!Function} nativeFunc JavaScript function.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1102,7 +1102,7 @@ Interpreter.prototype.initArray_ = function() {
       if (len === 0) return -1;
       var n = (fromIndex === undefined ? 0 : Interpreter.toInteger(fromIndex));
       if (n >= len) return -1;
-      var k = (n >= 0 ? n : Math.max(len - Math.abs(n), 0));
+      var k = (n >= 0) ? n : Math.max(len - Math.abs(n), 0);
       for (; k < len; k++) {
         if (obj.has(String(k), perms) &&
             obj.get(String(k), perms) === searchElement) {
@@ -1123,9 +1123,9 @@ Interpreter.prototype.initArray_ = function() {
       var obj = intrp.toObject(thisVal, perms);
       var len = Interpreter.toLength(obj.get('length', perms));
       if (len === 0) return -1;
-      var n = (fromIndex === undefined ? len - 1 :
-          Interpreter.toInteger(fromIndex));
-      var k = (n >= 0 ? Math.min(n, len - 1) : len - Math.abs(n));
+      var n = (fromIndex === undefined) ? len - 1 :
+          Interpreter.toInteger(fromIndex);
+      var k = (n >= 0) ? Math.min(n, len - 1) : len - Math.abs(n);
       for (; k >= 0 ; k--) {
         if (obj.has(String(k), perms) &&
             obj.get(String(k), perms) === searchElement) {
@@ -1253,11 +1253,11 @@ Interpreter.prototype.initArray_ = function() {
       var obj = intrp.toObject(thisVal, perms);
       var len = Interpreter.toLength(obj.get('length', perms));
       var relativeStart = Interpreter.toInteger(start);
-      var k = (relativeStart < 0 ? Math.max(len + relativeStart, 0) :
-          Math.min(relativeStart, len));
-      var relativeEnd = (end === undefined ? len : Interpreter.toInteger(end));
-      var final = (relativeEnd < 0 ? Math.max(len + relativeEnd, 0) :
-          Math.min(relativeEnd, len));
+      var k = (relativeStart < 0) ? Math.max(len + relativeStart, 0) :
+          Math.min(relativeStart, len);
+      var relativeEnd = (end === undefined) ? len : Interpreter.toInteger(end);
+      var final = (relativeEnd < 0) ? Math.max(len + relativeEnd, 0) :
+          Math.min(relativeEnd, len);
       // TODO(cpcallen): ArraySpeciesCreate should take count as an argument.
       // var count = Math.max(final - k, 0);
       var arr = new intrp.Array(perms);
@@ -2054,8 +2054,8 @@ Interpreter.toUint32 = function toUint32(value) {
 
 /**
  * The ToLength function from ES6 §7.1.15.  Note that this does NOT
- * enforce the actual array length limit of 2^32-1, but deals with
- * lengths up to 2^53-1, which is correct for the polymorphic
+ * enforce the actual array length limit of 2**32-1, but deals with
+ * lengths up to 2**53-1, which is correct for the polymorphic
  * Array.prototype methods.
  * @param {Interpreter.Value} value
  * @return {number} A non-negative integer less than 2**53.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2025,31 +2025,6 @@ Interpreter.prototype.initNetwork_ = function() {
 };
 
 /**
- * Is a value a legal integer for an array length?
- * @param {Interpreter.Value} x Value to check.
- * @return {number} Zero, or a positive integer if the value can be
- *     converted to such.  NaN otherwise.
- */
-Interpreter.legalArrayLength = function(x) {
-  var n = x >>> 0;
-  // Array length must be between 0 and 2^32-1 (inclusive).
-  return (n === Number(x)) ? n : NaN;
-};
-
-/**
- * Is a value a legal integer for an array index?
- * @param {Interpreter.Value} x Value to check.
- * @return {number} Zero, or a positive integer if the value can be
- *     converted to such.  NaN otherwise.
- */
-Interpreter.legalArrayIndex = function(x) {
-  var n = x >>> 0;
-  // Array index cannot be 2^32-1, otherwise length would be 2^32.
-  // 0xffffffff is 2^32-1.
-  return (String(n) === String(x) && n !== 0xffffffff) ? n : NaN;
-};
-
-/**
  * The ToInteger function from ES6 §7.1.4.  The abstract operation
  * ToInteger converts argument to an integral numeric value.
  * @param {Interpreter.Value} value
@@ -2293,13 +2268,16 @@ Interpreter.prototype.arrayNativeToPseudo = function(nArray, owner) {
  * to a native array, using the algorithm from ES5.1 §15.3.4.3
  * (Function.prototype.apply).  Does NOT recursively convert the type
  * of the array's contents.
+ *
+ * TODO(ES6): Add elementTypes param to become CreateListFromArrayLike
+ * (ES6 §7.3.17).
  * @param {!Interpreter.prototype.Object} pArray The interpreter array
  *     or array-like object to be converted.
  * @param {!Interpreter.Owner} perms Who is trying convert it?
  * @return {!Array<Interpreter.Value>} The equivalent native JS array.
  */
 Interpreter.prototype.arrayPseudoToNative = function(pArray, perms) {
-  var len = Interpreter.legalArrayLength(pArray.get('length', perms)) || 0;
+  var len = Interpreter.toLength(pArray.get('length', perms));
   var nArray = [];
   for (var i = 0; i < len; i++) {
     nArray.push(pArray.get(String(i), perms));

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1041,10 +1041,13 @@ Interpreter.prototype.initArray_ = function() {
   };
 
   // Static methods on Array.
-  wrapper = function(obj) {
-    return obj instanceof intrp.Array;
-  };
-  this.createNativeFunction('Array.isArray', wrapper, false);
+  new this.NativeFunction({
+    id: 'Array.isArray', length: 1,
+    /** @type {!Interpreter.NativeCallImpl} */
+    call: function(intrp, thread, state, thisVal, args) {
+      return args[0] instanceof intrp.Array;
+    }
+  });
 
   // Instance methods on Array.
   this.createNativeFunction('Array.prototype.toString',

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1996,8 +1996,37 @@ tests.ArrayPrototypeConcat = function() {
       'Array.prototype.concat.call(object, ...)');
 };
 
+tests.ArrayPrototypeIndexOf = function() {
+  console.assert([1, 2, 3, 2, 1].indexOf(2) === 1, 'Array.prototype.indexOf');
+  console.assert([1, 2, 3, 2, 1].indexOf(4) === -1,
+      'Array.prototype.indexOf not found');
+  console.assert([1, 2, 3, 2, 1].indexOf(2, 2) === 3,
+      'Array.prototype.indexOf(..., +)');
+  console.assert([1, 2, 3, 2, 1].indexOf(1, -3) === 4,
+      'Array.prototype.indexOf(..., -)');
+
+  var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
+  console.assert(Array.prototype.indexOf.call(o, 2) === 1,
+      'Array.prototype.indexOf.call(array-like, ...)');
+};
+
 tests.ArrayPrototypeJoin = function() {
   console.assert([1, 2, 3].join('-') === '1-2-3', 'Array.prototype.join');
+};
+
+tests.ArrayPrototypeLastIndexOf = function() {
+  console.assert([1, 2, 3, 2, 1].lastIndexOf(2) === 3,
+      'Array.prototype.lastIndexOf');
+  console.assert([1, 2, 3, 2, 1].lastIndexOf(4) === -1,
+      'Array.prototype.lastIndexOf not found');
+  console.assert([1, 2, 3, 2, 1].lastIndexOf(2, 2) === 1,
+      'Array.prototype.lastIndexOf(..., +)');
+  console.assert([1, 2, 3, 2, 1].lastIndexOf(1, -3) === 0,
+      'Array.prototype.lastIndexOf(..., -)');
+
+  var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
+  console.assert(Array.prototype.lastIndexOf.call(o, 2) === 3,
+      'Array.prototype.lastIndexOf.call(array-like, ...)');
 };
 
 tests.ArrayPrototypeJoinCycleDetection = function() {

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1989,6 +1989,54 @@ tests.ArrayPrototypeJoinCycleDetection = function() {
   console.assert(true, 'Array.prototype.join cycle detection');
 };
 
+tests.ArrayPrototypePop = function() {
+  var a = ['foo', 'bar', 'baz'];
+  var r = a.pop();
+  console.assert(a.length === 2 && r === 'baz', 'Array.prototype.pop');
+
+  a = [];
+  r = a.pop();
+  console.assert(
+      a.length === 0 && r === undefined, 'Array.prototype.pop empty array');
+
+  var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
+  r = Array.prototype.pop.apply(o);
+  console.assert(
+      o.length === 2 && r === 'baz', 'Array.prototype.pop.apply(array-like)');
+
+  o = {length: 0};
+  r = Array.prototype.pop.apply(o);
+  console.assert(o.length === 0 && r === undefined,
+      'Array.prototype.pop.apply(empty array-like)');
+
+  o = {5000000000000000: 'foo',
+       5000000000000001: 'quux',
+       length: 5000000000000002};
+  r = Array.prototype.pop.apply(o);
+  console.assert(o.length === 5000000000000001 && o[5000000000000000] === 'foo',
+      'Array.prototype.pop.apply(huge array-like)');
+};
+
+tests.ArrayPrototypePush = function() {
+  var a = [];
+  console.assert(a.push('foo') === 1 && a.push('bar') === 2 &&
+      a.length === 2 && a[0] === 'foo' && a[1] === 'bar',
+      'Array.prototype.push');
+
+  var o = {length: 0};
+  console.assert(Array.prototype.push.call(o, 'foo') === 1 &&
+      Array.prototype.push.call(o, 'bar') === 2 &&
+      o.length === 2 && o[0] === 'foo' && o[1] === 'bar',
+      'Array.prototype.push.call(array-like, ...)');
+
+  var o = {length: 5000000000000000};
+  console.assert(Array.prototype.push.call(o, 'foo') === 5000000000000001 &&
+      Array.prototype.push.call(o, 'bar') === 5000000000000002 &&
+      o[5000000000000000] === 'foo' && o[5000000000000001] === 'bar' &&
+      o.length === 5000000000000002,
+      'Array.prototype.push.call(huge array-like, ...)');
+};
+
 tests.ArrayPrototypeToStringCycleDetection = function() {
   var a = [1, , 3];
   a[1] = a;

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2037,6 +2037,34 @@ tests.ArrayPrototypePush = function() {
       'Array.prototype.push.call(huge array-like, ...)');
 };
 
+tests.ArrayPrototypeReverse = function () {
+  var a = [1, 2, 3];
+  console.assert(a.reverse() === a && a.length === 3 && String(a) === '3,2,1',
+      'Array.prototype.reverse odd-length');
+
+  a = [1, 2, , 4];
+  console.assert(a.reverse() === a && a.length === 4 && String(a) === '4,,2,1',
+      'Array.prototype.reverse even-length');
+
+  a = [];
+  console.assert(a.reverse() === a && a.length === 0,
+      'Array.prototype.reverse empty');
+
+  var o = {0: 1, 1: 2, 2: 3, length: 3};
+  console.assert(Array.prototype.reverse.call(o) === o &&
+      o.length === 3 && Array.prototype.toString.apply(o) === '3,2,1',
+      'Array.prototype.reverse.call(odd-length array-like)');
+
+  o = {0: 1, 1: 2, 3: 4, length: 4};
+  console.assert(Array.prototype.reverse.call(o) === o &&
+      o.length === 4 && Array.prototype.toString.apply(o) === '4,,2,1',
+      'Array.prototype.reverse.call(even-length array-like)');
+
+  o = {length: 0};
+  console.assert(Array.prototype.reverse.call(o) === o && o.length === 0,
+      'Array.prototype.reverse.call(empty array-like)');
+};
+
 tests.ArrayPrototypeShift = function() {
   var a = ['foo', 'bar', 'baz'];
   var r = a.shift();

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1972,6 +1972,11 @@ tests.ArrayIsArrayArrayLiteral = function() {
   console.assert(Array.isArray([]), 'Array.isArray Array literal');
 };
 
+tests.ArrayIsArrayArrayLike = function() {
+  console.assert(!Array.isArray({0: 'foo', 1: 'bar', length: 2}),
+      'Array.isArray(array-like)');
+};
+
 tests.ArrayPrototypeJoin = function() {
   console.assert([1, 2, 3].join('-') === '1-2-3', 'Array.prototype.join');
 };

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2096,6 +2096,78 @@ tests.ArrayPrototypeShift = function() {
   //     'Array.prototype.shift.apply(huge array-like)');
 };
 
+tests.ArrayPrototypeSlice = function() {
+  var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+  var s = a.slice();
+  console.assert(a.length === 6 && s.length === 6 && String(s) === String(a),
+      'Array.prototype.slice()');
+
+  s = a.slice(-2);
+  console.assert(a.length === 6 && s.length === 2 && String(s) === 'quux,quuux',
+      'Array.prototype.slice(-)');
+
+  s = a.slice(1, 4);
+  console.assert(a.length === 6 && s.length === 3 && !('2' in s) &&
+      String(s) === 'bar,baz,', 'Array.prototype.slice(+, +)');
+
+  s = a.slice(1, -2);
+  console.assert(a.length === 6 && s.length === 3 && !('2' in s) &&
+      String(s) === 'bar,baz,', 'Array.prototype.slice(+, +)');
+
+  var o = {0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6};
+  s = Array.prototype.slice.call(o, 1, -2);
+  console.assert(o.length === 6 && s.length === 3 && !('2' in s) &&
+      String(s) === 'bar,baz,', 'Array.prototype.slice.call(array-like, -, +)');
+
+  o = {
+    5000000000000000: 'foo', 5000000000000001: 'bar',
+    5000000000000002: 'baz', 5000000000000004: 'quux',
+    5000000000000005: 'quuux', length: 5000000000000006
+  };
+  s = Array.prototype.slice.call(o, -5, -2);
+  console.assert(o.length === 5000000000000006 &&
+      s.length === 3 && !('2' in s) && String(s) === 'bar,baz,',
+      'Array.prototype.slice.call(huge array-like, -, -)');
+};
+
+tests.ArrayPrototypeSplice = function() {
+  var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+  var s = a.splice();
+  console.assert(a.length === 6 && String(a) === 'foo,bar,baz,,quux,quuux' &&
+      s.length === 0 && String(s) === '', 'Array.prototype.splice()');
+
+  a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+  s = a.splice(-2);
+  console.assert(a.length === 4 && String(a) === 'foo,bar,baz,' &&
+      s.length === 2 && String(s) === 'quux,quuux',
+      'Array.prototype.splice(-)');
+
+  a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+  s = a.splice(1, 3, 'bletch');
+  console.assert(a.length === 4 && String(a) === 'foo,bletch,quux,quuux' &&
+      s.length === 3 && String(s) === 'bar,baz,',
+      'Array.prototype.splice(+, +, ...)');
+
+  var o = {0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6};
+  s = Array.prototype.splice.call(o, 0, 100, 'bletch');
+  console.assert(!Array.isArray(o) && o.length === 1 &&
+      Object.keys(o).length === 2 && o[0] === 'bletch' &&
+      s.length === 6 && !('3' in s) && String(s) === 'foo,bar,baz,,quux,quuux',
+      'Array.prototype.splice.call(array-like, 0, large, ...)');
+
+  o = {
+    5000000000000000: 'foo', 5000000000000001: 'bar',
+    5000000000000002: 'baz', 5000000000000004: 'quux',
+    5000000000000005: 'quuux', length: 5000000000000006
+  };
+  s = Array.prototype.splice.call(o, -2, -999, 'bletch', 'qux');
+  console.assert(!Array.isArray(o) && o.length === 5000000000000008 &&
+      o[5000000000000004] === 'bletch' && o[5000000000000005] === 'qux' &&
+      o[5000000000000006] === 'quux' && o[5000000000000007] === 'quuux' &&
+      Array.isArray(s) && s.length === 0,
+      'Array.prototype.splice.call(huge array-like, -, -)');
+};
+
 tests.ArrayPrototypeToStringCycleDetection = function() {
   var a = [1, , 3];
   a[1] = a;

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1944,14 +1944,6 @@ tests.ArrayIsArrayArrayLiteral = function() {
   console.assert(Array.isArray([]), 'Array.isArray Array literal');
 };
 
-tests.ArrayPrototypeToStringCycleDetection = function() {
-  var a = [1, , 3];
-  a[1] = a;
-  a.toString();
-  // Didn't crash!
-  console.assert(true, 'Array.prototype.toString cycle detection');
-};
-
 tests.ArrayPrototypeJoin = function() {
   console.assert([1, 2, 3].join('-') === '1-2-3', 'Array.prototype.join');
 };
@@ -1962,6 +1954,14 @@ tests.ArrayPrototypeJoinCycleDetection = function() {
   a.join('-');
   // Didn't crash!
   console.assert(true, 'Array.prototype.join cycle detection');
+};
+
+tests.ArrayPrototypeToStringCycleDetection = function() {
+  var a = [1, , 3];
+  a[1] = a;
+  a.toString();
+  // Didn't crash!
+  console.assert(true, 'Array.prototype.toString cycle detection');
 };
 
 tests.ArrayLegalIndexLength = function() {

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1977,6 +1977,25 @@ tests.ArrayIsArrayArrayLike = function() {
       'Array.isArray(array-like)');
 };
 
+tests.ArrayPrototypeConcat = function() {
+  var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+  var c = a.concat();
+  console.assert(a.length === 6 && c.length === 6 && c !== a &&
+      String(c) === String(a), 'Array.prototype.concat()');
+
+  var o = {0: 'quux', 1: 'quuux', length: 2};
+  c = [].concat(['foo', 'bar'], 'baz', undefined, o);
+  console.assert(c.length === 5 && '3' in c && c[3] === undefined &&
+      String(c) === 'foo,bar,baz,,[object Object]',
+      'Array.prototype.concat(...)');
+  
+  o = {0: 'foo', 1: 'bar', length: 2};
+  c = Array.prototype.concat.call(o, 'baz', [, 'quux', 'quuux']);
+  console.assert(c.length === 5 &&
+      String(c) === '[object Object],baz,,quux,quuux',
+      'Array.prototype.concat.call(object, ...)');
+};
+
 tests.ArrayPrototypeJoin = function() {
   console.assert([1, 2, 3].join('-') === '1-2-3', 'Array.prototype.join');
 };

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2037,12 +2037,65 @@ tests.ArrayPrototypePush = function() {
       'Array.prototype.push.call(huge array-like, ...)');
 };
 
+tests.ArrayPrototypeShift = function() {
+  var a = ['foo', 'bar', 'baz'];
+  var r = a.shift();
+  console.assert(a.length === 2 && a[0] === 'bar' && a[1] === 'baz' &&
+      r === 'foo', 'Array.prototype.shift');
+
+  a = [];
+  r = a.shift();
+  console.assert(
+      a.length === 0 && r === undefined, 'Array.prototype.shift empty array');
+
+  var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
+  r = Array.prototype.shift.apply(o);
+  console.assert(o.length === 2 && o[0] === 'bar' && o[1] === 'baz' &&
+      r === 'foo', 'Array.prototype.shift.apply(array-like)');
+
+  o = {length: 0};
+  r = Array.prototype.shift.apply(o);
+  console.assert(o.length === 0 && r === undefined,
+      'Array.prototype.shift.apply(empty array-like)');
+
+  // SKIP until more efficient shift implementation available.
+  console.log('SKIP:\tArray.prototype.shift.apply(huge array-like)');
+  // o = {5000000000000000: 'foo',
+  //      5000000000000001: 'quux',
+  //      length: 5000000000000002};
+  // r = Array.prototype.shift.apply(o);
+  // console.assert(o.length === 5000000000000001 && o[5000000000000000] === 'quux',
+  //     'Array.prototype.shift.apply(huge array-like)');
+};
+
 tests.ArrayPrototypeToStringCycleDetection = function() {
   var a = [1, , 3];
   a[1] = a;
   a.toString();
   // Didn't crash!
   console.assert(true, 'Array.prototype.toString cycle detection');
+};
+
+tests.ArrayPrototypeUnshift = function() {
+  var a = [];
+  console.assert(a.unshift('foo') === 1 && a.unshift('bar') === 2 &&
+      a.length === 2 && a[0] === 'bar' && a[1] === 'foo',
+      'Array.prototype.unshift');
+
+  var o = {length: 0};
+  console.assert(Array.prototype.unshift.call(o, 'foo') === 1 &&
+      Array.prototype.unshift.call(o, 'bar') === 2 &&
+      o.length === 2 && o[0] === 'bar' && o[1] === 'foo',
+      'Array.prototype.unshift.call(array-like, ...)');
+
+  // SKIP until more efficient unshift implementation available.
+  console.log('SKIP:\tArray.prototype.unshift.apply(huge array-like, ...)');
+  // var o = {length: 5000000000000000};
+  // console.assert(Array.prototype.unshift.call(o, 'foo') === 5000000000000001 &&
+  //     Array.prototype.unshift.call(o, 'bar') === 5000000000000002 &&
+  //     o[5000000000000000] === 'foo' && o[5000000000000001] === 'bar' &&
+  //     o.length === 5000000000000002,
+  //     'Array.prototype.unshift.call(huge array-like, ...)');
 };
 
 tests.ArrayLegalIndexLength = function() {

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1931,6 +1931,34 @@ tests.FunctionPrototypeCall = function() {
 //////////////////////////////////////////////////////////////
 // Array and Array.prototype
 
+tests.ArrayNoArgs = function() {
+  var a = new Array;
+  console.assert(Array.isArray(a), 'new Array() returns array');
+  console.assert(a.length === 0, '(new Array().length');
+};
+
+tests.ArrayNumericArg = function() {
+  var a = new Array(42);
+  console.assert(Array.isArray(a), 'new Array(number) returns array');
+  console.assert(!(0 in a), 'new Array(number) has no first item');
+  console.assert(!(41 in a), 'new Array(number) has no last item');
+  console.assert(a.length === 42, 'new Array(number).length');
+};
+
+tests.ArrayNonNumericArg = function() {
+  var a = new Array('foo');
+  console.assert(Array.isArray(a), 'new Array(non-number) returns array');
+  console.assert(a.length === 1, 'new Array(non-number).length');
+  console.assert(a[0] ==='foo', 'new Array(non-number)[0]');
+};
+
+tests.ArrayMultipleArgs = function() {
+  var a = new Array(1, 2, 3);
+  console.assert(Array.isArray(a), 'new Array(multiple...) return array');
+  console.assert(a.length === 3, 'new Array(multiple...).ength');
+  console.assert(String(a) ==='1,2,3', 'new Array(multiple...).toString()');
+};
+
 tests.ArrayIsArrayArrayPrototype = function() {
   console.assert(
       Array.isArray(Array.prototype), 'Array.isArray Array.prototype');

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -877,62 +877,6 @@ exports.testToIntegerEtc = function(t) {
 };
 
 /**
- * Unit tests for Interpreter.legalArrayIndex and
- * Interpreter.legalArrayLength.
- * @param {!T} t The test runner object.
- */
-exports.testLegalArrayIndexLength = function(t) {
-  var intrp = new Interpreter;
-  var cases = [
-    // [value, asIndex, asLength]
-    [false, NaN, 0],
-    [true, NaN, 1],
-
-    [0, 0, 0],
-    [1, 1, 1],
-    [0xfffffffe, 0xfffffffe, 0xfffffffe],
-    [0xffffffff, NaN, 0xffffffff],
-    [0x100000000, NaN, NaN],
-    [4.5, NaN, NaN],
-    [-1, NaN, NaN],
-
-    ['0', 0, 0],
-    ['1', 1, 1],
-    ['0xfffffffe', NaN, 0xfffffffe],
-    ['0xffffffff', NaN, 0xffffffff],
-    ['0x100000000', NaN, NaN],
-    ['4294967294', 0xfffffffe, 0xfffffffe],
-    ['4294967295', NaN, 0xffffffff],
-    ['4294967296', NaN, NaN],
-    ['4.5', NaN, NaN],
-    ['-1', NaN, NaN],
-
-    ['hello', NaN, NaN],
-    [null, NaN, 0],  // wat
-    [undefined, NaN, NaN],
-    [new intrp.Array, NaN, 0],  // wat!
-    [new intrp.Object, NaN, NaN],
-  ];
-  for (var i = 0; i < cases.length; i++) {
-    var tc = cases[i];
-    var name = 'testLegalArrayIndex: ' + tc[0];
-    var r = Interpreter.legalArrayIndex(tc[0]);
-    if (Object.is(r, tc[1])) {
-      t.pass(name);
-    } else {
-      t.fail(name, util.format('got %o  want %o', r, tc[1]));
-    }
-    name = 'testLegalArrayLength: ' + tc[0];
-    r = Interpreter.legalArrayLength(tc[0]);
-    if (Object.is(r, tc[2])) {
-      t.pass(name);
-    } else {
-      t.fail(name, util.format('got %o  want %o', r, tc[2]));
-    }
-  }
-};
-
-/**
  * Unit tests for Interpreter.prototype.nativeToPseudo.
  * @param {!T} t The test runner object.
  */

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -815,6 +815,68 @@ exports.testNumberToString = function(t) {
 };
 
 /**
+ * Unit tests for Interpreter.toInteger, .toLength. and .toUint32
+ * @param {!T} t The test runner object.
+ */
+exports.testToIntegerEtc = function(t) {
+  var intrp = new Interpreter;
+  var cases = [
+    // [value, ToInteger(value), ToLength(value), ToUint32(value)]
+    [false, 0, 0, 0],
+    [true, 1, 1, 1],
+
+    [0, 0, 0, 0],
+    [-0, -0, 0, 0],
+    [1, 1, 1, 1],
+    [-1, -1, 0, 0xffffffff],
+    [0xfffffffe, 0xfffffffe, 0xfffffffe, 0xfffffffe],
+    [0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff],
+    [0x100000000, 0x100000000, 0x100000000, 0],
+    [4.5, 4, 4, 4],
+    [2**53-1, 2**53-1, 2**53-1, 0xffffffff],
+    [2**53, 2**53, 2**53-1, 0],
+    [Infinity, Infinity, 2**53-1, 0],
+    [-Infinity, -Infinity, 0, 0],
+    [NaN, 0, 0, 0],
+
+    ['0', 0, 0, 0],
+    ['-0', -0, 0, 0],
+    ['1', 1, 1, 1],
+    ['-1', -1, 0, 0xffffffff],
+    ['0xfffffffe', 0xfffffffe, 0xfffffffe, 0xfffffffe],
+    ['0xffffffff', 0xffffffff, 0xffffffff, 0xffffffff],
+    ['0x100000000', 0x100000000, 0x100000000, 0],
+    ['4294967294', 0xfffffffe, 0xfffffffe, 0xfffffffe], 
+    ['4294967295', 0xffffffff, 0xffffffff, 0xffffffff], 
+    ['4294967296',  0x100000000, 0x100000000, 0],
+    ['4.5', 4, 4, 4],
+    ['9007199254740991', 2**53-1, 2**53-1, 0xffffffff],
+    ['9007199254740992', 2**53, 2**53-1, 0],
+
+    ['hello', 0, 0, 0],
+    [null, 0, 0, 0],
+    [undefined, 0, 0, 0],
+    [new intrp.Array, 0, 0, 0],
+    [new intrp.Object, 0, 0, 0],
+  ];
+  var funcs = [Interpreter.toInteger,
+               Interpreter.toLength,
+               Interpreter.toUint32];
+  for (var i = 0; i < cases.length; i++) {
+    var tc = cases[i];
+    for (var j = 0; j < funcs.length; j++) {
+      var name =  util.format('%s(%o)', funcs[j].name, tc[0]);
+      var r = funcs[j](tc[0]);
+      if (Object.is(r, tc[j + 1])) {
+        t.pass(name);
+      } else {
+        t.fail(name, util.format('got: %o  want: %o', r, tc[j + 1]));
+      }
+    }
+  }
+};
+
+/**
  * Unit tests for Interpreter.legalArrayIndex and
  * Interpreter.legalArrayLength.
  * @param {!T} t The test runner object.

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1622,6 +1622,44 @@ module.exports = [
     `,
     expected: true },
 
+  { name: 'Array.prototype.shift', src: `
+        var a = ['foo', 'bar', 'baz'];
+        var r = a.shift();
+        a.length === 2 && a[0] === 'bar' && a[1] === 'baz' && r;
+    `,
+    expected: 'foo' },
+
+  { name: 'Array.prototype.shift empty array', src: `
+        var a = [];
+        var r = a.shift();
+        a.length === 0 && r;
+    `,
+    expected: undefined },
+
+  { name: 'Array.prototype.shift.apply(array-like)', src: `
+        var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
+        var r = Array.prototype.shift.apply(o);
+        o.length === 2 && o[0] === 'bar' && o[1] === 'baz' && r;
+    `,
+    expected: 'foo' },
+
+  { name: 'Array.prototype.shift.apply(empty array-like)', src: `
+        var o = {length: 0};
+        var r = Array.prototype.shift.apply(o);
+        o.length === 0 && r;
+    `,
+    expected: undefined },
+
+  { name: 'Array.prototype.shift.apply(huge array-like)', src: `
+        var o = {5000000000000000: 'foo',
+                 5000000000000001: 'quux',
+                 length: 5000000000000002};
+        var r = Array.prototype.shift.apply(o);
+        o.length === 5000000000000001 && o[5000000000000000] === 'quux' && r;
+    `,
+    // SKIP until more efficient shift implementation available.
+    /* expected: 'foo' */ },
+
   { name: 'Array.prototype.toString cycle detection', src: `
     var a = [1, , 3];
     a[1] = a;
@@ -1629,6 +1667,33 @@ module.exports = [
     "Didn't crash!";
     `,
     expected: "Didn't crash!" },
+
+  { name: 'Array.prototype.unshift', src: `
+        var a = [];
+        a.unshift('foo') === 1 && a.unshift('bar') === 2 &&
+            a.length === 2 && a[0] === 'bar' && a[1] === 'foo';
+    `,
+    expected: true },
+
+  { name: 'Array.prototype.unshift.call(array-like, ...)', src: `
+        var o = {length: 0};
+        Array.prototype.unshift.call(o, 'foo') === 1 &&
+            Array.prototype.unshift.call(o, 'bar') === 2 &&
+            o.length === 2 && o[0] === 'bar' && o[1] === 'foo';
+
+    `,
+    expected: true },
+
+  { name: 'Array.prototype.unshift.call(huge array-like, ...)', src: `
+        var o = {length: 5000000000000000};
+        var o = {length: 5000000000000000};
+        Array.prototype.unshift.call(o, 'foo') === 5000000000000001 &&
+            Array.prototype.push.call(o, 'bar') === 5000000000000002 &&
+            o[5000000000000000] === 'bar' && o[5000000000000001] === 'foo' &&
+            o.length === 5000000000000002
+    `,
+    // SKIP until more efficient unshift implementation available.
+    /* expected: true */ },
 
   /******************************************************************/
   // Boolean

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1567,6 +1567,32 @@ module.exports = [
     `,
     expected: '[object Object],baz,,quux,quuux' },
 
+  { name: 'Array.prototype.indexOf', src: `
+    [1, 2, 3, 2, 1].indexOf(2);
+    `,
+    expected: 1 },
+
+  { name: 'Array.prototype.indexOf not found', src: `
+    [1, 2, 3, 2, 1].indexOf(4);
+    `,
+    expected: -1 },
+
+  { name: 'Array.prototype.indexOf(..., +)', src: `
+    [1, 2, 3, 2, 1].indexOf(2, 2);
+    `,
+    expected: 3 },
+
+  { name: 'Array.prototype.indexOf(..., -)', src: `
+    [1, 2, 3, 2, 1].indexOf(1, -3);
+    `,
+    expected: 4 },
+
+  { name: 'Array.prototype.indexOf.call(array-like, ...)', src: `
+    var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
+    Array.prototype.indexOf.call(o, 2);
+    `,
+    expected: 1 },
+
   { name: 'Array.prototype.join', src: `
     [1, 2, 3].join('-');
     `,
@@ -1579,6 +1605,32 @@ module.exports = [
     "Didn't crash!";
     `,
     expected: "Didn't crash!" },
+
+  { name: 'Array.prototype.lastIndexOf', src: `
+    [1, 2, 3, 2, 1].lastIndexOf(2);
+    `,
+    expected: 3 },
+
+  { name: 'Array.prototype.lastIndexOf not found', src: `
+    [1, 2, 3, 2, 1].lastIndexOf(4);
+    `,
+    expected: -1 },
+
+  { name: 'Array.prototype.lastIndexOf(..., +)', src: `
+    [1, 2, 3, 2, 1].lastIndexOf(2, 2);
+    `,
+    expected: 1 },
+
+  { name: 'Array.prototype.lastIndexOf(..., -)', src: `
+    [1, 2, 3, 2, 1].lastIndexOf(1, -3);
+    `,
+    expected: 0 },
+
+  { name: 'Array.prototype.lastIndexOf.call(array-like, ...)', src: `
+    var o = {0: 1, 1: 2, 2: 3, 3: 2, 4: 1, length: 5};
+    Array.prototype.lastIndexOf.call(o, 2);
+    `,
+    expected: 3 },
 
   { name: 'Array.prototype.pop', src: `
         var a = ['foo', 'bar', 'baz'];

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1546,6 +1546,27 @@ module.exports = [
     `,
     expected: false },
 
+  { name: 'Array.prototype.concat()', src: `
+        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+        var c = a.concat();
+        a.length === 6 && c.length === 6 && c !== a && String(c);
+    `,
+    expected: 'foo,bar,baz,,quux,quuux' },
+
+  { name: 'Array.prototype.concat(...)', src: `
+        var o = {0: 'quux', 1: 'quuux', length: 2};
+        var c = [].concat(['foo', 'bar'], 'baz', undefined, o);
+        c.length === 5 && '3' in c && c[3] === undefined && String(c);
+    `,
+    expected: 'foo,bar,baz,,[object Object]' },
+
+  { name: 'Array.prototype.concat.call(object, ...)', src: `
+        var o = {0: 'foo', 1: 'bar', length: 2};
+        var c = Array.prototype.concat.call(o, 'baz', [, 'quux', 'quuux']);
+        c.length === 5 && String(c);
+    `,
+    expected: '[object Object],baz,,quux,quuux' },
+
   { name: 'Array.prototype.join', src: `
     [1, 2, 3].join('-');
     `,

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1559,6 +1559,69 @@ module.exports = [
     `,
     expected: "Didn't crash!" },
 
+  { name: 'Array.prototype.pop', src: `
+        var a = ['foo', 'bar', 'baz'];
+        var r = a.pop();
+        a.length === 2 && r;
+    `,
+    expected: 'baz' },
+
+  { name: 'Array.prototype.pop empty array', src: `
+        var a = [];
+        var r = a.pop();
+        a.length === 0 && r;
+    `,
+    expected: undefined },
+
+  { name: 'Array.prototype.pop.apply(array-like)', src: `
+        var o = {0: 'foo', 1: 'bar', 2: 'baz', length: 3};
+        var r = Array.prototype.pop.apply(o);
+        o.length === 2 && r;
+    `,
+    expected: 'baz' },
+
+  { name: 'Array.prototype.pop.apply(empty array-like)', src: `
+        var o = {length: 0};
+        var r = Array.prototype.pop.apply(o);
+        o.length === 0 && r;
+    `,
+    expected: undefined },
+
+  { name: 'Array.prototype.pop.apply(huge array-like)', src: `
+        var o = {5000000000000000: 'foo',
+                 5000000000000001: 'quux',
+                 length: 5000000000000002};
+        var r = Array.prototype.pop.apply(o);
+        o.length === 5000000000000001 && o[5000000000000000] === 'foo' && r;
+    `,
+    expected: 'quux' },
+
+  { name: 'Array.prototype.push', src: `
+        var a = [];
+        a.push('foo') === 1 && a.push('bar') === 2 &&
+            a.length === 2 && a[0] === 'foo' && a[1] === 'bar';
+    `,
+    expected: true },
+
+  { name: 'Array.prototype.push.call(array-like, ...)', src: `
+        var o = {length: 0};
+        Array.prototype.push.call(o, 'foo') === 1 &&
+            Array.prototype.push.call(o, 'bar') === 2 &&
+            o.length === 2 && o[0] === 'foo' && o[1] === 'bar';
+
+    `,
+    expected: true },
+
+  { name: 'Array.prototype.push.call(huge array-like, ...)', src: `
+        var o = {length: 5000000000000000};
+        var o = {length: 5000000000000000};
+        Array.prototype.push.call(o, 'foo') === 5000000000000001 &&
+            Array.prototype.push.call(o, 'bar') === 5000000000000002 &&
+            o[5000000000000000] === 'foo' && o[5000000000000001] === 'bar' &&
+            o.length === 5000000000000002
+    `,
+    expected: true },
+
   { name: 'Array.prototype.toString cycle detection', src: `
     var a = [1, , 3];
     a[1] = a;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1502,6 +1502,30 @@ module.exports = [
   /******************************************************************/
   // Array and Array.prototype
 
+  { name: 'new Array()NoArgs', src: `
+    var a = new Array;
+    Array.isArray(a) && a.length;
+    `,
+    expected: 0 },
+
+  { name: 'newArray(number)', src: `
+    var a = new Array(42);
+    Array.isArray(a) && !(0 in a) && !(41 in a) && a.length;
+    `,
+    expected: 42 },
+
+  { name: 'new Array(non-number)', src: `
+    var a = new Array('foo');
+    Array.isArray(a) && a.length === 1 && a[0];
+    `,
+    expected: 'foo' },
+
+  { name: 'new Array multiple args', src: `
+    var a = new Array(1, 2, 3);
+    Array.isArray(a) && a.length === 3 && String(a);
+    `,
+    expected: '1,2,3' },
+
   { name: 'Array.isArray Array.prototype', src: `
     Array.isArray(Array.prototype);
     `,

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1698,6 +1698,102 @@ module.exports = [
     // SKIP until more efficient shift implementation available.
     /* expected: 'foo' */ },
 
+  { name: 'Array.prototype.slice()', src: `
+        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+        var s = a.slice();
+        a.length === 6 && s.length === 6 && String(s);
+    `,
+    expected: 'foo,bar,baz,,quux,quuux' },
+
+  { name: 'Array.prototype.slice(-)', src: `
+        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+        var s = a.slice(-2);
+        a.length === 6 && s.length === 2 && String(s);
+    `,
+    expected: 'quux,quuux' },
+
+  { name: 'Array.prototype.slice(+, +)', src: `
+        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+        var s = a.slice(1, 4);
+        a.length === 6 && s.length === 3 && !('2' in s) && String(s);
+    `,
+    expected: 'bar,baz,' },
+
+  { name: 'Array.prototype.slice(+, -)', src: `
+        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+        var s = a.slice(1, -2);
+        a.length === 6 && s.length === 3 && !('2' in s) && String(s);
+    `,
+    expected: 'bar,baz,' },
+
+  { name: 'Array.prototype.slice.call(array-like, -, +)', src: `
+        var o = {
+          0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6
+        };
+        var s = Array.prototype.slice.call(o, -5, 4);
+        !Array.isArray(o) && o.length === 6 &&
+            Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
+    `,
+    expected: 'bar,baz,' },
+
+  { name: 'Array.prototype.slice.call(huge array-like, -, -)', src: `
+        var o = {
+          5000000000000000: 'foo', 5000000000000001: 'bar',
+          5000000000000002: 'baz', 5000000000000004: 'quux',
+          5000000000000005: 'quuux', length: 5000000000000006
+        };
+        var s = Array.prototype.slice.call(o, -5, -2);
+        !Array.isArray(o) && o.length === 5000000000000006 &&
+            Array.isArray(s) && s.length === 3 && !('2' in s) && String(s);
+    `,
+    expected: 'bar,baz,' },
+
+  { name: 'Array.prototype.splice()', src: `
+        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+        var s = a.splice();
+        a.length === 6 && s.length === 0 && String(a) + ':' + String(s);
+    `,
+    expected: 'foo,bar,baz,,quux,quuux:' },
+
+  { name: 'Array.prototype.splice(-)', src: `
+        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+        var s = a.splice(-2);
+        a.length === 4 && s.length === 2 && String(a) + ':' + String(s);
+    `,
+    expected: 'foo,bar,baz,:quux,quuux' },
+
+  { name: 'Array.prototype.splice(+, +, ...)', src: `
+        var a = ['foo', 'bar', 'baz', , 'quux', 'quuux'];
+        var s = a.splice(1, 3, 'bletch');
+        a.length === 4 && s.length === 3 && String(a) + ':' + String(s);
+    `,
+    expected: 'foo,bletch,quux,quuux:bar,baz,' },
+
+  { name: 'Array.prototype.splice.call(array-like, 0, large, ...)', src: `
+        var o = {
+          0: 'foo', 1: 'bar', 2: 'baz', 4: 'quux', 5: 'quuux', length: 6
+        };
+        var s = Array.prototype.splice.call(o, 0, 100, 'bletch');
+        !Array.isArray(o) && o.length === 1 && Object.keys(o).length === 2 &&
+        o[0] === 'bletch' &&
+        Array.isArray(s) && s.length === 6 && !('3' in s) && String(s);
+    `,
+    expected: 'foo,bar,baz,,quux,quuux' },
+
+  { name: 'Array.prototype.splice.call(huge array-like, -, -, many...)', src: `
+        var o = {
+          5000000000000000: 'foo', 5000000000000001: 'bar',
+          5000000000000002: 'baz', 5000000000000004: 'quux',
+          5000000000000005: 'quuux', length: 5000000000000006
+        };
+        var s = Array.prototype.splice.call(o, -2, -999, 'bletch', 'qux');
+        !Array.isArray(o) && o.length === 5000000000000008 &&
+            o[5000000000000004] === 'bletch' && o[5000000000000005] === 'qux' &&
+            o[5000000000000006] === 'quux' && o[5000000000000007] === 'quuux' &&
+            Array.isArray(s) && s.length === 0;
+    `,
+    expected: true },
+
   { name: 'Array.prototype.toString cycle detection', src: `
     var a = [1, , 3];
     a[1] = a;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1517,14 +1517,6 @@ module.exports = [
     `,
     expected: true },
 
-  { name: 'Array.prototype.toString cycle detection', src: `
-    var a = [1, , 3];
-    a[1] = a;
-    a.toString();
-    "Didn't crash!";
-    `,
-    expected: "Didn't crash!" },
-
   { name: 'Array.prototype.join', src: `
     [1, 2, 3].join('-');
     `,
@@ -1534,6 +1526,14 @@ module.exports = [
     var a = [1, , 3];
     a[1] = a;
     a.join('-');
+    "Didn't crash!";
+    `,
+    expected: "Didn't crash!" },
+
+  { name: 'Array.prototype.toString cycle detection', src: `
+    var a = [1, , 3];
+    a[1] = a;
+    a.toString();
     "Didn't crash!";
     `,
     expected: "Didn't crash!" },

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1622,6 +1622,44 @@ module.exports = [
     `,
     expected: true },
 
+  { name: 'Array.prototype.reverse odd-length', src: `
+        var a = [1, 2, 3];
+        a.reverse() === a && a.length === 3 && String(a);
+    `,
+    expected: '3,2,1' },
+
+  { name: 'Array.prototype.reverse even-length', src: `
+        var a = [1, 2, , 4];
+        a.reverse() === a && a.length === 4 && String(a);
+    `,
+    expected: '4,,2,1' },
+
+  { name: 'Array.prototype.reverse empty', src: `
+        var a = [];
+        a.reverse() === a && a.length;
+    `,
+    expected: 0 },
+
+  { name: 'Array.prototype.reverse.call(odd-length array-like)', src: `
+        var o = {0: 1, 1: 2, 2: 3, length: 3};
+        Array.prototype.reverse.call(o) === o && o.length === 3 &&
+            Array.prototype.toString.apply(o);
+    `,
+    expected: '3,2,1' },
+
+  { name: 'Array.prototype.reverse.call(even-length array-like)', src: `
+        var o = {0: 1, 1: 2, 3: 4, length: 4};
+        Array.prototype.reverse.call(o) === o && o.length === 4 &&
+            Array.prototype.toString.apply(o);
+    `,
+    expected: '4,,2,1' },
+
+  { name: 'Array.prototype.reverse.call(empty array-like)', src: `
+        var o = {length: 0};
+        Array.prototype.reverse.call(o) === o && o.length;
+    `,
+    expected: 0 },
+
   { name: 'Array.prototype.shift', src: `
         var a = ['foo', 'bar', 'baz'];
         var r = a.shift();

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1541,6 +1541,11 @@ module.exports = [
     `,
     expected: true },
 
+  { name: 'Array.isArray(array-like)', src: `
+    Array.isArray({0: 'foo', 1: 'bar', length: 2});
+    `,
+    expected: false },
+
   { name: 'Array.prototype.join', src: `
     [1, 2, 3].join('-');
     `,


### PR DESCRIPTION
Only `Array.prototype.toString` and `Array.prototype.join` still use their old implementation; they will be dealt with in the next PR.