### PR TITLE
Fix .stack generation

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2099,7 +2099,7 @@ Interpreter.prototype.initNetwork_ = function() {
       server.listen(function() {
         rr.resolve();
       }, function(e) {
-        rr.reject(intrp.errorNativeToPseudo(e, perms));
+        rr.reject(intrp.errorNativeToPseudo(e, perms), perms);
       });
       return Interpreter.FunctionResult.Block;
     }
@@ -2125,7 +2125,7 @@ Interpreter.prototype.initNetwork_ = function() {
         if (e instanceof Error) {
           // Somehow something has gone wrong.  (Maybe mulitple
           // concurrent calls to .close on the same net.Server?)
-          rr.reject(intrp.errorNativeToPseudo(e, perms));
+          rr.reject(intrp.errorNativeToPseudo(e, perms), perms);
         } else {
           // All socket (and all open connections on it) now closed.
           rr.resolve();
@@ -2720,7 +2720,7 @@ Interpreter.prototype.unwind_ = function(thread, type, value, label) {
  * @param {!Interpreter.Thread} thread The thread to be controlled.
  * @param {!Interpreter.State} state The state in which thread to block.
  * @return {{resolve: function(Interpreter.Value=):void,
- *           reject: function(Interpreter.Value):void}}
+ *           reject: function(Interpreter.Value, !Interpreter.Owner):void}}
  */
 Interpreter.prototype.getResolveReject = function(thread, state) {
   var /** boolean */ done = false;
@@ -2748,11 +2748,10 @@ Interpreter.prototype.getResolveReject = function(thread, state) {
       thread.status = Interpreter.Thread.Status.READY;
       intrp.go_();
     },
-    reject: function reject(value) {
+    reject: function reject(value, perms) {
       check();
       thread.status = Interpreter.Thread.Status.READY;
-      intrp.unwind_(
-          thread, Interpreter.CompletionType.THROW, value, undefined);
+      intrp.throw_(thread, value, perms);
       intrp.go_();
     }
   };

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2616,6 +2616,7 @@ Interpreter.prototype.setValue = function(scope, ref, value, perms) {
 Interpreter.prototype.throw_ = function(thread, e, perms) {
   if (e instanceof this.Error) {
     // Userland Error object thrown; make sure it has a .stack.
+    // BUG(cpcallen): this will set .stack on Error.prototype, etc.
     e.makeStack(thread.callers(perms), perms);
   } else if (e instanceof Error) {
     // Uh oh.  This is an internal error in the interpreter.  Kill

--- a/server/tests/db/test_02_errors.js
+++ b/server/tests/db/test_02_errors.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Code City: Testing code.
+ *
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Test language extensions related to errors.
+ * @author cpcallen@google.com (Christopher Allen)
+ */
+
+tests.errorStack = function() {
+  // Use eval to make parsing .stack easier.
+  var e = eval('new Error;');
+  var lines = e.stack.split('\n');
+  console.assert(lines[0].match(/at "new Error;" 1:1/), 'new Error has .stack');
+
+  try {
+    (function buggy() {1 instanceof 2;})();
+    console.assert(false, "thrown Error wasn't thrown??");
+  } catch (e) {
+    lines = e.stack.split('\n');
+    console.assert(
+        lines[0].match(/at buggy 1:1/), 'thrown Error has .stack');
+  }
+};

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2299,6 +2299,27 @@ module.exports = [
     expected: 'TypeError' },
 
   /////////////////////////////////////////////////////////////////////////////
+  // Error and Error.prototype (and all the other native error types too)
+
+  { name: 'new Error has .stack', src: `
+    // Use eval to make parsing .stack easier.
+    var e = eval('new Error;');
+    var lines = e.stack.split('\\n');
+    Boolean(lines[0].match(/at "new Error;" 1:1/));
+    `,
+    expected: true },
+
+  { name: 'thrown Error has .stack', src: `
+    try {
+      (function buggy() {1 instanceof 2;})();
+    } catch (e) {
+      var lines = e.stack.split('\\n');
+    }
+    Boolean(lines[0].match(/at buggy 1:1/));
+    `,
+    expected: true },
+
+  /////////////////////////////////////////////////////////////////////////////
   // JSON
 
   { name: 'JSON.stringify', src: `


### PR DESCRIPTION
Previously we tried to set `.stack` on Error objects at construction time, in the internal `intrp.Error` constructor.  Unfortunately this depended on using `intrp.thread` to find the current thread, and, outside of `.step` or `.run`—and in particular, in async callbacks—this might be `null` or (worse) point at the wrong thread.

PR #172 attempted to solve this by making the current thread available as a lexical variable in the async function callbacks, but after looking carefully at all the places `Error` objects can be constructed it became clear that this would still leave many possible avenues for an `Error` to end up with the wrong thread's stack in its `.stack`.

So, instead, set `.stack` in the built-in `Error` constructors (which covers all `Error` objects created by user code), and _also_ whenever an `Error` object is thrown (which covers all `Error` objects created by native code).