### PR TITLE
Fix bug in unwind_

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2674,7 +2674,7 @@ Interpreter.prototype.unwind_ = function(thread, type, value, label) {
   }
 
   // Unhandled completion.  Terminate thread.
-  this.thread.status = Interpreter.Thread.Status.ZOMBIE;
+  thread.status = Interpreter.Thread.Status.ZOMBIE;
 
   if (type === Interpreter.CompletionType.THROW) {
     // Log exception and stack trace.

--- a/server/tests/testing.js
+++ b/server/tests/testing.js
@@ -149,6 +149,22 @@ T.prototype.fail = function(name, message) {
   this.result('FAIL', name, message);
 };
 
+
+/**
+ * Check if assertion is true and nd record test pass if so or test
+ * failure otherwise.
+ * @param {string} name The name of the test.
+ * @param {*} assertion Condition to verify.
+ * @param {string=} message Additional info to log on failure only.
+ */
+T.prototype.assert = function(name, assertion, message) {
+  if (assertion) {
+    this.pass(name);
+  } else {
+    this.fail(name, message);
+  }
+};
+
 /**
  * Check if Object.is(got, want) and record test pass if so or test
  * failure otherwise.


### PR DESCRIPTION
Turns out that, when called as a result of an error being thrown in an async function or indeed in any other situation where `intrp.thread` is not the thread to be unwound, `unwind_` will unwind the correct thread's stack but then, if that stack is empty, kill whatever thread `intrp.thread` happens to be pointing at.

Fix this and add tests to make sure it stays fixed.