### PR TITLE
MemberExpression spec compliance

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2562,9 +2562,9 @@ Interpreter.prototype.errorNativeToPseudo = function(err, owner) {
 };
 
 /**
- * Implements the ToObject method from ES5.1 §9.9, but returning
- * temporary Box objects instead of boxed Boolean, Number or String
- * instances.
+ * Implements the ToObject specification method from ES5.1 §9.9 / ES6
+ * §7.1.13, but returning temporary Box objects instead of boxed
+ * Boolean, Number or String instances.
  * @param {Interpreter.Value} value The value to be converted to an Object.
  * @param {!Interpreter.Owner} perms Who is trying convert it?
  * @return {!Interpreter.ObjectLike}

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -6180,7 +6180,12 @@ stepFuncs_['MemberExpression'] = function (thread, stack, state, node) {
   }
   stack.pop();
   if (state.wantRef_) {
-    stack[stack.length - 1].ref = [state.tmp_, key];
+    var base = state.tmp_;
+    if (base === null || base === undefined) {
+      throw new this.Error(perms, this.TYPE_ERROR,
+          "Can't convert " + base + ' to Object');
+    }
+    stack[stack.length - 1].ref = [base, key];
   } else {
     var perms = state.scope.perms;
     stack[stack.length - 1].value =

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -6174,22 +6174,24 @@ stepFuncs_['MemberExpression'] = function (thread, stack, state, node) {
       state.step_ = 2;
       return new Interpreter.State(node['property'], state.scope);
     }
-    var /** string */ key = node['property']['name'];
-  } else {  // state.step_ === 2: Save computed property key.
-    key = String(state.value);
   }
   stack.pop();
+  // TODO(cpcallen): add test for order of following two specification
+  // method calls from the algorithm in ES6 §2.3.2.1.
+  // Step 7: bv = RequireObjectCoercible(baseValue).
+  var /** Interpreter.Value */ base = state.tmp_;
+  if (base === null || base === undefined) {
+    throw new this.Error(perms, this.TYPE_ERROR,
+        "Can't convert " + base + ' to Object');
+  }
+  // Step 9: propertyKey = ToPropertyKey(propertyNameValue).
+  var /** string */ key =
+      node['computed'] ? String(state.value) : node['property']['name'];
   if (state.wantRef_) {
-    var base = state.tmp_;
-    if (base === null || base === undefined) {
-      throw new this.Error(perms, this.TYPE_ERROR,
-          "Can't convert " + base + ' to Object');
-    }
     stack[stack.length - 1].ref = [base, key];
   } else {
     var perms = state.scope.perms;
-    stack[stack.length - 1].value =
-        this.toObject(state.tmp_, perms).get(key, perms);
+    stack[stack.length - 1].value = this.toObject(base, perms).get(key, perms);
   }
 };
 

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1162,7 +1162,7 @@ tests.instanceofNonObjectPrototype = function() {
   }
 };
 
-tests.nulUndefinedProps = function() {
+tests.nullUndefinedProps = function() {
   try {
     undefined.foo;
     console.assert(false, "undefined.foo didn't throw");
@@ -1170,10 +1170,12 @@ tests.nulUndefinedProps = function() {
     console.assert(e.name === 'TypeError', 'undefined.foo wrong error');
   }
   try {
-    undefined.foo = undefined;
+    var c = 0;
+    undefined.foo = c++;
     console.assert(false, "undefined.foo = ... didn't throw");
   } catch (e) {
     console.assert(e.name === 'TypeError', 'undefined.foo = ... wrong error');
+    console.assert(c === 0, 'undefined.foo = ... evaluated RHS');
   }
   try {
     null.foo;
@@ -1182,10 +1184,12 @@ tests.nulUndefinedProps = function() {
     console.assert(e.name === 'TypeError', 'null.foo wrong error');
   }
   try {
-    null.foo = undefined;
+    c = 0;
+    null.foo = c++;
     console.assert(false, "null.foo = ... didn't throw");
   } catch (e) {
     console.assert(e.name === 'TypeError', 'null.foo = ... wrong error');
+    console.assert(c === 0, 'null.foo = ... evaluated RHS');
   }
 };
 

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -770,12 +770,13 @@ module.exports = [
 
   { name: 'undefined.foo = ...', src: `
     try {
-      undefined.foo = undefined;
+      var c = 0;
+      undefined.foo = c++;
     } catch (e) {
-      e.name;
+      e.name + ',' + c;
     }
     `,
-    expected: 'TypeError' },
+    expected: 'TypeError,0' },
 
   { name: 'null.foo', src: `
     try {
@@ -788,12 +789,13 @@ module.exports = [
 
   { name: 'null.foo = ...', src: `
     try {
-      null.foo = undefined;
+      var c = 0;
+      null.foo = c++;
     } catch (e) {
-      e.name;
+      e.name + ',' + c;
     }
     `,
-    expected: 'TypeError' },
+    expected: 'TypeError,0' },
 
   { name: 'deleteProp', src: `
     var o = {foo: 'bar'};


### PR DESCRIPTION
Check for Object coercibility in MemberExpression (and before converting the property key to a string), even if not evaluating the reference yet.

Most other JavaScript engines get this wrong, but [tc39 do not intend to change this part of the spec](https://github.com/tc39/ecma262/issues/467) and it's easy enough to do it correctly.