### PR TITLE
Misc. Function-related changes

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4141,7 +4141,7 @@ Interpreter.prototype.installTypes = function() {
   };
 
   /**
-   * The [[Call]] internal method for bound functions, defined by
+   * The [[Construct]] internal method for bound functions, defined by
    * ES5.1 §15.3.4.5.2 / ES6 §9.4.1.2.
    * @override
    */
@@ -6086,4 +6086,6 @@ module.exports = Interpreter;
 var acornNode = acorn.parse('', Interpreter.PARSE_OPTIONS).constructor;
 /** @constructor */ Interpreter.Node =
     acornNode.bind(acorn, {options: Interpreter.PARSE_OPTIONS});
+// Only needed to help serializser; not needed for `new Node` since
+// contructing a bound function uses the target function's .prototype.
 Interpreter.Node.prototype = acornNode.prototype;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -547,16 +547,15 @@ Interpreter.prototype.initBuiltins_ = function() {
         throw intrp.errorNativeToPseudo(e, state.scope.perms);
       }
       var source = new Interpreter.Source(code);
-      var evalNode = new Interpreter.Node;
-      evalNode['type'] = 'EvalProgram_';
-      evalNode['body'] = ast['body'];
-      evalNode['source'] = source;
+      // Change node type from Program to EvalProgram_.
+      ast['type'] = 'EvalProgram_';
+      ast['source'] = source;
       // Create new scope and update it with definitions in eval().
       var outerScope = state.info_.directEval ? state.scope : intrp.global;
       var scope = new Interpreter.Scope(state.scope.perms, outerScope);
-      intrp.populateScope_(evalNode, scope);
+      intrp.populateScope_(ast, scope);
       thread.stateStack_[thread.stateStack_.length] =
-          new Interpreter.State(evalNode, scope);
+          new Interpreter.State(ast, scope);
       state.value = undefined;  // Default value if no explicit return.
       return FunctionResult.AwaitValue;
     }

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2019,24 +2019,6 @@ tests.FunctionPrototypeBind = function() {
   console.assert(f.bind(undefined, 1)(2, 3) === 4, 'Function.prototype.bind');
 };
 
-// TODO(cpcallen): Is there a way to do this and next test using only
-// ES5 constructs?
-tests.FunctionPrototypeBindClassConstructor = function() {
-  var f = WeakMap.bind();
-  try {
-    f();
-    console.assert(false, "Calling bound class constructor didn't throw");
-  } catch (e) {
-    console.assert(e.name === 'TypeError',
-        'Calling bound class constructor threw wrong error');
-  }
-}
-
-tests.FunctionPrototypeBindClassConstructorNew = function() {
-  console.assert(String(new (WeakMap.bind())) === '[object WeakMap]',
-      'FunctionPrototypeBindClassConstructorNew');
-};
-
 ///////////////////////////////////////////////////////////////////////////////
 // Array and Array.prototype
 

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -2019,6 +2019,38 @@ tests.FunctionPrototypeBind = function() {
   console.assert(f.bind(undefined, 1)(2, 3) === 4, 'Function.prototype.bind');
 };
 
