### PR TITLE
Introduce IterableWeakMap

### DIFF
--- a/server/compile
+++ b/server/compile
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 OPTIONS='-O ADVANCED_OPTIMIZATIONS --checks-only --assume_function_wrapper'
+OPTIONS+=' --module_resolution NODE'
 EXTERNS='--externs=externs.js'
 FILES=interpreter.js
 

--- a/server/externs.js
+++ b/server/externs.js
@@ -24,7 +24,7 @@
  */
 
 /**
- * @param name
+ * @param {string} name
  * @return {*}
  */
 var require = function(name) {};
@@ -82,3 +82,103 @@ net.Server.prototype.listen;
  */
 net.Server.prototype.on;
 
+/**
+ * @constructor
+ * @template REF
+ */
+var WeakRef = function() {};
+
+/**
+ * @param {T} obj
+ * @param {!Function} callback
+ * @return {!WeakRef<T>}
+ * @template T
+ * @suppress {duplicate}
+ */
+var weak = function(obj, callback) {};
+
+/**
+ * @param {!WeakRef<T>} ref
+ * @return {T}
+ * @template T
+ */
+weak.get = function(ref) {};
+
+/**
+ * @constructor @struct
+ * @param {Iterable<!Array<KEY|VALUE>>|!Array<!Array<KEY|VALUE>>=} iterable
+ * @implements {Iterable<!Array<KEY|VALUE>>}
+ * @template KEY, VALUE
+ * @nosideeffects
+ * @suppress {duplicate}
+ */
+function IterableWeakMap(iterable) {}
+
+/** @return {void} */
+IterableWeakMap.prototype.clear = function() {};
+
+/**
+ * @param {KEY} key
+ * @return {boolean}
+ */
+IterableWeakMap.prototype.delete = function(key) {};
+
+/**
+ * @return {!IteratorIterable<!Array<KEY|VALUE>>}
+ * @nosideeffects
+ */
+IterableWeakMap.prototype.entries = function() {};
+
+/**
+ * @param {function(this:THIS, VALUE, KEY, MAP)} callback
+ * @param {THIS=} thisArg
+ * @this {MAP}
+ * @template MAP,THIS
+ */
+IterableWeakMap.prototype.forEach = function(callback, thisArg) {};
+
+/**
+ * @param {KEY} key
+ * @return {VALUE}
+ * @nosideeffects
+ */
+IterableWeakMap.prototype.get = function(key) {};
+
+/**
+ * @param {KEY} key
+ * @return {boolean}
+ * @nosideeffects
+ */
+IterableWeakMap.prototype.has = function(key) {};
+
+/**
+ * @return {!IteratorIterable<KEY>}
+ * @nosideeffects
+ */
+IterableWeakMap.prototype.keys = function() {};
+
+/**
+ * @param {KEY} key
+ * @param {VALUE} value
+ * @return {THIS}
+ * @this {THIS}
+ * @template THIS
+ */
+IterableWeakMap.prototype.set = function(key, value) {};
+
+/**
+ * @type {number}
+ * (readonly)
+ */
+IterableWeakMap.prototype.size;
+
+/**
+ * @return {!IteratorIterable<VALUE>}
+ * @nosideeffects
+ */
+IterableWeakMap.prototype.values = function() {};
+
+/**
+ * @return {!Iterator<!Array<KEY|VALUE>>}
+ */
+IterableWeakMap.prototype[Symbol.iterator] = function() {};

