### PR TITLE
Per-thread completion values

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -292,7 +292,8 @@ Interpreter.prototype.step = function() {
   var state = stack[stack.length - 1];
   var node = state.node;
   try {
-    var nextState = stepFuncs_[node['type']].call(this, stack, state, node);
+    var nextState =
+        stepFuncs_[node['type']].call(this, thread, stack, state, node);
   } catch (e) {
     if (e instanceof Error) {
       // Uh oh.  This is a real error in the interpreter.  Kill thread
@@ -343,7 +344,8 @@ Interpreter.prototype.run = function() {
       var state = stack[stack.length - 1];
       var node = state.node;
       try {
-        var nextState = stepFuncs_[node['type']].call(this, stack, state, node);
+        var nextState =
+            stepFuncs_[node['type']].call(this, thread, stack, state, node);
       } catch (e) {
         if (e instanceof Error) {
           // Uh oh.  This is a real error in the interpreter.  Kill
@@ -4688,9 +4690,10 @@ Descriptor.prototype.withValue = function(value) {
  *
  * TODO(cpcallen): It should be possible to declare individual
  * functions below using this typedef (instead of listing full type
- * details for each once.
+ * details for each once
  * https://github.com/google/closure-compiler/issues/2857 is fixed.
  * @typedef {function(this: Interpreter,
+ *                    !Interpreter.Thread,
  *                    !Array<!Interpreter.State>,
  *                    !Interpreter.State,
  *                    !Interpreter.Node)
@@ -4707,12 +4710,13 @@ var stepFuncs_ = {};
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ArrayExpression'] = function (stack, state, node) {
+stepFuncs_['ArrayExpression'] = function (thread, stack, state, node) {
   var n = state.n_;
   if (!state.tmp_) {  // Create Array object
     state.tmp_ = new this.Array(state.scope.perms);
@@ -4737,12 +4741,13 @@ stepFuncs_['ArrayExpression'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['AssignmentExpression'] = function (stack, state, node) {
+stepFuncs_['AssignmentExpression'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Get Reference to left.
     state.step_ = 1;
     // Get Reference for left subexpression.
@@ -4793,12 +4798,13 @@ Interpreter.CallInfo;
 /**
  * CallExpression AND NewExpression
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['BinaryExpression'] = function (stack, state, node) {
+stepFuncs_['BinaryExpression'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Evaluate left.
     state.step_ = 1;
     return new Interpreter.State(node['left'], state.scope);
@@ -4855,12 +4861,13 @@ stepFuncs_['BinaryExpression'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['BlockStatement'] = function (stack, state, node) {
+stepFuncs_['BlockStatement'] = function (thread, stack, state, node) {
   var n = state.n_;
   var /** ?Interpreter.Node */ statement = node['body'][n];
   if (statement) {
@@ -4872,14 +4879,13 @@ stepFuncs_['BlockStatement'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['BreakStatement'] = function (stack, state, node) {
-  // TODO(cpcallen): thread should be a param, or something.
-  var thread = this.thread;
+stepFuncs_['BreakStatement'] = function (thread, stack, state, node) {
   if (!thread) throw Error('No thread in BreakStatement??');
   this.unwind_(thread, Interpreter.CompletionType.BREAK, undefined,
       node['label'] ? node['label']['name'] : undefined
@@ -4889,12 +4895,13 @@ stepFuncs_['BreakStatement'] = function (stack, state, node) {
 /**
  * ConditionalExpression AND IfStatement
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['CallExpression'] = function (stack, state, node) {
+stepFuncs_['CallExpression'] = function (thread, stack, state, node) {
   /* NOTE 1: If you edit any of the step_ values in this function, be
    * sure to also update the following functions to match!:
    *
@@ -4973,17 +4980,11 @@ stepFuncs_['CallExpression'] = function (stack, state, node) {
       throw new this.Error(state.scope.perms, this.TYPE_ERROR,
           func + ' is not a function');
     }
-    // TODO(cpcallen): this is here just to satisfy type checking of
-    // args to .call and .construct.  Perhaps have (non-null) thread
-    // arg to step functions?
-    if (this.thread === null) {
-      throw TypeError('No current thread??');
-    }
     var args = state.info_.arguments;
     var r =
         state.node['type'] === 'NewExpression' ?
-        func.construct(this, this.thread, state, args) :
-        func.call(this, this.thread, state, state.info_.this, args);
+        func.construct(this, thread, state, args) :
+        func.call(this, thread, state, state.info_.this, args);
     if (r instanceof FunctionResult) {
       if (r === FunctionResult.CallAgain) {
         state.step_ = 3;  // N.B: SEE NOTE 1 ABOVE!
@@ -5004,12 +5005,13 @@ stepFuncs_['CallExpression'] = function (stack, state, node) {
  * ConditionalExpression AND IfStatement.  The only difference is the
  * latter does not return a value to the parent state.
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ConditionalExpression'] = function (stack, state, node) {
+stepFuncs_['ConditionalExpression'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Evaluate test.
     state.step_ = 1;
     return new Interpreter.State(node['test'], state.scope);
@@ -5037,27 +5039,26 @@ stepFuncs_['ConditionalExpression'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ContinueStatement'] = function (stack, state, node) {
-  // TODO(cpcallen): thread should be a param, or something.
-  var thread = this.thread;
-  if (!thread) throw Error('No thread in ContinueStatement??');
+stepFuncs_['ContinueStatement'] = function (thread, stack, state, node) {
   this.unwind_(thread, Interpreter.CompletionType.CONTINUE, undefined,
       node['label'] ? node['label']['name'] : undefined);
 };
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['DebuggerStatement'] = function (stack, state, node) {
+stepFuncs_['DebuggerStatement'] = function (thread, stack, state, node) {
   // Do nothing.  May be overridden by developers.
   stack.pop();
 };
@@ -5066,12 +5067,13 @@ stepFuncs_['DebuggerStatement'] = function (stack, state, node) {
  * DoWhileStatement AND WhileStatement.  The only difference is the
  * former skips evaluating the test expression the first time through.
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['DoWhileStatement'] = function (stack, state, node) {
+stepFuncs_['DoWhileStatement'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Decide whether to skip first test.
     state.step_ = 1;
     if (node['type'] === 'DoWhileStatement') {
@@ -5096,23 +5098,25 @@ stepFuncs_['DoWhileStatement'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['EmptyStatement'] = function (stack, state, node) {
+stepFuncs_['EmptyStatement'] = function (thread, stack, state, node) {
   stack.pop();
 };
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['EvalProgram_'] = function (stack, state, node) {
+stepFuncs_['EvalProgram_'] = function (thread, stack, state, node) {
   var n = state.n_;
   var /** ?Interpreter.Node */ expression = node['body'][n];
   if (expression) {
@@ -5125,12 +5129,13 @@ stepFuncs_['EvalProgram_'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ExpressionStatement'] = function (stack, state, node) {
+stepFuncs_['ExpressionStatement'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Evaluate expression.
     state.step_ = 1;
     return new Interpreter.State(node['expression'], state.scope);
@@ -5155,12 +5160,13 @@ Interpreter.ForInInfo;
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ForInStatement'] = function (stack, state, node) {
+stepFuncs_['ForInStatement'] = function (thread, stack, state, node) {
   while (true) {
     switch (state.step_) {
       case 0:  // Initial set-up.
@@ -5219,12 +5225,13 @@ stepFuncs_['ForInStatement'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ForStatement'] = function (stack, state, node) {
+stepFuncs_['ForStatement'] = function (thread, stack, state, node) {
   // If we've just evaluated node.test, and result was false, terminate loop.
   if (state.step_ === 2 && !state.value) {
     stack.pop();
@@ -5259,26 +5266,28 @@ stepFuncs_['ForStatement'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['FunctionDeclaration'] = function (stack, state, node) {
+stepFuncs_['FunctionDeclaration'] = function (thread, stack, state, node) {
   // This was found and handled when the scope was populated.
   stack.pop();
 };
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['FunctionExpression'] = function (stack, state, node) {
+stepFuncs_['FunctionExpression'] = function (thread, stack, state, node) {
   stack.pop();
-  var src = this.thread.getSource();
+  var src = thread.getSource();
   if (src === undefined) {
     throw Error("No source found when evaluating function expression??");
   }
@@ -5288,12 +5297,13 @@ stepFuncs_['FunctionExpression'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['Identifier'] = function (stack, state, node) {
+stepFuncs_['Identifier'] = function (thread, stack, state, node) {
   stack.pop();
   var /** string */ name = node['name'];
   if (state.wantRef_) {
@@ -5307,12 +5317,13 @@ stepFuncs_['IfStatement'] = stepFuncs_['ConditionalExpression'];
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['LabeledStatement'] = function (stack, state, node) {
+stepFuncs_['LabeledStatement'] = function (thread, stack, state, node) {
   // Note that a statement might have multiple labels.
   var /** !Array<string> */ labels = state.labels || [];
   labels[labels.length] = node['label']['name'];
@@ -5325,12 +5336,13 @@ stepFuncs_['LabeledStatement'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['Literal'] = function (stack, state, node) {
+stepFuncs_['Literal'] = function (thread, stack, state, node) {
   var /** (null|boolean|number|string|!RegExp) */ literal = node['value'];
   var /** Interpreter.Value */ value;
   if (literal instanceof RegExp) {
@@ -5345,12 +5357,13 @@ stepFuncs_['Literal'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['LogicalExpression'] = function (stack, state, node) {
+stepFuncs_['LogicalExpression'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Eval left.
     state.step_ = 1;
     return new Interpreter.State(node['left'], state.scope);
@@ -5372,12 +5385,13 @@ stepFuncs_['LogicalExpression'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['MemberExpression'] = function (stack, state, node) {
+stepFuncs_['MemberExpression'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Evaluate LHS (object).
     state.step_ = 1;
     return new Interpreter.State(node['object'], state.scope);
@@ -5405,12 +5419,13 @@ stepFuncs_['NewExpression'] = stepFuncs_['CallExpression'];
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ObjectExpression'] = function (stack, state, node) {
+stepFuncs_['ObjectExpression'] = function (thread, stack, state, node) {
   var n = state.n_;
   if (!state.tmp_) {  // First execution.  Create object.
     state.tmp_ = new this.Object(state.scope.perms);
@@ -5442,12 +5457,13 @@ stepFuncs_['ObjectExpression'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['Program'] = function (stack, state, node) {
+stepFuncs_['Program'] = function (thread, stack, state, node) {
   var n = state.n_;
   var /** ?Interpreter.Node */ expression = node['body'][n];
   if (expression) {
@@ -5459,31 +5475,30 @@ stepFuncs_['Program'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ReturnStatement'] = function (stack, state, node) {
+stepFuncs_['ReturnStatement'] = function (thread, stack, state, node) {
   if (node['argument'] && !state.done_) {
     state.done_ = true;
     return new Interpreter.State(node['argument'], state.scope);
   }
-  // TODO(cpcallen): thread should be a param, or something.
-  var thread = this.thread;
-  if (!thread) throw Error('No thread in ReturnStatement??');
   this.unwind_(
       thread, Interpreter.CompletionType.RETURN, state.value, undefined);
 };
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['SequenceExpression'] = function (stack, state, node) {
+stepFuncs_['SequenceExpression'] = function (thread, stack, state, node) {
   var n = state.n_;
   var /** ?Interpreter.Node */ expression = node['expressions'][n];
   if (expression) {
@@ -5502,12 +5517,13 @@ Interpreter.SwitchInfo;
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['SwitchStatement'] = function (stack, state, node) {
+stepFuncs_['SwitchStatement'] = function (thread, stack, state, node) {
   // First check return value to see if case test succeeded.
   if (state.step_ === 2 && state.value === state.tmp_) {
     state.step_ = 3;
@@ -5563,24 +5579,26 @@ stepFuncs_['SwitchStatement'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ThisExpression'] = function (stack, state, node) {
+stepFuncs_['ThisExpression'] = function (thread, stack, state, node) {
   stack.pop();
   stack[stack.length - 1].value = this.getValueFromScope(state.scope, 'this');
 };
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['ThrowStatement'] = function (stack, state, node) {
+stepFuncs_['ThrowStatement'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Evaluate value to throw.
     state.step_ = 1;
     return new Interpreter.State(node['argument'], state.scope);
@@ -5590,12 +5608,13 @@ stepFuncs_['ThrowStatement'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['TryStatement'] = function (stack, state, node) {
+stepFuncs_['TryStatement'] = function (thread, stack, state, node) {
   switch (state.step_) {
     case 0:  // Evaluate 'try' block.
       state.step_ = 1;
@@ -5627,9 +5646,6 @@ stepFuncs_['TryStatement'] = function (stack, state, node) {
         // There was no catch handler, or the catch/finally threw an
         // error.  Resume unwinding the stack in search of
         // TryStatement / CallExpression / target of break or continue.
-        // TODO(cpcallen): thread should be a param, or something.
-        var thread = this.thread;
-        if (!thread) throw Error('No thread in TryStatement??');
         this.unwind_(
             thread, state.info_.type, state.info_.value, state.info_.label);
       }
@@ -5638,12 +5654,13 @@ stepFuncs_['TryStatement'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['UnaryExpression'] = function (stack, state, node) {
+stepFuncs_['UnaryExpression'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Evaluate (or get reference) to argument.
     state.step_ = 1;
     // Get argument - need Reference if operator is 'delete':
@@ -5685,12 +5702,13 @@ stepFuncs_['UnaryExpression'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['UpdateExpression'] = function (stack, state, node) {
+stepFuncs_['UpdateExpression'] = function (thread, stack, state, node) {
   if (state.step_ === 0) {  // Get Reference to argument.
     state.step_ = 1;
     return new Interpreter.State(node['argument'], state.scope, true);
@@ -5713,12 +5731,13 @@ stepFuncs_['UpdateExpression'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['VariableDeclaration'] = function (stack, state, node) {
+stepFuncs_['VariableDeclaration'] = function (thread, stack, state, node) {
   var declarations = node['declarations'];
   var n = state.n_;
   var decl = declarations[n];
@@ -5743,12 +5762,13 @@ stepFuncs_['VariableDeclaration'] = function (stack, state, node) {
 
 /**
  * @this {!Interpreter}
+ * @param {!Interpreter.Thread} thread
  * @param {!Array<!Interpreter.State>} stack
  * @param {!Interpreter.State} state
  * @param {!Interpreter.Node} node
  * @return {!Interpreter.State|undefined}
  */
-stepFuncs_['WithStatement'] = function (stack, state, node) {
+stepFuncs_['WithStatement'] = function (thread, stack, state, node) {
   throw new this.Error(state.scope.perms, this.SYNTAX_ERROR,
       'Strict mode code may not include a with statement');
 };

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2786,6 +2786,8 @@ Interpreter.Thread = function(id, state, runAt) {
   this.runAt = runAt;
   /** @type {?Interpreter.prototype.Thread} */
   this.wrapper = null;
+  /** @type {Interpreter.Value} */
+  this.value = undefined;
 };
 
 /**
@@ -5028,7 +5030,7 @@ stepFuncs_['ConditionalExpression'] = function (thread, stack, state, node) {
       return new Interpreter.State(node['alternate'], state.scope);
     }
     // eval('1;if(false){2}') -> undefined
-    this.value = undefined;
+    thread.value = undefined;
   }
   // state.step_ === 2: Consequent or alternate done.  Do return?
   stack.pop();
@@ -5124,7 +5126,7 @@ stepFuncs_['EvalProgram_'] = function (thread, stack, state, node) {
     return new Interpreter.State(expression, state.scope);
   }
   stack.pop();
-  stack[stack.length - 1].value = this.value;
+  stack[stack.length - 1].value = thread.value;
 };
 
 /**
@@ -5148,7 +5150,7 @@ stepFuncs_['ExpressionStatement'] = function (thread, stack, state, node) {
   // TODO(cpcallen): This is suspected to not be strictly correct
   // compared to how the ES5.1 spec defines completion values.  Add
   // tests to prove it one way or the other.
-  this.value = state.value;
+  thread.value = state.value;
 };
 
 /**

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -56,18 +56,13 @@ interpreter.addVariableToScope(interpreter.global, 'src');
 function runTest(t, name, src, expected) {
   try {
     interpreter.setValueToScope(interpreter.global, 'src', src);
-    // TODO(cpcallen): it shouldn't be necessary to reset
-    // interpreter.value to undefined between tests; that it is is a
-    // symptom of incorrect completion value handling by the
-    // interpreter.
-    interpreter.value = undefined;
-    interpreter.createThreadForSrc('eval(src);');
+    var thread = interpreter.createThreadForSrc('eval(src);').thread;
     interpreter.run();
   } catch (e) {
     t.crash(name, util.format('%s\n%s', src, e.stack));
     return;
   }
-  var r = interpreter.pseudoToNative(interpreter.value);
+  var r = interpreter.pseudoToNative(thread.value);
   if (Object.is(r, expected)) {
     t.pass(name);
   } else {
@@ -107,7 +102,7 @@ function runComplexTest(t, name, src, expected, initFunc, asyncFunc) {
   }
 
   try {
-    intrp.createThreadForSrc(src);
+    var thread = intrp.createThreadForSrc(src).thread;
     while (intrp.run()) {
       if (asyncFunc) {
         asyncFunc(intrp);
@@ -117,7 +112,7 @@ function runComplexTest(t, name, src, expected, initFunc, asyncFunc) {
     t.crash(name, util.format('%s\n%s', src, e.stack));
     return;
   }
-  var r = intrp.pseudoToNative(intrp.value);
+  var r = intrp.pseudoToNative(thread.value);
   if (Object.is(r, expected)) {
     t.pass(name);
   } else {

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -84,7 +84,7 @@ function runTest(t, name, src1, src2, src3, expected, steps, noBuiltins) {
       intrp.run();
     }
     if (src1) {
-      intrp.createThreadForSrc(src1);
+      var thread = intrp.createThreadForSrc(src1).thread;
       intrp.run();
     }
   } catch (e) {
@@ -94,7 +94,7 @@ function runTest(t, name, src1, src2, src3, expected, steps, noBuiltins) {
 
   try {
     if (src2) {
-      intrp.createThreadForSrc(src2);
+      thread = intrp.createThreadForSrc(src2).thread;
     }
     var trips = 0;
     if (steps === undefined) {
@@ -120,7 +120,7 @@ function runTest(t, name, src1, src2, src3, expected, steps, noBuiltins) {
   try {
     intrp.run();
     if (src3) {
-      intrp.createThreadForSrc(src3);
+      thread = intrp.createThreadForSrc(src3).thread;
       intrp.run();
     }
   } catch (e) {
@@ -128,7 +128,7 @@ function runTest(t, name, src1, src2, src3, expected, steps, noBuiltins) {
     return;
   }
 
-  var r = intrp.pseudoToNative(intrp.value);
+  var r = intrp.pseudoToNative(thread.value);
   if (Object.is(r, expected)) {
     t.pass(name);
   } else {


### PR DESCRIPTION
Store completion values (i.e., thing printed by the JS console after you type code and press enter, or returned by `eval`) on the thread, rather than on the interpreter.

This is mainly so tests can have multiple threads running and still be sure of getting the correct thread's completion value to test at the end.