+tests.FunctionPrototypeBindCallBF = function() {
+  var constructed;
+  function Foo() {constructed = (this instanceof Foo)}
+  var f = Foo.bind();
+  f();
+  console.assert(constructed === false,
+      'Function.prototype.bind: calling bound function calls target');
+};
+
+tests.FunctionPrototypeBindConstructBF = function() {
+  var constructed;
+  function Foo() {constructed = (this instanceof Foo)}
+  var f = Foo.bind();
+  new f;
+  console.assert(constructed === true,
+      'Function.prototype.bind: constructing bound function constructs target');
+};
+
+tests.FunctionPrototypeCallBindConstructBF = function() {
+  var invoked;
+  function Foo() {invoked = true;}
+  var f = Foo.call.bind(Foo);
+  try {
+    new f;
+    console.assert(false, "Calling bound call function didn't throw");
+  } catch (e) {
+    console.assert(e.name === 'TypeError',
+        'Calling bound call function threw wrong error');
+  }
+  console.assert(!invoked, 'Calling bound call function invoked call target');
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // Array and Array.prototype
 
@@ -2079,7 +2111,7 @@ tests.ArrayPrototypeConcat = function() {
   console.assert(c.length === 5 && '3' in c && c[3] === undefined &&
       String(c) === 'foo,bar,baz,,[object Object]',
       'Array.prototype.concat(...)');
-  
+
   o = {0: 'foo', 1: 'bar', length: 2};
   c = Array.prototype.concat.call(o, 'baz', [, 'quux', 'quuux']);
   console.assert(c.length === 5 &&

--- a/server/tests/db/test_01_es6.js
+++ b/server/tests/db/test_01_es6.js
@@ -159,6 +159,25 @@ tests.ObjectIs = function() {
 };
 
 ///////////////////////////////////////////////////////////////////////////////
+// Function and Funciton.prototype
+
+tests.FunctionPrototypeBindClassConstructor = function() {
+  var f = WeakMap.bind();
+  try {
+    f();
+    console.assert(false, "Calling bound class constructor didn't throw");
+  } catch (e) {
+    console.assert(e.name === 'TypeError',
+        'Calling bound class constructor threw wrong error');
+  }
+}
+
+tests.FunctionPrototypeBindClassConstructorNew = function() {
+  console.assert(String(new (WeakMap.bind())) === '[object WeakMap]',
+      'FunctionPrototypeBindClassConstructorNew');
+};
+
+///////////////////////////////////////////////////////////////////////////////
 // Array and Array.prototype
 
 tests.ArrayFind = function() {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1644,8 +1644,7 @@ module.exports = [
     `,
     expected: 4 },
 
-  // TODO(cpcallen): Is there a way to do this and next test using
-  // only ES5 constructs?
+  // N.B.: tests of class constructor semantics unavoidably ES6.
   { name: 'Function.protote.bind class constructor w/o new', src: `
     var f = WeakMap.bind();  // Should be O.K.
     try {
@@ -1656,6 +1655,7 @@ module.exports = [
     `,
     expected: 'TypeError' },
 
+  // N.B.: tests of class constructor semantics unavoidably ES6.
   { name: 'Function.protote.bind class constructor', src: `
     String(new (WeakMap.bind()));
     `,

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1646,7 +1646,7 @@ module.exports = [
 
   // TODO(cpcallen): Is there a way to do this and next test using
   // only ES5 constructs?
-  { name: 'Function.protote.bind class constructor', src: `
+  { name: 'Function.protote.bind class constructor w/o new', src: `
     var f = WeakMap.bind();  // Should be O.K.
     try {
       f();
@@ -1656,7 +1656,7 @@ module.exports = [
     `,
     expected: 'TypeError' },
 
-  { name: 'Function.protote.bind class constructor w/o new', src: `
+  { name: 'Function.protote.bind class constructor', src: `
     String(new (WeakMap.bind()));
     `,
     expected: '[object WeakMap]' },

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1142,7 +1142,7 @@ module.exports = [
     var o = {parent: 'o'};
     var p = {parent: 'p'};
     var q = Object.create(o);
-    Object.setPrototypeOf(q, p) === q && 
+    Object.setPrototypeOf(q, p) === q &&
         Object.getPrototypeOf(q) === p && q.parent;
     `,
     expected: 'p' },
@@ -1150,7 +1150,7 @@ module.exports = [
   { name: 'Object.setPrototypeOf circular', src: `
     var o = {};
     var p = Object.create(o);
-    try {    
+    try {
       Object.setPrototypeOf(o, p);
     } catch (e) {
       e.name;
@@ -1644,8 +1644,38 @@ module.exports = [
     `,
     expected: 4 },
 
+  { name: 'Function.prototype.bind call BF', src: `
+    var constructed;
+    function Foo() {constructed = (this instanceof Foo)}
+    var f = Foo.bind();
+    f();
+    constructed;
+    `,
+    expected: false },
+
+  { name: 'Function.prototype.bind construct BF', src: `
+    var constructed;
+    function Foo() {constructed = (this instanceof Foo)}
+    var f = Foo.bind();
+    new f;
+    constructed;
+    `,
+    expected: true },
+
+  { name: 'Function.prototype.call.bind construct BF', src: `
+    var invoked;
+    function Foo() {invoked = true};
+    var f = Foo.call.bind(Foo);
+    try {
+      new f;
+    } catch (e) {
+      !invoked && e.name;
+    }
+    `,
+    expected: 'TypeError' },
+
   // N.B.: tests of class constructor semantics unavoidably ES6.
-  { name: 'Function.protote.bind class constructor w/o new', src: `
+  { name: 'Function.prototype.bind class constructor w/o new', src: `
     var f = WeakMap.bind();  // Should be O.K.
     try {
       f();


### PR DESCRIPTION
A bunch of loosely-related changes, mostly having to do with CallExpression evaluation or `Function.prototype.apply` / `.bind` / `.call`.

This is in preparation for splitting CallExpression into two separate steps.