### PR TITLE
Set function names automatically

### DIFF
--- a/server/codecity.js
+++ b/server/codecity.js
@@ -67,6 +67,7 @@ CodeCity.startup = function(opt_databaseDirectory) {
   CodeCity.interpreter = new Interpreter({
     trimEval: true,
     trimProgram: true,
+    methodNames: true,
   });
   CodeCity.initSystemFunctions();
   if (i === -1) {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4830,15 +4830,15 @@ Interpreter.prototype.installTypes = function() {
     }
     var stack = [];
     for (var i = 0; i < callers.length; i++) {
-      var line = '    ';
+      var /** string */ line = '    ';
       var frame = callers[i];
       if ('func' in frame) {
-        var func = frame.func;
-        var name;
+        var /** !Interpreter.prototype.Function */ func = frame.func;
+        var /** string */ name;
         try {
           var pd = func.getOwnPropertyDescriptor('name', perms);
           if (pd) {
-            name = pd.value;
+            name = String(pd.value);
           } else {
             name = 'anonymous function';
           }

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5307,6 +5307,15 @@ var isIdentifierRef = function(node) {
   return node['type'] === 'Identifier';
 };
 
+/**
+ * Returns true iff node is a MemberExpression.
+ * @param {!Interpreter.Node} node The node to be tested.
+ * @return {boolean} True if node is an identifier.
+ */
+var isMemberRef = function(node) {
+  return node['type'] === 'MemberExpression';
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 // Step Functions: one to handle each node type.
 ///////////////////////////////////////////////////////////////////////////////
@@ -5396,12 +5405,13 @@ stepFuncs_['AssignmentExpression'] = function (thread, stack, state, node) {
       value = rightValue;
       // Set name if anonymous function expression.
       if (isAnonymousFunctionDefinition(node['right']) &&
-          isIdentifierRef(node['left'])) {
+          (isIdentifierRef(node['left']) ||
+           (this.options.methodNames && isMemberRef(node['left'])))) {
         var func = /** @type {!Interpreter.prototype.Function} */(value);
         // TODO(ES6): Check that func does not already have a 'name'
         // own property before calling setName?  (Spec requires, but
         // unclear why since we know RHS is anonymous.  Proxies?)
-        func.setName(node['left']['name']);
+        func.setName(state.ref[1]);
       }
       break;
     // All the rest are simple and similar.

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -6436,9 +6436,18 @@ stepFuncs_['VariableDeclaration'] = function (thread, stack, state, node) {
   var n = state.n_;
   var decl = declarations[n];
   if (state.step_ === 1) {  // Initialise variable with evaluated init value.
+    var name = decl['id']['name'];
+    var value = state.value;
+    if (isAnonymousFunctionDefinition(decl['init'])) {
+      var func = /** @type {!Interpreter.prototype.Function} */(value);
+      // TODO(ES6): Check that func does not already have a 'name' own
+      // property before calling setName?  (Spec requires, but unclear
+      // why since we know RHS is anonymous.  Proxies?)
+      func.setName(name);
+    }
     // Note that this is setting the value, not defining the variable.
     // Variable definition (addVariableToScope) is done when scope is populated.
-    this.setValueToScope(state.scope, decl['id']['name'], state.value);
+    this.setValueToScope(state.scope, name, value);
     decl = declarations[++n];
   }
   while (decl) {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4212,8 +4212,9 @@ Interpreter.prototype.installTypes = function() {
     // and we need to audit all use of String() throughout the
     // interpreter (including implicit use inside v8-native
     // functions).
-    return 'function ' + this.get('name', intrp.ANYBODY) +
-        '() { [native code] }';
+    var pd = this.getOwnPropertyDescriptor('name', intrp.ANYBODY);
+    var name = pd ? pd.value : '';
+    return 'function ' + name + '() { [native code] }';
   };
 
   /**
@@ -4311,6 +4312,9 @@ Interpreter.prototype.installTypes = function() {
     this.node = node;
     this.scope = scope;
     if (node['id']) {
+      // BUG(cpcallen): Per ES5 §13 / ES6 §14.1.20, we should actually
+      // create a new scope for the BindingIdentifier here, rather
+      // than inserting it into the scope created at call time.
       this.setName(node['id']['name']);
     }
     var length = node['params'].length;
@@ -4821,8 +4825,9 @@ Interpreter.prototype.installTypes = function() {
         var func = frame.func;
         var name;
         try {
-          if (func.has('name', perms)) {
-            name = func.get('name', perms);
+          var pd = func.getOwnPropertyDescriptor('name', perms);
+          if (pd) {
+            name = pd.value;
           } else {
             name = 'anonymous function';
           }

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4213,7 +4213,7 @@ Interpreter.prototype.installTypes = function() {
     // interpreter (including implicit use inside v8-native
     // functions).
     var pd = this.getOwnPropertyDescriptor('name', intrp.ANYBODY);
-    var name = pd ? pd.value : '';
+    var name = pd && typeof pd.value === 'string' ? pd.value : '';
     return 'function ' + name + '() { [native code] }';
   };
 

--- a/server/tests/db/test_01_es6.js
+++ b/server/tests/db/test_01_es6.js
@@ -22,6 +22,12 @@
  * @author fraser@google.com (Neil Fraser)
  */
 
+// Test automatic setting of function .name properties.
+tests.functionNameSetting = function() {
+  var o = {myPropFunc: function() {}};
+  console.assert(o.myPropFunc.name === 'myPropFunc',
+      'Object expression sets anonymous function name');
+};
 
 // Run some tests of the various constructors and their associated
 // literals and prototype objects.
@@ -159,7 +165,7 @@ tests.ObjectIs = function() {
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-// Function and Funciton.prototype
+// Function and Function.prototype
 
 tests.FunctionPrototypeBindClassConstructor = function() {
   var f = WeakMap.bind();

--- a/server/tests/db/test_01_es6.js
+++ b/server/tests/db/test_01_es6.js
@@ -24,6 +24,11 @@
 
 // Test automatic setting of function .name properties.
 tests.functionNameSetting = function() {
+  var myAssignedFunc;
+  myAssignedFunc = function() {};
+  console.assert(myAssignedFunc.name === 'myAssignedFunc',
+      'Assignment expression sets anonymous function name');
+
   var o = {myPropFunc: function() {}};
   console.assert(o.myPropFunc.name === 'myPropFunc',
       'Object expression sets anonymous function name');

--- a/server/tests/db/test_01_es6.js
+++ b/server/tests/db/test_01_es6.js
@@ -32,6 +32,10 @@ tests.functionNameSetting = function() {
   var o = {myPropFunc: function() {}};
   console.assert(o.myPropFunc.name === 'myPropFunc',
       'Object expression sets anonymous function name');
+
+  var myVarDeclFunc = function() {};
+  console.assert(myVarDeclFunc.name === 'myVarDeclFunc',
+      'Variable declaration sets anonymous function name');
 };
 
 // Run some tests of the various constructors and their associated

--- a/server/tests/interpreter_common.js
+++ b/server/tests/interpreter_common.js
@@ -36,17 +36,23 @@ exports.startupFiles = {
 
 /**
  * Create an initialize an Interpreter instance.
+ * @param {!Interpreter.Options=} options Interpreter constructor
+ *     options.  (Default: see implementation.)
+ * @param {boolean=} init Load the standard startup files?  (Default: true.)
  * @return {!Interpreter}
  */
-exports.getInterpreter = function() {
-  var intrp = new Interpreter({
+exports.getInterpreter = function(options, init) {
+  options = options || {
     noLog: ['net', 'unhandled'],
     trimEval: true,
     trimProgram: true,
-  });
-  for (const file of Object.values(exports.startupFiles)) {
-    intrp.createThreadForSrc(file);
-    intrp.run();
+  };
+  var intrp = new Interpreter(options);
+  if (init || init === undefined) {
+    for (const file of Object.values(exports.startupFiles)) {
+      intrp.createThreadForSrc(file);
+      intrp.run();
+    }
   }
   return intrp;
 }

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -475,6 +475,33 @@ exports.testBinaryOp = function(t) {
 };
 
 /**
+ * Run tests of setting the name of an anonymous function in an
+ * assignment expression where the LHS is a member expression.  This
+ * is CodeCity-specific behaviour controlled by a server flag.
+ */
+exports.testFunctionNameSetting = function(t) {
+  // Tests of the methodNames option which causes the functions that
+  // result from evaluating anonymous function expressions to get a
+  // .name when assigned to a property.
+  var name = "Assignment to property doesn't set anonymous function name";
+  var src = `
+      var o = {};
+      o.myMethod = function() {};
+      var gOPD = new 'Object.getOwnPropertyDescriptor';
+      gOPD(o.myMethod, 'name');
+  `;
+  runCustomTest(t, name, src, undefined, {methodNames: false}, false);
+  
+  name = 'Assignment to property sets anonymous function name';
+  src = `
+      var o = {};
+      o.myMethod = function() {};
+      o.myMethod.name;
+  `;
+  runCustomTest(t, name, src, 'myMethod', {methodNames: true}, false);
+};
+
+/**
  * Run some tests of the Abstract Relational Comparison Algorithm, as
  * defined in §11.8.5 of the ES5.1 spec and as embodied by the '<'
  * operator.

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -1061,6 +1061,21 @@ exports.testClasses = function(t) {
 };
 
 /**
+ * Run a destructive test of Function.prototype.toString.
+ * @param {!T} t The test runner object.
+ */
+exports.testFunctionPrototypeToString = function(t) {
+  var name = 'Funciton.prototype.toString applied to anonymous NativeFunction';
+  var src = `
+      var parent = function parent() {};
+      delete escape.name;
+      Object.setPrototypeOf(escape, parent);
+      escape.toString().replace(/\\s*/g, '');  // Strip whitespace.
+  `;
+  runCustomTest(t, name, src, 'function(){[nativecode]}');
+};
+
+/**
  * Run a test of multiple simultaneous calls to Array.prototype.join.
  * @param {!T} t The test runner object.
  */

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2432,9 +2432,9 @@ module.exports = [
     // Use eval to make parsing .stack easier.
     var e = eval('new Error;');
     var lines = e.stack.split('\\n');
-    Boolean(lines[0].match(/at "new Error;" 1:1/));
+    lines[0].trim();
     `,
-    expected: true },
+    expected: 'at "new Error;" 1:1' },
 
   { name: 'thrown Error has .stack', src: `
     try {
@@ -2442,9 +2442,17 @@ module.exports = [
     } catch (e) {
       var lines = e.stack.split('\\n');
     }
-    Boolean(lines[0].match(/at buggy 1:1/));
+    lines[0].trim();
     `,
-    expected: true },
+    expected: 'at buggy 1:19' },
+
+  { name: 'Error .stack correctly reports anonymous function', src: `
+    // Use eval to make parsing .stack easier.
+    var e = eval('(function () {return new Error;})()');
+    var lines = e.stack.split('\\n');
+    lines[0].trim();
+    `,
+    expected: 'at anonymous function 1:21' },
 
   /////////////////////////////////////////////////////////////////////////////
   // JSON

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -149,6 +149,13 @@ module.exports = [
     `,
     expected: 49 },
 
+  { name: 'assignmentSetsAnonFuncName', src: `
+    var myAssignedFunc;
+    myAssignedFunc = function() {};
+    myAssignedFunc.name;
+    `,
+    expected: 'myAssignedFunc' },
+
   { name: 'objectExprSetsAnonFuncName', src: `
     var o = {myPropFunc: function() {}};
     o.myPropFunc.name;

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -162,6 +162,12 @@ module.exports = [
     `,
     expected: 'myPropFunc' },
 
+  { name: 'varDeclSetsAnonFuncName', src: `
+    var myVarDeclFunc = function() {};
+    myVarDeclFunc.name;
+    `,
+    expected: 'myVarDeclFunc' },
+
   { name: 'fExpWithParameter', src: `
     var v;
     var f = function(x) { v = x; };

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -149,6 +149,12 @@ module.exports = [
     `,
     expected: 49 },
 
+  { name: 'objectExprSetsAnonFuncName', src: `
+    var o = {myPropFunc: function() {}};
+    o.myPropFunc.name;
+    `,
+    expected: 'myPropFunc' },
+
   { name: 'fExpWithParameter', src: `
     var v;
     var f = function(x) { v = x; };


### PR DESCRIPTION
ES6 mandates that `Function` objects created from anonymous function expressions have their `name` property set under certain circumstances.  This PR implements all of those cases (except those that involve destructuring assignment), plus an additional case that is especially important to our usage: assigning an anonymous function to a property on an object.
