### PR TITLE
Optimise ConditionalExpression/IfStatement and LogicalExpression

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5516,25 +5516,19 @@ stepFuncs_['ConditionalExpression'] = function (thread, stack, state, node) {
     state.step_ = 1;
     return new Interpreter.State(node['test'], state.scope);
   }
-  if (state.step_ === 1) {  // Test evaluated; result is in .value
-    state.step_ = 2;
-    var value = Boolean(state.value);
-    if (value && node['consequent']) {
-      // Execute 'if' block.
-      return new Interpreter.State(node['consequent'], state.scope);
-    }
-    if (!value && node['alternate']) {
-      // Execute 'else' block.
-      return new Interpreter.State(node['alternate'], state.scope);
-    }
-    // eval('1;if(false){2}') -> undefined
-    thread.value = undefined;
-  }
-  // state.step_ === 2: Consequent or alternate done.  Do return?
+  // state.step_ === 1: Test evaluated; result is in .value
   stack.pop();
-  if (node['type'] === 'ConditionalExpression') {
-    stack[stack.length - 1].value = state.value;
+  var value = Boolean(state.value);
+  if (value && node['consequent']) {
+    // Execute 'if' block.
+    return new Interpreter.State(node['consequent'], state.scope);
   }
+  if (!value && node['alternate']) {
+    // Execute 'else' block.
+    return new Interpreter.State(node['alternate'], state.scope);
+  }
+  // eval('1;if(false){2}') -> undefined
+  thread.value = undefined;
 };
 
 /**

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5993,13 +5993,12 @@ stepFuncs_['ReturnStatement'] = function (thread, stack, state, node) {
  */
 stepFuncs_['SequenceExpression'] = function (thread, stack, state, node) {
   var n = state.n_;
-  var /** ?Interpreter.Node */ expression = node['expressions'][n];
-  if (expression) {
-    state.n_ = n + 1;
-    return new Interpreter.State(expression, state.scope);
+  var /** ?Interpreter.Node */ expression = node['expressions'][n++];
+  if (n >= node['expressions'].length) {
+    stack.pop();
   }
-  stack.pop();
-  stack[stack.length - 1].value = state.value;
+  state.n_ = n;
+  return new Interpreter.State(expression, state.scope);
 };
 
 /**

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5862,19 +5862,18 @@ stepFuncs_['LogicalExpression'] = function (thread, stack, state, node) {
     state.step_ = 1;
     return new Interpreter.State(node['left'], state.scope);
   }
-  if (state.step_ == 1) {  // Check for short-circuit; eval right.
-    var /** string */ op = node['operator'];
-    if (op !== '&&' && op !== '||') {
-      throw SyntaxError("Unknown logical operator '" + op + "'");
-    } else if ((op === '&&' && state.value) || (op === '||' && !state.value)) {
-      // No short-circuit this time.
-      state.step_ = 2;
-      return new Interpreter.State(node['right'], state.scope);
-    }
-  }
-  // state.step_ === 2: Return most recently evaluated subexpression.
+  // state.step_ == 1: Check for short-circuit; optionally eval right.
   stack.pop();
-  stack[stack.length - 1].value = state.value;
+  var /** string */ op = node['operator'];
+  if (op !== '&&' && op !== '||') {
+    throw SyntaxError("Unknown logical operator '" + op + "'");
+  } else if ((op === '&&' && !state.value) || (op === '||' && state.value)) {
+    // Short circuit.  Return left value.
+    stack[stack.length - 1].value = state.value;
+  } else {
+    // Tail-eval right.
+    return new Interpreter.State(node['right'], state.scope);
+  }
 };
 
 /**

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -373,6 +373,13 @@ module.exports = [
     `,
     expected: 0 },
 
+  { name: 'sequenceExpresion', src: `
+    var x, y, z;
+    x = (y = 60, z = 5, 0.5);
+    x + y + z;
+    `,
+    expected: 65.5 },
+
   { name: 'forTriangular', src: `
     var t = 0;
     for (var i = 0; i < 12; i++) {


### PR DESCRIPTION
These two step functions do not need to be revisited once it's been determined which subexpression (sub-statement) will be evaluated, so don't.

Unfortunately this doesn't avoid any allocation, so the performance boost is not as great as it would be if we could avoid creating a whole `State` object, but makes some difference and is a prerequisite to doing proper tail calls.