### PR TITLE
Protoype and property cleanup

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2425,44 +2425,6 @@ Interpreter.prototype.toObject = function(value, perms) {
 };
 
 /**
- * Look up the prototype for this value.
- * @param {Interpreter.Value} value Data object.
- * @return {Interpreter.prototype.Object} Prototype object, null if none.
- */
-Interpreter.prototype.getPrototype = function(value) {
-  switch (typeof value) {
-    case 'number':
-      return this.NUMBER;
-    case 'boolean':
-      return this.BOOLEAN;
-    case 'string':
-      return this.STRING;
-  }
-  if (value) {
-    return value.proto;
-  }
-  return null;
-};
-
-/**
- * Fetch a property value from a data object.
- * @param {Interpreter.Value} obj Data object.
- * @param {Interpreter.Value} name Name of property.
- * @return {Interpreter.Value} Property value (may be undefined).
- */
-Interpreter.prototype.getProperty = function(obj, name) {
-  // BUG(cpcallen:perms): Kludge.  Incorrect except when doing .step
-  // or run.  Should be an argument instead, forcing caller to decide.
-  try {
-    var perms = this.thread.perms();
-  } catch (e) {
-    perms = this.ROOT;
-  }
-  var key = String(name);
-  return this.toObject(obj, perms).get(key, perms);
-};
-
-/**
  * Retrieves a value from the scope chain.
  * @param {!Interpreter.Scope} scope Scope to read from.
  * @param {string} name Name of variable.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -864,19 +864,13 @@ Interpreter.prototype.initObject_ = function() {
     id: 'Object.prototype.isPrototypeOf', length: 1,
     /** @type {!Interpreter.NativeCallImpl} */
     call: function(intrp, thread, state, thisVal, args) {
-      var obj = args[0];
+      var v = args[0];
+      if (!(v instanceof intrp.Object)) return false;
+      var o = intrp.toObject(thisVal, state.scope.perms);
       while (true) {
-        // Note, circular loops shouldn't be possible.
-        // BUG(cpcallen): behaviour of getPrototype is wrong for
-        // isPrototypeOf, according to either ES5.1 or ES6.
-        obj = intrp.getPrototype(obj);
-        if (obj === null) {
-          // No parent; reached the top.
-          return false;
-        }
-        if (obj === thisVal) {
-          return true;
-        }
+        v = v.proto;
+        if (v === null) return false;  // No parent; reached the top.
+        if (o === v) return true;
       }
     }
   });

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -768,11 +768,10 @@ Interpreter.prototype.initObject_ = function() {
     id: 'Object.getPrototypeOf', length: 1,
     /** @type {!Interpreter.NativeCallImpl} */
     call: function(intrp, thread, state, thisVal, args) {
-      var obj = args[0];
-      throwIfNullUndefined(obj);
-      // TODO(cpcallen): behaviour of our getPrototype is wrong for
-      // getPrototypeOf according to ES5.1 (but correct for ES6).
-      return intrp.getPrototype(obj);
+      // N.B.: This conforms to ES6.  ES5.1 would throw TypeError for
+      // Object.getPrototypeOf(<boolean, string or number>)
+      var o = intrp.toObject(args[0], state.scope.perms);
+      return o.proto;
     }
   });
 

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1741,19 +1741,50 @@ tests.ObjectPrototypeHasOwnProperty = function() {
   console.assert(r === 83, 'Object.prototype.hasOwnProperty');
 };
 
