### PR TITLE
Error traceback improvements

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -37,10 +37,17 @@ acorn.plugins.alwaysStrict = function(parser, configValue) {
 };
 
 /**
+ * @typedef {!Object}
+ */
+var InterpreterOptions;
+
+/**
  * Create a new interpreter.
  * @constructor
+ * @param {!InterpreterOptions=} options
  */
-var Interpreter = function() {
+var Interpreter = function(options) {
+  this.options = options || {};
   this.installTypes();
   /**
    * Map of builtins - e.g. Object, Function.prototype, Array.pop, etc.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -37,7 +37,10 @@ acorn.plugins.alwaysStrict = function(parser, configValue) {
 };
 
 /**
- * @typedef {!Object}
+ * @typedef {{
+ *     trimEval: (boolean|undefined),
+ *     trimProgram: (boolean|undefined),
+ * }}
  */
 var InterpreterOptions;
 
@@ -179,6 +182,9 @@ Interpreter.prototype.createThread = function(owner, state, runAt) {
  * @return {!Interpreter.prototype.Thread} Userland Thread object.
  */
 Interpreter.prototype.createThreadForSrc = function(src, runAt) {
+  if (this.options.trimProgram) {
+    src = src.trim();
+  }
   // Acorn may throw a Syntax error, but it's the caller's problem.
   var ast = acorn.parse(src, Interpreter.PARSE_OPTIONS);
   ast['source'] = new Interpreter.Source(src);
@@ -542,6 +548,9 @@ Interpreter.prototype.initBuiltins_ = function() {
     /** @type {!Interpreter.NativeCallImpl} */
     call: function(intrp, thread, state, thisVal, args) {
       var code = args[0];
+      if (intrp.options.trimEval) {
+        code = code.trim();
+      }
       if (typeof code !== 'string') {  // eval()
         // Eval returns the argument if the argument is not a string.
         // eval(Array) -> Array

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4620,8 +4620,7 @@ Interpreter.prototype.installTypes = function() {
         name = '"' + frame.program + '"';
       }
       if ('line' in frame) {
-        line += 'at ' + name + ' ' +
-            String(frame.line) + ':' + String(frame.col);
+        line += 'at ' + name + ' ' + frame.line + ':' + frame.col;
       } else {
         line += 'in ' + name;
       }

--- a/server/tests/interpreter_common.js
+++ b/server/tests/interpreter_common.js
@@ -39,7 +39,10 @@ exports.startupFiles = {
  * @return {!Interpreter}
  */
 exports.getInterpreter = function() {
-  var intrp = new Interpreter;
+  var intrp = new Interpreter({
+    trimEval: true,
+    trimProgram: true,
+  });
   for (const file of Object.values(exports.startupFiles)) {
     intrp.createThreadForSrc(file);
     intrp.run();


### PR DESCRIPTION
Create an (internal) `Thread.prototype.callers` function to get call stack information, and use it as the basis for improving the generation of the `.stack` property in the `intrp.Error` constructor.