### PR TITLE
Have built-in Thread constructor take var args

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1979,33 +1979,29 @@ Interpreter.prototype.initThread_ = function() {
 
   /* Thread constructor.  Usage:
    *
-   *     var thread = new Thread(func, thisArg, argArray, delay);
+   *     var thread = new Thread(func, delay, thisArg, ...args);
    *
    * - func is function to run in thread.  (Maybe in future we will
    *   accept src to eval, but not for now.)
-   * - thsArg is the 'this' value to use for the call (as if via .apply).
-   * - argArray is array or array-like of arguments to pass.
    * - delay is time to wait, in ms, before starting thread.
+   * - thisArg is the 'this' value to use for the call (as if via .apply).
+   * - ...args are additional arguments to pass to func.
    */
   new this.NativeFunction({
-    id: 'Thread', length: 4,
+    id: 'Thread', length: 1,
     /** @type {!Interpreter.NativeConstructImpl} */
     construct: function(intrp, thread, state, args) {
       var func = args[0];
-      var thisArg = args[1];
-      var argArray = args[2];
-      var delay = Number(args[3]) || 0;
+      var delay = Number(args[1]) || 0;
+      var thisArg = args[2];
+      args = args.slice(3);
       var perms = state.scope.perms;
       if (!(func instanceof intrp.Function)) {
         throw new intrp.Error(perms, intrp.TYPE_ERROR,
             func + ' is not a function');
-      } else if (argArray === null || argArray === undefined) {
-        var argList = [];
-      } else {
-        argList = intrp.createListFromArrayLike(argArray, perms);
       }
       return intrp.createThreadForFuncCall(
-          perms, func, thisArg, argList, intrp.now() + delay);
+          perms, func, thisArg, args, intrp.now() + delay);
     }
   });
 

--- a/server/startup/esx.js
+++ b/server/startup/esx.js
@@ -186,7 +186,8 @@ var setTimeout = function(func, delay) {
    */
   // TODO(cpcallen:perms): setPerms(callerPerms());
   var args = arguments.slice(2);
-  return new Thread(func, undefined, args, delay);
+  args = [undefined, func, delay, undefined].concat(args);
+  return new (Thread.bind.apply(Thread, args));
 };
 
 var clearTimeout = function(thread) {

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -1006,8 +1006,8 @@ exports.testThreading = function(t) {
 
   src = `
       var s = '';
-      new Thread(function() { s += this; }, 2, undefined, 500);
-      new Thread(function(x) { s += x; }, undefined, [4], 1500);
+      new Thread(function() { s += this; }, 500, 2);
+      new Thread(function(x) { s += x; }, 1500, undefined, [4]);
       new Thread(function() { s += '1'; })
       suspend(1000);
       s += '3';


### PR DESCRIPTION
Previous the signature was:
```JS
    new Thread(func, thisArg, argArray, delay);
```
But now it is:
```JS
    new Thread(func, delay, thisArg, ...args);
```