-tests.ObjectPrototypeGetPrototypeOf = function() {
+tests.ObjectPrototypeIsPrototypeOf = function() {
+  var pfx = 'Object.prototype.isPrototypeOf';
+  console.assert(!Boolean.prototype.isPrototypeOf(false),
+                 'Boolean.prototype.isPrototypeOf(false)');
+  console.assert(!Number.prototype.isPrototypeOf(0),
+                 'Number.prototype.isPrototypeOf(0)');
+  console.assert(!String.prototype.isPrototypeOf(''),
+                 "String.prototype.isPrototypeOf('')");
+  console.assert(!Object.prototype.isPrototypeOf.call(false, false),
+                 pfx + '.call(false, false)');
+  console.assert(!Object.prototype.isPrototypeOf.call(0, 0),
+                 pfx + '.call(0, 0)');
+  console.assert(!Object.prototype.isPrototypeOf.call('', ''),
+                pfx + ".call('', '')");
+  console.assert(!Object.prototype.isPrototypeOf.call(null, null),
+                 pfx + '.call(null, null)');
+  console.assert(!Object.prototype.isPrototypeOf.call(undefined, undefined),
+                 pfx + '.call(undefined, undefined)');
+  try {
+    Object.prototype.isPrototypeOf.call(null, Object.create(null));
+    console.assert(false, pfx + ".call(null, ...) didn't throw");
+  } catch (e) {
+    console.assert(e.name === 'TypeError',
+                   pfx + '.call(null, ...) wrong error');
+  }
+  try {
+    Object.prototype.isPrototypeOf.call(undefined, Object.create(undefined));
+    console.assert(false, pfx + ".call(undefined, ...) didn't throw");
+  } catch (e) {
+    console.assert(e.name === 'TypeError',
+                   pfx + '.call(undefined, ...) wrong error');
+  }
+
   var g = {};
   var p = Object.create(g);
   var o = Object.create(p);
-  console.assert(!o.isPrototypeOf(o), 'Object.prototype.getPrototypeOf self');
-  console.assert(
-      !o.isPrototypeOf({}), 'Object.prototype.getPrototypeOf siblings');
-  console.assert(
-      g.isPrototypeOf(o), 'Object.prototype.getPrototypeOf grandchild');
-  console.assert(p.isPrototypeOf(o), 'Object.prototype.getPrototypeOf child');
-  console.assert(!o.isPrototypeOf(p), 'Object.prototype.getPrototypeOf parent');
-  console.assert(
-      !o.isPrototypeOf(g), 'Object.prototype.getPrototypeOf grandparent');
+  console.assert(!o.isPrototypeOf(o), pfx + ' self');
+  console.assert(!Object.prototype.isPrototypeOf(Object.create(null)),
+                 pfx + ' unrelated');
+  console.assert(!o.isPrototypeOf({}), pfx + ' siblings');
+  console.assert(g.isPrototypeOf(o), pfx + ' grandchild');
+  console.assert(p.isPrototypeOf(o), pfx + ' child');
+  console.assert(!o.isPrototypeOf(p), pfx + ' parent');
+  console.assert(!o.isPrototypeOf(g), pfx + ' grandparent');
 };
 
 tests.ObjectPrototypePropertyIsEnumerable = function() {

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -884,7 +884,7 @@ exports.testNativeToPseudo = function(t) {
   for (var k in props) {
     if (!props.hasOwnProperty(k)) continue;
     var name = 'testNativeToPseudo(array)["' + k + '"]';
-    var r = intrp.getProperty(pArr, k);
+    var r = pArr.get(k, intrp.ROOT);
     check('.' + k, r, props[k]);
   }
 
@@ -906,9 +906,9 @@ exports.testNativeToPseudo = function(t) {
 
     check(' instanceof intrp.Error', pError instanceof intrp.Error, true);
     check('.proto', pError.proto, proto);
-    check('.name', intrp.getProperty(pError, 'name'), Err.prototype.name);
-    check('.message', intrp.getProperty(pError, 'message'), errMessage);
-    check('.stack', intrp.getProperty(pError, 'stack'), error.stack);
+    check('.name', pError.get('name', intrp.ROOT), Err.prototype.name);
+    check('.message', pError.get('message', intrp.ROOT), errMessage);
+    check('.stack', pError.get('stack', intrp.ROOT), error.stack);
   }
 };
 

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1295,9 +1295,44 @@ module.exports = [
     `,
     expected: 83 },
 
+  { name: 'Object.protoype.isPrototypeOf primitives', src: `
+    Boolean.prototype.isPrototypeOf(false) ||
+    Number.prototype.isPrototypeOf(0) ||
+    String.prototype.isPrototypeOf('') ||
+    Object.prototype.isPrototypeOf.call(false, false) ||
+    Object.prototype.isPrototypeOf.call(0, 0) ||
+    Object.prototype.isPrototypeOf.call('', '') ||
+    Object.prototype.isPrototypeOf.call(null, null) ||
+    Object.prototype.isPrototypeOf.call(undefined, undefined);
+    `,
+    expected: false },
+
+  { name: 'Object.protoype.isPrototypeOf.call(null, ...)', src: `
+    try {
+      Object.prototype.isPrototypeOf.call(null, Object.create(null));
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
+  { name: 'Object.protoype.isPrototypeOf.call(undefined, ...)', src: `
+    try {
+      Object.prototype.isPrototypeOf.call(undefined, Object.create(undefined));
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
   { name: 'Object.protoype.isPrototypeOf self', src: `
     var o = {};
     o.isPrototypeOf(o);
+    `,
+    expected: false },
+
+  { name: 'Object.protoype.isPrototypeOf unrelated', src: `
+    Object.prototype.isPrototypeOf(Object.create(null))
     `,
     expected: false },
 


### PR DESCRIPTION
Improved test for the built-in `Object.prototype.isPrototypeOf` lead to rewriting the last remaining callers of the legacy functions `Interpreter.prototype.getPrototype` and `Interpreter.prototype.getProperty`, which were then removed.