--- a/server/iterable_weakmap.js
+++ b/server/iterable_weakmap.js
@@ -79,14 +79,14 @@ class Cell {
 // closure-compiler supports bounded generic types
 class IterableWeakMap extends WeakMap {
   /**
-    * @param {Iterable<!Array<KEY|VALUE>>|!Array<!Array<KEY|VALUE>>=} iterable
+   * @param {Iterable<!Array<KEY|VALUE>>|!Array<!Array<KEY|VALUE>>=} iterable
    */
   constructor(iterable = undefined) {
     super();
     /** @private @const @type {!Set<!Cell>} */
     this.cells_ = new Set();
 
-    if (iterable == null || iterable === undefined) {
+    if (iterable === null || iterable === undefined) {
       return;
     }
     if (typeof this.set !== 'function') {

--- a/server/iterable_weakmap.js
+++ b/server/iterable_weakmap.js
@@ -1,0 +1,227 @@
+/**
+ * @license
+ * IterableWeakMap
+ *
+ * Copyright 2018 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview A WeakMap that's iterable.
+ * @author cpcallen@google.com (Christohper Allen)
+ */
+'use strict';
+
+const weak = require('weak');
+
+/**
+ * Function to clean up dead cells from an IterableWeakMap when a key
+ * object has been garbaged collected.
+ * @this {!IterableWeakMap} IterableWeakMap to remove GCed key from.
+ * @param {!Cell} cell Cell containing GCed key.
+ * @return {void}
+ */
+function cleanup(cell) {
+  this.cells_.delete(cell);
+}
+
+/**
+ * A weak-key, value tuple in an IterableWeakMap.
+ * @template KEY, VALUE
+ */
+class Cell {
+  /**
+   * @param {!IterableWeakMap} iwm Map this cell will belong to (for cleanup).
+   * @param {KEY} key The key for this cell.
+   * @param {VALUE} value The value for this cell.
+   */
+  constructor(iwm, key, value) {
+    /** @type {!WeakRef<KEY>} */
+    this.wk = weak(key, cleanup.bind(iwm, this));
+    /** @type {VALUE} */
+    this.value = value;
+  }
+
+  /**
+   * Return the cell's key (as a strong reference).
+   * @return {KEY}
+   */
+  getKey() {
+    return weak.get(this.wk);
+  }
+}
+
+/**
+ * A WeakMap implementing the full Map interface, including iterability.
+ * @struct
+ * @implements {Iterable<!Array<KEY|VALUE>>}
+ * @template KEY, VALUE
+ */
+// TODO(cpcallen): Make KEY a bounded to {!Object} once
+// closure-compiler supports bounded generic types
+class IterableWeakMap extends WeakMap {
+  /**
+    * @param {Iterable<!Array<KEY|VALUE>>|!Array<!Array<KEY|VALUE>>=} iterable
+   */
+  constructor(iterable = undefined) {
+    super();
+    /** @private @const @type {!Set<!Cell>} */
+    this.cells_ = new Set();
+
+    if (iterable == null || iterable === undefined) {
+      return;
+    }
+    if (typeof this.set !== 'function') {
+      throw TypeError("'" + this.set + "' returned for property 'set' " +
+          'of object ' + this + ' is not a function');
+    }
+    for (const /** ?Array<KEY|VALUE>> */ entry of iterable) {
+      if (typeof entry !== 'object' && typeof entry !== 'function' ||
+          entry === null) {
+        throw TypeError('Iterator value ' + entry + ' is not an entry object');
+      }
+      this.set(entry[0], entry[1]);
+    }
+  }
+
+  /**
+   * Remove all entries from the map.
+   * @return {void}
+   * @override
+   */
+  clear() {
+    for (const cell of this.cells_) {
+      const key = cell.getKey();
+      if (key !== undefined) this.delete(key);
+    }
+  }
+
+  /**
+   * Remove a single entry from the map.
+   * @param {KEY} key The key to be deleted.
+   * @return {boolean} Was anything deleted?
+   * @override
+   */
+  delete(key) {
+    const cell = super.get(key);
+    if (cell) {
+      this.cells_.delete(cell);
+    }
+    return super.delete(key);
+  }
+
+  /**
+   * Return a iterator over [key, value] pairs of the map.
+   * @return {!IteratorIterable<!Array<KEY|VALUE>>}
+   */
+  *entries() {
+    for (const cell of this.cells_) {
+      const key = cell.getKey();
+      if (key === undefined) {  // key was garbage collected.  Remove cell.
+        this.cells_.delete(cell);
+      } else {
+        yield [key, cell.value];
+      }
+    }
+  }
+
+  /**
+   * Execute the provided callback for each entry in the map, calling
+   * it with thisArg as its this value and arguments key, value and
+   * this map.
+   * @this {MAP}
+   * @param {function(this:THIS, VALUE, KEY, MAP)} callback
+   * @param {THIS=} thisArg
+   * @return {void}
+   * @template MAP, THIS
+   */
+  forEach(callback, thisArg = undefined) {
+    for (const [key, value] of this.entries()) {
+      callback.call(thisArg, value, key, this);
+    }
+  }
+
+  /**
+   * Return the value corresponding to a given key.
+   * @param {KEY} key The key whose corresponding value is desired.
+   * @return {VALUE} The value corresponging to key, or undefined if not found.
+   * @override
+   */
+  get(key) {
+    const cell = super.get(key);
+    return (cell === undefined) ? undefined : cell.value;
+  }
+
+  /**
+   * Return an iterator over the keys of the map.
+   * @return {!IteratorIterable<KEY>}
+   */
+  *keys() {
+    for (const cell of this.cells_) {
+      const key = cell.getKey();
+      if (key === undefined) {  // key was garbage collected.  Remove cell.
+        this.cells_.delete(cell);
+      } else {
+        yield key;
+      }
+    }
+  }
+
+  /**
+   * Add or update the value associated with key in the map.
+   * @this {THIS}
+   * @param {KEY} key The key to add or update.
+   * @param {VALUE} value The new value to associate with key.
+   * @return {THIS}
+   * @override
+   * @template THIS
+   */
+  set(key, value) {
+    if (super.has(key)) {
+      super.get(key).value = value;
+    } else {
+      const cell = new Cell(this, key, value);
+      super.set(key, cell);
+      this.cells_.add(cell);
+    }
+    return this;
+  }
+
+  /**
+   * @return {number}
+   */
+  get size() {
+    return this.cells_.size;
+  }
+
+  /**
+   * Return an iterator over the value of the map.
+   * @return {!IteratorIterable<VALUE>}
+   */
+  *values() {
+    for (const cell of this.cells_) {
+      const key = cell.getKey();
+      if (key === undefined) {  // key was garbage collected.  Remove cell.
+        this.cells_.delete(cell);
+      } else {
+        yield cell.value;
+      }
+    }
+  }
+}
+
+IterableWeakMap.prototype[Symbol.iterator] = IterableWeakMap.prototype.entries;
+
+module.exports = IterableWeakMap;

--- a/server/iterable_weakmap.js
+++ b/server/iterable_weakmap.js
@@ -65,6 +65,12 @@ class Cell {
 
 /**
  * A WeakMap implementing the full Map interface, including iterability.
+ *
+ * BUG(cpcallen): This implementation causes layered collection of
+ * chained entries.  That is, if you have N entries in the
+ * IterableWeakMap, where key_i === value_i+1, but none of the keys
+ * are referenced elsewhere, it will take N garbage collections to
+ * completely empty the map.
  * @struct
  * @implements {Iterable<!Array<KEY|VALUE>>}
  * @template KEY, VALUE

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,11 +9,30 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
       "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
     "tosource": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tosource/-/tosource-1.0.0.tgz",
       "integrity": "sha1-QtiN0RZhi88A1hBt1URvNCeQL/E=",
       "dev": true
+    },
+    "weak": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/weak/-/weak-1.0.1.tgz",
+      "integrity": "sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=",
+      "requires": {
+        "bindings": "1.3.0",
+        "nan": "2.10.0"
+      }
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "Server for the CodeCity project",
   "main": "codecity.js",
   "dependencies": {
-    "acorn": "^5.1.1"
+    "acorn": "^5.1.1",
+    "weak": "^1.0.1"
   },
   "devDependencies": {
     "tosource": "^1.0.0"

--- a/server/tests/iterable_weakmap_test.js
+++ b/server/tests/iterable_weakmap_test.js
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * IterableWeakMap Tests
+ *
+ * Copyright 2018 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Test for IterableWeakMap.
+ * @author cpcallen@google.com (Christohper Allen)
+ */
+'use strict';
+
+let IterableWeakMap = require('../iterable_weakmap');
+let util = require('util');
+
+/**
+ * Run some basic tests of IterableWeakMap.
+ * @param {!T} t The test runner object.
+ */
+exports.testIterableWeakMap = function(t) {
+  let name = 'IterableWeakMap';
+
+  let assertSame = function(got, want, desc) {
+    if (got === want) {
+      t.pass(name + ': ' + desc);
+    } else {
+      t.fail(name + ': ' + desc, util.format('got %o  want %o', got, want));
+    }
+  };
+
+  const obj1 = {};
+  const obj2 = {};
+  const iwm = new IterableWeakMap([[obj1, 42], [obj2, 69]]);
+  (() => {
+    // Sequester obj3 in an IIFE, because just doing tmp = undefined
+    // to allow the object to be garbage collected seems to be
+    // insufficient.  (Presumably V8 optimises the assignment away.)
+    const obj3 = {};
+    assertSame(iwm.set(obj3, 105), iwm, 'iwm.set(tmp, 105)');
+    assertSame(iwm.get(obj3), 105, 'iwm.get(tmp)');
+    assertSame(Array.from(iwm.values()).reduce((x, y) => x + y), 42 + 69 + 105,
+        'sum of .values()');
+    let count = 0;
+    let sum = 0;
+    iwm.forEach((v, k, m) => {
+      assertSame(m, iwm, 'Map param in iwm.forEach callback');
+      count++;
+      sum += v;
+    });
+    assertSame(count, 3, 'Iterations in iwm.forEach callback');
+    assertSame(sum, 42 + 69 + 105, 'Sum of values in iwm.forEach callback');
+  })();
+  assertSame(iwm.get(obj1), 42, 'iwm.get(obj)');
+  assertSame(iwm.has(obj1), true, 'iwm.has(obj)');
+  assertSame(iwm.has({}), false, 'iwm.has({})');
+  assertSame(iwm.size, 3, 'iwm.size');
+
+  gc();
+  assertSame(iwm.has(obj1), true, 'iwm.has(obj) (after GC)');
+  assertSame(iwm.get(obj1), 42, 'iwm.get(obj) (after GC)');
+  assertSame(iwm.size, 2, 'iwm.size (after GC)');
+  const keys = Array.from(iwm.keys());
+  assertSame(keys.length, 2, 'Array.from(iwm.keys()).length');
+  assertSame(keys[0], obj1, 'Array.from(iwm.keys())[0]');
+  assertSame(keys[1], obj2, 'Array.from(iwm.keys())[1]');
+
+  assertSame(iwm.delete({}), false, 'iwm.delete({})');
+  assertSame(iwm.delete(obj2), true, 'iwm.delete(obj)');
+  assertSame(iwm.size, 1, 'iwm.size (still)');
+  const entries = Array.from(iwm);
+  assertSame(entries.length, 1, 'Array.from(iwm).length (after delete)');
+  assertSame(entries[0][0], obj1, 'Array.from(iwm)[0][0]');
+  assertSame(entries[0][1], 42, 'Array.from(iwm)[0][1]');
+
+  iwm.clear();
+  assertSame(iwm.has(obj1), false, 'iwm.has(obj) (after clear)');
+  assertSame(iwm.get(obj1), undefined, 'iwm.get(obj) (after clear)');
+  assertSame(iwm.size, 0, 'iwm.size (after clear)');
+};
+
+/**
+ * Test for layered collection of IterableWeakMap.
+ *
+ * When a WeakMap contains a chain of object (i.e., wm.get(o1) === o2,
+ * wm.get(o2) === o3, etc.) all should simultaneously be eligible for
+ * collection if the 'head' object becomes unreachable.  This test
+ * will either pass (if that is true of IterableWeakMap) or issue a
+ * warning if it takes several GCs to entierly empty the map.
+ * @param {!T} t The test runner object.
+ */
+exports.testIterableWeakMapLayeredGC = function(t) {
+  /* N.B.: This test seems to be deterministic but very sensitive to
+   * seemingly insignificant code changes, which can (for no obvious
+   * reason, but probably due to some internal optimisations) result
+   * in the IterableWeakMap keys not being garbage collected at all.
+   *
+   * This can be difficult to debug, because e.g. adding a console.log
+   * call inside the loop that calls gc() will make the problem go
+   * away.
+   */
+  const name =  'IterableWeakMapLayeredGC';
+  const iwm = new IterableWeakMap;
+
+  // Make a chain of entries.
+  (() => {
+    let objs = [{}, {}, {}, {}, {}];
+    for (let i = 0; i < objs.length; i++) {
+      iwm.set(objs[i], objs[i + 1]);
+    }
+  })();
+    
+  const limit = 10;  // objs.length * 2
+  let count = 0;
+  for (; count < limit && iwm.size > 0; count++) {
+    gc();
+  }
+  
+  if (count >= limit) {
+    t.fail(name, 'Test failed to terminate in a reasonable time.');
+  } else if (count > 1) {
+    t.result('WARN', name, 'IterableWeakMap causes layered GC!');
+  } else {
+    t.pass(name);
+  }
+};

--- a/server/tests/run
+++ b/server/tests/run
@@ -1,5 +1,5 @@
 # Run unit tests in Node.
-node tests/run.js
+node --expose-gc tests/run.js
 
 # Delete any existing checkpoint files.
 rm tests/db/*.city


### PR DESCRIPTION
A subclass of `WeakMap` that implements the entire `Map` API—notably iteration over keys, values, or key-value pairs plus `forEach`, but also `.size` (like `.length` for Arrays) and `.clear()`.

Written in ES6 to new styleguide as it is unavoidably not ES5 compatible and I'd eventually like to package it up as a separate NPM, since there is nothing CodeCity specific about it and we are not the only ones who have use for such a thing.  (Not doing that until we have proved it in production first, though.)
