### PR TITLE
Scopes for named FunctionExpressions

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2622,13 +2622,12 @@ Interpreter.prototype.setValueToScope = function(scope, name, value) {
 /**
  * Creates a variable in the given scope.
  * @param {!Interpreter.Scope} scope Scope to write to.
- * @param {Interpreter.Value} name Name of variable.
+ * @param {string} name Name of variable.
  * @param {Interpreter.Value} value Initial value.
  * @param {boolean=} notWritable True if constant (default: false).
  */
 Interpreter.prototype.addVariableToScope =
     function(scope, name, value, notWritable) {
-  name = String(name);
   if (!(name in scope.vars)) {
     scope.vars[name] = value;
   }

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3086,6 +3086,51 @@ Interpreter.Scope = function(perms, outerScope) {
 };
 
 /**
+ * Returns true iff this scope has a binding for the given name.
+ *
+ * Based on HasBinding for declarative environment records,
+ * from ES5.1 §10.2.1.1.1 / ES6 §8.1.1.1.1.
+ * @param {string} name Name of variable.
+ * @return {boolean} True iff name is bound in this scope.
+ */
+Interpreter.Scope.prototype.hasBinding = function(name) {
+  return name in this.vars;
+};
+
+/**
+ * Creates a mutable binding in the given scope and initialises it to
+ * undefined or the provided valued.
+ *
+ * Based on CreateMutableBinding for declarative environment records,
+ * from ES5.1 §10.2.1.1.2 / ES6 §8.1.1.1.2.
+ * @param {string} name Name of variable.
+ * @param {Interpreter.Value=} value Initial value (default: undefined).
+ */
+Interpreter.Scope.prototype.createMutableBinding = function(name, value) {
+  if (name in this.vars) {
+    throw Error(name + ' already has binding in this scope??');
+  }
+  this.vars[name] = value;
+};
+
+/**
+ * Creates an immutable binding in the given scope and initialises it
+ * to the provided valued.
+ *
+ * Based on CreateImmutableBinding for declarative environment records,
+ * from ES5.1 §10.2.1.1.7 / ES6 §8.1.1.1.3.
+ * @param {string} name Name of variable.
+ * @param {Interpreter.Value} value Initial value.
+ */
+Interpreter.Scope.prototype.createImmutableBinding = function(name, value) {
+  if (name in this.vars) {
+    throw Error(name + ' already has binding in this scope??');
+  }
+  this.vars[name] = value;
+  this.notWritable.add(name);
+};
+
+/**
  * Source is an encapsulated hunk of source text.  Source objects can
  * be sliced to obtain a Source object representing a substring of the
  * original source text.  Such sliced objects "remember" their

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3058,8 +3058,7 @@ Interpreter.PropertyIterator.prototype.next = function() {
 /**
  * Class for a scope.
  * @param {!Interpreter.Owner} perms The permissions with which code
- *     in the current scope is executing (default: outerScope.perms if
- *     supplied; otherwise null).
+ *     in the current scope is executing.
  * @param {?Interpreter.Scope} outerScope The enclosing scope ("outer
  *     lexical environment reference", in ECMAScript spec parlance)
  *     (default: null).
@@ -4467,11 +4466,6 @@ Interpreter.prototype.installTypes = function() {
     // constructor have this.scope set to the global scope, which is
     // owned by root!
     var scope = new Interpreter.Scope(owner, this.scope);
-    // Add the function's name to the scope.
-    var name = this.node['id'] && this.node['id']['name'];
-    if (name) {
-      scope.createImmutableBinding(name, this);
-    }
     // Add all arguments to the scope.
     var params = this.node['params'];
     for (var i = 0; i < params.length; i++) {
@@ -6056,8 +6050,15 @@ stepFuncs_['FunctionExpression'] = function (thread, stack, state, node) {
   if (!source) {
     throw Error("No source found when evaluating function expression??");
   }
-  stack[stack.length - 1].value =
-      new this.UserFunction(node, state.scope, source, state.scope.perms);
+  var scope = state.scope;
+  var perms = scope.perms;
+  // If the function expression has a name, create an outer scope to
+  // bind that name.  See ES5.1 §13 / ES6 §14.1.20.
+  var name = node['id'] && node['id']['name'];
+  if (name) scope = new Interpreter.Scope(perms, scope);
+  var func = new this.UserFunction(node, scope, source, perms);
+  if (name) scope.createImmutableBinding(name, func);
+  stack[stack.length - 1].value = func;
 };
 
 /**

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4438,19 +4438,19 @@ Interpreter.prototype.installTypes = function() {
       var paramValue = args.length > i ? args[i] : undefined;
       intrp.addVariableToScope(scope, paramName, paramValue);
     }
-    // Build arguments variable.
+    // Build arguments object.
     //
     // BUG(cpcallen): mustn't create arguments object if 'arguments'
-    // the name of a local variable or named parameter.  Needn't
+    // is the name of a local variable or named parameter.  Needn't
     // create arguments object if it is never referecned.
-    var argsList = new intrp.Arguments(owner);
-    argsList.defineProperty(
+    var argsObj = new intrp.Arguments(owner);
+    argsObj.defineProperty(
         'length', Descriptor.wc.withValue(args.length), owner);
     for (i = 0; i < args.length; i++) {
-      argsList.defineProperty(
+      argsObj.defineProperty(
           String(i), Descriptor.wec.withValue(args[i]), owner);
     }
-    intrp.addVariableToScope(scope, 'arguments', argsList, true);
+    intrp.addVariableToScope(scope, 'arguments', argsObj, true);
     // Add the function's name (var x = function foo(){};)
     var name = this.node['id'] && this.node['id']['name'];
     if (name) {

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -684,7 +684,7 @@ tests.simpleFunctionExpression = function() {
   console.assert(value === 49, 'simpleFunctionExpression');
 };
 
-tests.fExpWithParameter = function() {
+tests.funExpWithParameter = function() {
   var value;
   var f = function(x) {
     value = x;
@@ -1227,25 +1227,27 @@ tests.funcDecl = function() {
 };
 
 tests.namedFunctionExpression = function() {
-  var f = function foo(x) {
+  var f = function half(x) {
     if (x < 100) {
       return x;
     }
-    return foo(x / 2);
+    return half(x / 2);
   };
   console.assert(f(152) === 76, 'namedFunctionExpression');
-};
 
-tests.namedFunExpNoLeak = function() {
-  var f = function foo() {};
-  console.assert(typeof foo === 'undefined', 'namedFunExpNoLeak');
-};
+  f = function foo() {return foo;};
+  console.assert(f() === f, 'namedFunExpNameBinding');
 
-tests.namedFunExpSameSame = function() {
-  var f = function foo() {
-    return f === foo;
-  };
-  console.assert(f(), 'namedFunExpSameSame');
+  f = function foo() {};
+  console.assert(typeof foo === 'undefined', 'namedFunExpBindingNoLeak');
+
+  try {
+    (function foo() {foo = null;})();
+    console.assert(false, "namedFunExpNameBindingImmutable didn't throw");
+  } catch (e) {
+    console.assert(e.name === 'TypeError',
+      'namedFunExpNameBindingImmutable wrong error');
+  }
 };
 
 tests.closureIndependence = function() {

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1248,6 +1248,19 @@ tests.namedFunctionExpression = function() {
     console.assert(e.name === 'TypeError',
       'namedFunExpNameBindingImmutable wrong error');
   }
+
+  f = function foo(foo) {
+    foo += 0.1;  // Verify mutability.
+    return foo;
+  };
+  console.assert(f(76) === 76.1, 'nameFunExpNameBindingShadowedByParam');
+
+  f = function foo() {
+    var foo;
+    foo = 76.2;  // Verify mutability.
+    return foo;
+  };
+  console.assert(f(76) === 76.2, 'nameFunExpNameBindingShadowedByVar');
 };
 
 tests.closureIndependence = function() {

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -38,7 +38,7 @@ const testcases = require('./testcases');
 
 // Prepare static interpreter instance for runTest.
 var interpreter = getInterpreter();
-interpreter.addVariableToScope(interpreter.global, 'src');
+interpreter.global.createMutableBinding('src');
 
 /**
  * Run a simple test of the interpreter.  Only a single Interpreter
@@ -165,10 +165,10 @@ async function runAsyncTest(t, name, src, expected, initFunc, sideFunc) {
   // called.
   var resolve, reject, result;
   var p = new Promise(function(res, rej) { resolve = res; reject = rej; });
-  intrp.addVariableToScope(intrp.global, 'resolve',
-      intrp.createNativeFunction('resolve', resolve));
-  intrp.addVariableToScope(intrp.global, 'reject',
-      intrp.createNativeFunction('reject', reject));
+  intrp.global.createMutableBinding(
+      'resolve', intrp.createNativeFunction('resolve', resolve));
+  intrp.global.createMutableBinding(
+      'reject', intrp.createNativeFunction('reject', reject));
 
   try {
     intrp.createThreadForSrc(src);
@@ -657,7 +657,7 @@ exports.testAsync = function(t) {
   // resolve/reject callbacks and first arg in test-local variables.
   var resolve, reject, arg;
   var initFunc = function(intrp) {
-    intrp.addVariableToScope(intrp.global, 'async', new intrp.NativeFunction({
+    intrp.global.createMutableBinding('async', new intrp.NativeFunction({
       name: 'async', length: 0,
       call: function(intrp, thread, state, thisVal, args) {
         arg = args[0];
@@ -1172,7 +1172,7 @@ exports.testNetworking = async function(t) {
       send();
    `;
   var initFunc = function(intrp) {
-    intrp.addVariableToScope(intrp.global, 'send', intrp.createNativeFunction(
+    intrp.global.createMutableBinding('send', intrp.createNativeFunction(
         'send', function() {
           // Send some data to server.
           var client = net.createConnection({ port: 8888 }, function() {
@@ -1199,7 +1199,7 @@ exports.testNetworking = async function(t) {
       CC.connectionUnlisten(8888);
    `;
   initFunc = function(intrp) {
-    intrp.addVariableToScope(intrp.global, 'receive', new intrp.NativeFunction({
+    intrp.global.createMutableBinding('receive', new intrp.NativeFunction({
       name: 'receive', length: 0,
       call: function(intrp, thread, state, thisVal, args) {
         var reply = '';

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -173,10 +173,10 @@ async function runAsyncTest(t, name, src1, src2, expected, initFunc) {
   // called.
   var resolve, reject, result;
   var p = new Promise(function(res, rej) { resolve = res; reject = rej; });
-  intrp1.addVariableToScope(intrp1.global, 'resolve',
-      intrp1.createNativeFunction('resolve', resolve));
-  intrp1.addVariableToScope(intrp1.global, 'reject',
-      intrp1.createNativeFunction('reject', reject));
+  intrp1.global.createMutableBinding(
+      'resolve', intrp1.createNativeFunction('resolve', resolve));
+  intrp1.global.createMutableBinding(
+      'reject', intrp1.createNativeFunction('reject', reject));
 
   try {
     intrp1.start();
@@ -208,10 +208,10 @@ async function runAsyncTest(t, name, src1, src2, expected, initFunc) {
 
   // New promise.
   p = new Promise(function(res, rej) { resolve = res; reject = rej; });
-  intrp2.addVariableToScope(intrp2.global, 'resolve',
-      intrp2.createNativeFunction('resolve', resolve));
-  intrp2.addVariableToScope(intrp2.global, 'reject',
-      intrp2.createNativeFunction('reject', reject));
+  intrp2.global.createMutableBinding(
+      'resolve', intrp2.createNativeFunction('resolve', resolve));
+  intrp2.global.createMutableBinding(
+      'reject', intrp2.createNativeFunction('reject', reject));
 
   try {
     Serializer.deserialize(JSON.parse(json), intrp2);
@@ -380,7 +380,7 @@ exports.testRoundtripAsync = async function(t) {
       send();
    `;
   var initFunc = function(intrp) {
-    intrp.addVariableToScope(intrp.global, 'send', intrp.createNativeFunction(
+    intrp.global.createMutableBinding('send', intrp.createNativeFunction(
         'send', function() {
           // Send some data to server.
           var client = net.createConnection({ port: 8888 }, function() {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -168,7 +168,7 @@ module.exports = [
     `,
     expected: 'myVarDeclFunc' },
 
-  { name: 'fExpWithParameter', src: `
+  { name: 'funExpWithParameter', src: `
     var v;
     var f = function(x) { v = x; };
     f(50);
@@ -828,29 +828,39 @@ module.exports = [
     expected: 75 },
 
   { name: 'namedFunctionExpression', src: `
-    var f = function foo(x) {
+    var f = function half(x) {
       if (x < 100) {
         return x;
       }
-      return foo(x / 2);
+      return half(x / 2);
     };
     f(152)
     `,
     expected: 76 },
 
-  { name: 'namedFunExpNoLeak', src: `
+  { name: 'namedFunExpNameBinding', src: `
+    var f = function foo() {return foo;};
+    f() === f;
+    `,
+    expected: true },
+
+  { name: 'namedFunExpNameBindingNoLeak', src: `
     var f = function foo() {};
     typeof foo;
     `,
     expected: 'undefined' },
 
-  { name: 'namedFunExpSameSame', src: `
+  { name: 'namedFunExpNameBindingImmutable', src: `
     var f = function foo() {
-      return f === foo;
+      try {
+        foo = null;
+      } catch (e) {
+        return e.name;
+      }
     };
     f();
     `,
-    expected: true },
+    expected: 'TypeError' },
 
   { name: 'closureIndependence', src: `
     function makeAdder(x) {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -176,6 +176,12 @@ module.exports = [
     `,
     expected: 50 },
 
+  { name: 'funExpParameterNotShadowedByVar', src: `
+    var f = function(x) { var x; return x; };
+    f(50.1);
+    `,
+    expected: 50.1 },
+
   { name: 'functionWithReturn', src: `
     (function(x) { return x; })(51);
     `,
@@ -861,6 +867,25 @@ module.exports = [
     f();
     `,
     expected: 'TypeError' },
+
+  { name: 'namedFunExpNameBindingShadowedByParam', src: `
+    var f = function foo(foo) {
+      foo += 0.1;  // Verify mutability.
+      return foo;
+    };
+    f(76);
+    `,
+    expected: 76.1 },
+
+  { name: 'namedFunExpNameBindingShadowedByVar', src: `
+    var f = function foo() {
+      var foo;
+      foo = 76.2;  // Verify mutability.
+      return foo;
+    };
+    f();
+    `,
+    expected: 76.2 },
 
   { name: 'closureIndependence', src: `
     function makeAdder(x) {


### PR DESCRIPTION
Do a bit of reorganising of Interpreter.Scope usage to make code structure reflect spec better, then implement a separate outer scope for named function expressions, allowing the name to be immutable but shadow-able.