### PR TITLE
Encapsulate source code in Source objects

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3026,18 +3026,19 @@ Interpreter.Source.prototype.slice = function(start, end) {
 };
 
 /**
- * Return the (1-based) line number of a given position within the
- * given Source object.
+ * Return the (1-based) line and column numbers of a given position
+ * within the Source object.
  * @param {number} pos Position whose line number we are interested
  *     in, as an absolute position within the original source text.
- * @return {number} Number of the line containing pos, relative to the
- *     start of this particular slice.
+ * @return {{line: number, col: number}} {line, col} tuple for the
+ *     position pos, relative to the start of this particular slice.
  */
-Interpreter.Source.prototype.lineForPos = function(pos) {
+Interpreter.Source.prototype.lineColForPos = function(pos) {
   if (pos < this.start_ || pos > this.end_) {
     throw RangeError('Source position out of range');
   }
-  return this.src_.slice(this.start_, pos).split('\n').length;
+  var lines = this.src_.slice(this.start_, pos).split('\n');
+  return {line: lines.length, col: lines[lines.length - 1].length + 1};
 };
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2959,6 +2959,65 @@ Interpreter.PropertyIterator.prototype.next = function() {
   }
 };
 
+/**
+ * Source is an encapsulated hunk of source text.  Source objects can
+ * be sliced to obtain a Source object representing a substring of the
+ * original source text.  Such sliced objects "remember" their
+ * position within the original source text.
+ * @constructor
+ * @param {string} src Some source text
+ * @param {number=} start_ For internal use only.
+ * @param {number=} end_ For internal use only.
+ */
+Interpreter.Source = function(src, start_, end_) {
+  /** @private @type {string} */
+  this.src_ = src;
+  if (start_ === undefined) {
+    /** @private @type {number} */
+    this.start_ = 0;
+  } else if (start_ < 0 || start_ >= src.length) {
+    throw RangeError('Source start out of range');
+  } else {
+    this.start_ = start_;
+  }
+  if (end_ === undefined) {
+    /** @private @type {number} */
+    this.end_ = src.length;
+  } else if (end_ < 0 || end_ >= src.length) {
+    throw RangeError('Source end out of range');
+  } else {
+    this.end_ = end_;
+  }
+  Object.freeze(this);
+};
+
+/**
+ * Return the contents of a Source object as an ordinary string.
+ * @return {string}
+ */
+Interpreter.Source.prototype.toString = function() {
+  return this.src_.slice(this.start_, this.end_);
+};
+
+/**
+ * Return a Source object representing a substring of this Source
+ * object.
+ * @param {number} start Offset of first character of slice, as an absolute
+ *     position within the original source text.
+ * @param {number} end Offset of character following last character of
+ *     slice, as an absolute position within the original source text.
+ * @return {!Interpreter.Source} The sliced source.
+ */
+Interpreter.Source.prototype.slice = function(start, end) {
+  if (start < this.start_ || start > this.end_) {
+    throw RangeError('Source slice start out of range');
+  }
+  if (end < this.start_ || end > this.end_) {
+    throw RangeError('Source slice end out of range');
+  }
+  return new Interpreter.Source(this.src_, start, end);
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // Types representing JS objects - Object, Function, Array, etc.
 ///////////////////////////////////////////////////////////////////////////////

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3018,6 +3018,21 @@ Interpreter.Source.prototype.slice = function(start, end) {
   return new Interpreter.Source(this.src_, start, end);
 };
 
+/**
+ * Return the (1-based) line number of a given position within the
+ * given Source object.
+ * @param {number} pos Position whose line number we are interested
+ *     in, as an absolute position within the original source text.
+ * @return {number} Number of the line containing pos, relative to the
+ *     start of this particular slice.
+ */
+Interpreter.Source.prototype.lineForPos = function(pos) {
+  if (pos < this.start_ || pos > this.end_) {
+    throw RangeError('Source position out of range');
+  }
+  return this.src_.slice(this.start_, pos).split('\n').length;
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // Types representing JS objects - Object, Function, Array, etc.
 ///////////////////////////////////////////////////////////////////////////////

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -419,6 +419,7 @@ Serializer.getTypesDeserialize_ = function (intrp) {
     'State': Interpreter.State,
     'Thread': Interpreter.Thread,
     'PropertyIterator': Interpreter.PropertyIterator,
+    'Source': Interpreter.Source,
     'PseudoObject': intrp.Object,
     'PseudoFunction': intrp.Function,
     'PseudoUserFunction': intrp.UserFunction,

--- a/server/tests/interpreter_unit_test.js
+++ b/server/tests/interpreter_unit_test.js
@@ -147,3 +147,21 @@ exports.testNativeToPseudo = function(t) {
     check(t, name + '.stack', pError.get('stack', intrp.ROOT), error.stack);
   }
 };
+
+/**
+ * Unit tests for Interpreter.Source class.
+ * @param {!T} t The test runner object.
+ */
+exports.testSource = function(t) {
+  var src = new Interpreter.Source('ABCDEF');
+  var name = "Source('ABCDEF')";
+  check(t, name + '.toString()', String(src), 'ABCDEF');
+
+  src = src.slice(1, 5);
+  name += '.slice(1, 5)';
+  check(t, name + '.toString()', String(src), 'BCDE');
+  
+  src = src.slice(2, 4);
+  name += '.slice(2, 4)';
+  check(t, name + '.toString()', String(src), 'CD');
+};

--- a/server/tests/interpreter_unit_test.js
+++ b/server/tests/interpreter_unit_test.js
@@ -164,4 +164,16 @@ exports.testSource = function(t) {
   src = src.slice(2, 4);
   name += '.slice(2, 4)';
   check(t, name + '.toString()', String(src), 'CD');
+
+  var s = '1\n2\n3\n4\n5\n';
+  var pos3 = s.indexOf('3');
+  src = new Interpreter.Source(s);
+  name = "Source('" + s + "')";
+  check(t, name + '.lineForPos(' + pos3 + ')', src.lineForPos(pos3), 3);
+
+  src = src.slice(2, 8);
+  name += '.slice(2, 8)';
+  check(t, name + '.toString()', String(src), '2\n3\n4\n');
+
+  check(t, name + '.lineForPos(' + pos3 + ')', src.lineForPos(pos3), 2);
 };

--- a/server/tests/interpreter_unit_test.js
+++ b/server/tests/interpreter_unit_test.js
@@ -165,15 +165,19 @@ exports.testSource = function(t) {
   name += '.slice(2, 4)';
   check(t, name + '.toString()', String(src), 'CD');
 
-  var s = '1\n2\n3\n4\n5\n';
+  var s = '1\n.2\n..3\n.4\n5\n';
   var pos3 = s.indexOf('3');
   src = new Interpreter.Source(s);
   name = "Source('" + s + "')";
-  check(t, name + '.lineForPos(' + pos3 + ')', src.lineForPos(pos3), 3);
+  var lc = src.lineColForPos(pos3);
+  check(t, name + '.lineColForPos(' + pos3 + ').line', lc.line, 3);
+  check(t, name + '.lineColForPos(' + pos3 + ').col', lc.col, 3);
 
-  src = src.slice(2, 8);
-  name += '.slice(2, 8)';
-  check(t, name + '.toString()', String(src), '2\n3\n4\n');
+  src = src.slice(2, 12);
+  name += '.slice(2, 12)';
+  lc = src.lineColForPos(pos3);
+  check(t, name + '.toString()', String(src), '.2\n..3\n.4\n');
 
-  check(t, name + '.lineForPos(' + pos3 + ')', src.lineForPos(pos3), 2);
+  check(t, name + '.lineColForPos(' + pos3 + ').line', lc.line, 2);
+  check(t, name + '.lineColForPos(' + pos3 + ').col', lc.col, 3);
 };


### PR DESCRIPTION
Introduce the `Source` class to encapsulate storage of source code, to allow us to easily change our mind about representation (and thus garbage collection issues) later.

Also a few related changes:
* Don't store source code for functions twice.
* Make source arg to `populateScope_` optional, since (for initial call) the source *should* be stored on the AST node it is searching from.