### PR TITLE
Fix serialisation of WeakMaps

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -24,6 +24,7 @@
 'use strict';
 
 var acorn = require('acorn');
+var IterableWeakMap = /** @type {?} */(require('./iterable_weakmap'));
 var net = require('net');
 
 // Create an Acorn plugin called 'alwaysStrict'.
@@ -3267,7 +3268,7 @@ Interpreter.prototype.Error.prototype.toString = function() {
  * @param {?Interpreter.prototype.Object=} proto
  */
 Interpreter.prototype.WeakMap = function(owner, proto) {
-  /** @type {!WeakMap} */
+  /** @type {!IterableWeakMap} */
   this.weakMap;
   throw Error('Inner class constructor not callable on prototype');
 };
@@ -4264,8 +4265,8 @@ Interpreter.prototype.installTypes = function() {
   intrp.WeakMap = function(owner, proto) {
     intrp.Object.call(/** @type {?} */ (this), owner,
         (proto === undefined ? intrp.WEAKMAP : proto));
-    /** @type {!WeakMap} */
-    this.weakMap = new WeakMap;
+    /** @type {!IterableWeakMap} */
+    this.weakMap = new IterableWeakMap;
   };
 
   intrp.WeakMap.prototype = Object.create(intrp.Object.prototype);

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -287,6 +287,24 @@ exports.testRoundtripScopeRefAndPropIter = function(t) {
 };
 
 /**
+ * Run a round trip of serializing WeakMaps.
+ * @param {!T} t The test runner object.
+ */
+exports.testRoundtripWeakMap = function(t) {
+  runTest(t, 'testRoundtripWeakMap', `
+      var o1 = {};
+      var wm = new WeakMap;
+      var o2 = {};
+      wm.set(o1, 105);
+      wm.set(o2, 42);
+      var empty = new WeakMap;
+  `, '', `
+      (empty instanceof WeakMap) && (wm instanceof WeakMap) &&
+          wm.get(o1) - wm.get(o2);
+  `, 105 - 42);
+};
+
+/**
  * Run more detailed tests of the state of the post-rountrip interpreter.
  * @param {!T} t The test runner object.
  */


### PR DESCRIPTION
Use an IterableWeakMap as the implementation of WeakMap, so that the serialiser can find out what is in the map.  Otherwise the serialiser would have to test every object against every WeakMap.  O(n * m) is not nice!

Also fix two issues in objectHunt_:

- Don't bother recursively hunting objects stored in properties of Date, RegExp or Set instances, because we don't encode their properties so no need to know about any objects referenced (only) from there.  (We *must* skip hunting through IterableWeakMap properties, as otherwise we get errors trying to serialize/deserialize their internal .cells_ property.)

- *Do* bother recursively hunting objects stored in Set instances (and now IterableWeakMaps too).

Finally, replace one instance of Array.from(foo).map(func) with Array.from(foo, func), which is slightly more efficient.