### PR TITLE
Fix breakage caused by fd9f0cb

### DIFF
--- a/server/startup/cc.js
+++ b/server/startup/cc.js
@@ -96,7 +96,7 @@ var PermissionError = new 'PermissionError';
     var number = Number(value);
     if (isNaN(number)) {
       return 0;
-    } else if (number === 0 || !isFinite(number) {
+    } else if (number === 0 || !isFinite(number)) {
       return number;
     }
     return Math.trunc(number);


### PR DESCRIPTION
Missing ')' in cc.js caused SyntaxError at startup.