### PR TITLE
Array join rewrite

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1406,18 +1406,26 @@ Interpreter.prototype.initArray_ = function() {
   });
 
   wrapper = function(separator) {
-    var cycles = intrp.toStringCycles_;
-    cycles[cycles.length] = this;
+    var isArray = (this instanceof intrp.Array);
+    if (isArray) {
+      var cycles = intrp.toStringCycles_;
+      if (cycles.indexOf(this) !== -1) {
+        return '';
+      }
+      cycles[cycles.length] = this;
+    }
     try {
       var text = [];
       for (var i = 0; i < this.properties.length; i++) {
         var value = this.properties[i];
-        if (value !== null && value !== undefined) {
+        if (value === null || value === undefined) {
+          text[i] = '';
+        } else {
           text[i] = String(value);
         }
       }
     } finally {
-      cycles.pop();
+      if (isArray) cycles.pop();
     }
     return text.join(separator);
   };

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2006,6 +2006,15 @@ Interpreter.prototype.initThread_ = function() {
  * @private
  */
 Interpreter.prototype.initPerms_ = function() {
+  // Create object, never available to userland, to be used to
+  // rpresent the permissions of "a generic user" when such a thing is
+  // needed (e.g., for internal toString implementations, which have
+  // no information about caller perms but need to access properties
+  // on the object - something which can't be done with the null
+  // permissions).
+  var anybody = new this.Object(null, this.OBJECT);
+  this.ANYBODY = /** @type {!Interpreter.Owner} */ (anybody);
+
   new this.NativeFunction({
     id: 'perms', length: 0,
     /** @type {!Interpreter.NativeCallImpl} */

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2130,7 +2130,7 @@ Interpreter.toInteger = function toInteger(value) {
   var number = Number(value);
   if (isNaN(number)) {
     return 0;
-  } else if (number === 0 || number === Infinity || number === -Infinity) {
+  } else if (number === 0 || !isFinite(number)) {
     return number;
   }
   return Math.trunc(number);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -69,7 +69,7 @@ var Interpreter = function() {
   // Create builtins and (minimally) initialize global scope:
   this.initBuiltins_();
 
-  /**  @private @const {!Array<!Interpreter.Thread>} */
+  /** @private @const {!Array<!Interpreter.Thread>} */
   this.threads = [];
   /** @private @type {?Interpreter.Thread} */
   this.thread = null;
@@ -1050,7 +1050,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.concat', length: 1,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var perms = state.scope.perms;
       var obj = intrp.toObject(thisVal, perms);
       var arr = new intrp.Array(perms);
@@ -1095,7 +1095,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.indexOf', length: 1,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var searchElement = args[0];
       var fromIndex = args[1];
       var perms = state.scope.perms;
@@ -1118,7 +1118,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.lastIndexOf', length: 1,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var searchElement = args[0];
       var fromIndex = args[1];
       var perms = state.scope.perms;
@@ -1141,7 +1141,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.pop', length: 0,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var perms = state.scope.perms;
       var obj = intrp.toObject(thisVal, perms);
       var len = Interpreter.toLength(obj.get('length', perms));
@@ -1160,7 +1160,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.push', length: 1,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var perms = state.scope.perms;
       var obj = intrp.toObject(thisVal, perms);
       var len = Interpreter.toLength(obj.get('length', perms));
@@ -1181,7 +1181,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.reverse', length: 0,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var perms = state.scope.perms;
       var obj = intrp.toObject(thisVal, perms);
       var len = Interpreter.toLength(obj.get('length', perms));
@@ -1221,7 +1221,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.shift', length: 0,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var perms = state.scope.perms;
       var obj = intrp.toObject(thisVal, perms);
       var len = Interpreter.toLength(obj.get('length', perms));
@@ -1248,7 +1248,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.slice', length: 2,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var start = args[0];
       var end = args[1];
       var perms = state.scope.perms;
@@ -1278,7 +1278,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.splice', length: 2,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var start = args[0];
       var deleteCount = args[1];
       var perms = state.scope.perms;
@@ -1349,7 +1349,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.toString', length: 0,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       if (!state.info_.funcState) {  // First visit: call .join().
         state.info_.funcState = true;
         var perms = state.scope.perms;
@@ -1373,7 +1373,7 @@ Interpreter.prototype.initArray_ = function() {
   new this.NativeFunction({
     id: 'Array.prototype.unshift', length: 1,
     /** @type {!Interpreter.NativeCallImpl} */
-    call:  function(intrp, thread, state, thisVal, args) {
+    call: function(intrp, thread, state, thisVal, args) {
       var perms = state.scope.perms;
       var obj = intrp.toObject(thisVal, perms);
       var len = Interpreter.toLength(obj.get('length', perms));
@@ -2070,7 +2070,7 @@ Interpreter.prototype.initNetwork_ = function() {
     if (port !== (port >>> 0) || port > 0xffff) {
       rej(new intrp.Error(perms, intrp.RANGE_ERROR, 'invalid port'));
       return;
-    } else  if (port in intrp.listeners_) {
+    } else if (port in intrp.listeners_) {
       rej(new intrp.Error(perms, intrp.RANGE_ERROR, 'port already listened'));
       return;
     }
@@ -5013,7 +5013,7 @@ stepFuncs_['CallExpression'] = function (thread, stack, state, node) {
         info.directEval = (state.ref[1] === 'eval');
       } else {
         // Method call; save 'this' value.
-        info.this =  state.ref[0];
+        info.this = state.ref[0];
       }
     } else {  // Callee already fully evaluated.
       info.callee = state.value;
@@ -5380,7 +5380,7 @@ stepFuncs_['Identifier'] = function (thread, stack, state, node) {
   if (state.wantRef_) {
     stack[stack.length - 1].ref = [Interpreter.SCOPE_REFERENCE, name];
   } else {
-    stack[stack.length - 1].value =  this.getValueFromScope(state.scope, name);
+    stack[stack.length - 1].value = this.getValueFromScope(state.scope, name);
   }
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1435,8 +1435,15 @@ Interpreter.prototype.initString_ = function() {
   this.STRING = new this.Object(this.ROOT);
   this.builtins_['String.prototype'] = this.STRING;
   this.STRING.class = 'String';
+
   // String constructor.
-  this.createNativeFunction('String', String, false);  // No: new String()
+  new this.NativeFunction({
+    id: 'String', length: 1,
+    /** @type {!Interpreter.NativeCallImpl} */
+    call: function(intrp, thread, state, thisVal, args) {
+      return String(args[0]);
+    }
+  });
 
   // Static methods on String.
   this.createNativeFunction('String.fromCharCode', String.fromCharCode, false);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1037,9 +1037,6 @@ Interpreter.prototype.initArray_ = function() {
     }
   });
 
-  var intrp = this;
-  var wrapper;
-
   // Static methods on Array.
   new this.NativeFunction({
     id: 'Array.isArray', length: 1,
@@ -1404,32 +1401,6 @@ Interpreter.prototype.initArray_ = function() {
       return len + argCount;
     }
   });
-
-  wrapper = function(separator) {
-    var isArray = (this instanceof intrp.Array);
-    if (isArray) {
-      var cycles = intrp.toStringCycles_;
-      if (cycles.indexOf(this) !== -1) {
-        return '';
-      }
-      cycles[cycles.length] = this;
-    }
-    try {
-      var text = [];
-      for (var i = 0; i < this.properties.length; i++) {
-        var value = this.properties[i];
-        if (value === null || value === undefined) {
-          text[i] = '';
-        } else {
-          text[i] = String(value);
-        }
-      }
-    } finally {
-      if (isArray) cycles.pop();
-    }
-    return text.join(separator);
-  };
-  this.createNativeFunction('Array.prototype.join', wrapper, false);
 };
 
 /**

--- a/server/startup/cc.js
+++ b/server/startup/cc.js
@@ -115,6 +115,17 @@ var PermissionError = new 'PermissionError';
   Object.defineProperty(Array.prototype, 'join', {
     configurable: true, writable: true,
     value: function(separator) {
+      // This implements Array.prototype.join from ES6 §22.1.3.12,
+      // with the addition of cycle detection as discussed in
+      // https://github.com/tc39/ecma262/issues/289.
+      //
+      // The only difference from the ES6 version is that the cycle
+      // detection mechanism is thread-aware, so multiple parallel
+      // invocations of .join will not interfere with each other.
+      //
+      // Variable names reflect those in the spec.
+      //
+      // N.B. This function is defined in a closure!
       var isObj = (typeof this === 'object' || typeof this === 'function') &&
           this !== null;
       if (isObj) {

--- a/server/startup/cc.js
+++ b/server/startup/cc.js
@@ -88,6 +88,74 @@ var PermissionError = new 'PermissionError';
 })();
 
 ///////////////////////////////////////////////////////////////////////////////
+// Array.prototype polyfills
+///////////////////////////////////////////////////////////////////////////////
+
+(function() {
+  function toInteger(value) {
+    var number = Number(value);
+    if (isNaN(number)) {
+      return 0;
+    } else if (number === 0 || number === Infinity || number === -Infinity) {
+      return number;
+    }
+    return Math.trunc(number);
+  }
+
+  function toLength(value) {
+    var len = toInteger(value);
+    if (len <= 0) return 0;
+    return Math.min(len, Number.MAX_SAFE_INTEGER);  // Handles len === Infinity.
+  };
+
+  // For cycle detection in array to string and error conversion; see
+  // spec bug github.com/tc39/ecma262/issues/289.
+  var visitedByThread = new WeakMap;
+
+  Object.defineProperty(Array.prototype, 'join', {
+    configurable: true, writable: true,
+    value: function(separator) {
+      var isObj = (typeof this === 'object' || typeof this === 'function') &&
+          this !== null;
+      if (isObj) {
+        if (visitedByThread.has(Thread.current())) {
+          var visited = visitedByThread.get(Thread.current());
+        } else {
+          visited = [];
+          visitedByThread.set(Thread.current(), visited);
+        }
+        if (visited.indexOf(this) !== -1) {
+          return '';
+        }
+        visited.push(this);
+      }
+      try {
+        // TODO(cpcallen): setPerms(callerPerms());
+        var len = toLength(this.length);
+        var sep = (separator === undefined) ? ',' : String(separator);
+        if (len === 0) {
+          return '';
+        }
+        var r = '';
+        for (var k = 0; k < len; k++) {
+          if (k > 0) r += sep;
+          var element = this[k];
+          if (element !== undefined && element !== null) {
+            r += String(element);
+          }
+        }
+        return r;
+      } finally {
+        if (isObj) visited.pop();
+        if (visited.length === 0) {
+          visitedByThread.delete(Thread.current());
+        }
+      }
+    }
+  });
+})();
+
+///////////////////////////////////////////////////////////////////////////////
 // Threads API; parts are roughly conformant with HTML Living
 // Standard, plus our local extensions.
 //

--- a/server/startup/cc.js
+++ b/server/startup/cc.js
@@ -133,7 +133,7 @@ var PermissionError = new 'PermissionError';
         // TODO(cpcallen): setPerms(callerPerms());
         var len = toLength(this.length);
         var sep = (separator === undefined) ? ',' : String(separator);
-        if (len === 0) {
+        if (!len) {
           return '';
         }
         var r = '';
@@ -147,7 +147,7 @@ var PermissionError = new 'PermissionError';
         return r;
       } finally {
         if (isObj) visited.pop();
-        if (visited.length === 0) {
+        if (!visited.length) {
           visitedByThread.delete(Thread.current());
         }
       }

--- a/server/startup/cc.js
+++ b/server/startup/cc.js
@@ -96,7 +96,7 @@ var PermissionError = new 'PermissionError';
     var number = Number(value);
     if (isNaN(number)) {
       return 0;
-    } else if (number === 0 || number === Infinity || number === -Infinity) {
+    } else if (number === 0 || !isFinite(number) {
       return number;
     }
     return Math.trunc(number);

--- a/server/startup/es5.js
+++ b/server/startup/es5.js
@@ -403,7 +403,7 @@ Object.defineProperty(Array.prototype, 'forEach',
         // TODO(cpcallen): setPerms(callerPerms());
         var len = this.length >>> 0;
         var sep = (separator === undefined) ? ',' : String(separator);
-        if (len === 0) {
+        if (!len) {
           return '';
         }
         var r = '';

--- a/server/startup/es5.js
+++ b/server/startup/es5.js
@@ -386,7 +386,6 @@ Object.defineProperty(Array.prototype, 'forEach',
 (function() {
   // For cycle detection in array to string and error conversion; see
   // spec bug github.com/tc39/ecma262/issues/289.
-  // BUG(cpcallen): This should be per-thread.
   var visited = [];
 
   Object.defineProperty(Array.prototype, 'join', {

--- a/server/startup/es5.js
+++ b/server/startup/es5.js
@@ -391,6 +391,13 @@ Object.defineProperty(Array.prototype, 'forEach',
   Object.defineProperty(Array.prototype, 'join', {
     configurable: true, writable: true,
     value: function(separator) {
+      // This implements Array.prototype.join from ES5 §15.4.4.5, with
+      // the addition of cycle detection as discussed in
+      // https://github.com/tc39/ecma262/issues/289.
+      //
+      // Variable names reflect those in the spec.
+      //
+      // N.B. This function is defined in a closure!
       var isObj = (typeof this === 'object' || typeof this === 'function') &&
           this !== null;
       if (isObj) {

--- a/server/startup/es6.js
+++ b/server/startup/es6.js
@@ -102,7 +102,6 @@ var WeakMap = new 'WeakMap';
 
   // For cycle detection in array to string and error conversion; see
   // spec bug github.com/tc39/ecma262/issues/289.
-  // BUG(cpcallen): This should be per-thread.
   var visited = [];
 
   Object.defineProperty(Array.prototype, 'join', {

--- a/server/startup/es6.js
+++ b/server/startup/es6.js
@@ -88,7 +88,7 @@ var WeakMap = new 'WeakMap';
     var number = Number(value);
     if (isNaN(number)) {
       return 0;
-    } else if (number === 0 || number === Infinity || number === -Infinity) {
+    } else if (number === 0 || !isFinite(number)) {
       return number;
     }
     return Math.trunc(number);

--- a/server/startup/es6.js
+++ b/server/startup/es6.js
@@ -119,7 +119,7 @@ var WeakMap = new 'WeakMap';
         // TODO(cpcallen): setPerms(callerPerms());
         var len = toLength(this.length);
         var sep = (separator === undefined) ? ',' : String(separator);
-        if (len === 0) {
+        if (!len) {
           return '';
         }
         var r = '';

--- a/server/startup/es6.js
+++ b/server/startup/es6.js
@@ -107,6 +107,17 @@ var WeakMap = new 'WeakMap';
   Object.defineProperty(Array.prototype, 'join', {
     configurable: true, writable: true,
     value: function(separator) {
+      // This implements Array.prototype.join from ES6 §22.1.3.12, with
+      // the addition of cycle detection as discussed in
+      // https://github.com/tc39/ecma262/issues/289.
+      //
+      // The only difference from the ES5 version of the spec is that
+      // .length is normalised using the specification function
+      // ToLength rather than ToUint32.
+      //
+      // Variable names reflect those in the spec.
+      //
+      // N.B. This function is defined in a closure!
       var isObj = (typeof this === 'object' || typeof this === 'function') &&
           this !== null;
       if (isObj) {

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2100,12 +2100,12 @@ tests.ArrayPrototypeReverse = function () {
 
   var o = {0: 1, 1: 2, 2: 3, length: 3};
   console.assert(Array.prototype.reverse.call(o) === o &&
-      o.length === 3 && Array.prototype.toString.apply(o) === '3,2,1',
+      o.length === 3 && Array.prototype.slice.apply(o).toString() === '3,2,1',
       'Array.prototype.reverse.call(odd-length array-like)');
 
   o = {0: 1, 1: 2, 3: 4, length: 4};
   console.assert(Array.prototype.reverse.call(o) === o &&
-      o.length === 4 && Array.prototype.toString.apply(o) === '4,,2,1',
+      o.length === 4 && Array.prototype.slice.apply(o).toString() === '4,,2,1',
       'Array.prototype.reverse.call(even-length array-like)');
 
   o = {length: 0};

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1716,14 +1716,14 @@ module.exports = [
   { name: 'Array.prototype.reverse.call(odd-length array-like)', src: `
         var o = {0: 1, 1: 2, 2: 3, length: 3};
         Array.prototype.reverse.call(o) === o && o.length === 3 &&
-            Array.prototype.toString.apply(o);
+            Array.prototype.slice.apply(o).toString();
     `,
     expected: '3,2,1' },
 
   { name: 'Array.prototype.reverse.call(even-length array-like)', src: `
         var o = {0: 1, 1: 2, 3: 4, length: 4};
         Array.prototype.reverse.call(o) === o && o.length === 4 &&
-            Array.prototype.toString.apply(o);
+            Array.prototype.slice.apply(o).toString();
     `,
     expected: '4,,2,1' },
 
@@ -1874,6 +1874,18 @@ module.exports = [
     "Didn't crash!";
     `,
     expected: "Didn't crash!" },
+
+  { name: 'Array.prototype.toString.call(obj-w/join)', src: `
+    var o = {join: function() {return 'OK';}};
+    Array.prototype.toString.apply(o);
+    `,
+    expected: 'OK' },
+
+  { name: 'Array.prototype.toString.call(array-like)', src: `
+    var o = {0: 'foo', 1: 'bar', length: 2};
+    Array.prototype.toString.apply(o);
+    `,
+    expected: '[object Object]' },
 
   { name: 'Array.prototype.unshift', src: `
         var a = [];

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2002,10 +2002,62 @@ module.exports = [
     `,
     expected: 'pass' },
 
+  { name: 'String calls valueOf', src: `
+        var o = Object.create(null);
+        o.valueOf = function() {return 'OK';};
+        String(o);
+    `,
+    expected: 'OK' },
+
+  { name: 'String calling valueOf returns string', src: `
+        var o = Object.create(null);
+        o.valueOf = function() {return 42;};
+        String(o);
+    `,
+    expected: '42' },
+
+  { name: 'String calling valueOf throws', src: `
+        var o = Object.create(null);
+        o.valueOf = function() {return {};};
+        try {
+          String(o);
+        } catch (e) {
+          e.name;
+        }
+    `,
+    expected: 'TypeError' },
+
+  { name: 'String calls toString', src: `
+        var o = Object.create(null);
+        o.valueOf = function() {return 'Whoops: called valueOf';};
+        o.toString = function() {return 'OK';};
+        String(o);
+    `,
+    expected: 'OK' },
+
+  { name: 'String calling toString returns string', src: `
+        var o = Object.create(null);
+        o.valueOf = function() {return 42;};
+        String(o);
+    `,
+    expected: '42' },
+
+  { name: 'String calling toString throws', src: `
+        var o = Object.create(null);
+        o.valueOf = function() {return {};};
+        o.toString = function() {return {};};
+        try {
+          String(o);
+        } catch (e) {
+          e.name;
+        }
+    `,
+    expected: 'TypeError' },
+
   { name: 'String.prototype.length',
     src: `String.prototype.length;`,
     expected: 0 },
-    
+
   { name: 'String.prototype.replace(string, string)',
     src: `'xxxx'.replace('xx', 'y');`,
     expected: 'yxx' },


### PR DESCRIPTION
Rewrite String to actually call (userland) .toString.  Array.prototype.toString already calls .join if applicable.  Rewrite .join as a polyfill, in ES5, ES6 and thread-aware versions.  Add a test which fails without thread-aware version.