### PR TITLE
Performance improvments

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -5420,7 +5420,7 @@ Interpreter.StepFunction;
  * that a Map is much slower than a null-parent object (v8 in 2017).
  * @const {Object<string,Interpreter.StepFunction>}
  */
-var stepFuncs_ = {};
+var stepFuncs_ = Object.create(null);
 
 /**
  * @this {!Interpreter}

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3231,7 +3231,6 @@ Interpreter.Source.prototype.lineColForPos = function(pos) {
  * @constructor
  */
 Interpreter.State = function(node, scope, wantRef) {
-  if (!node) return;  // Deserializing
   /** @const @type {!Interpreter.Node} */
   this.node = node;
   /** @const @type {!Interpreter.Scope} */

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -124,6 +124,12 @@ Serializer.deserialize = function(json, intrp) {
       case 'IterableWeakMap':
         obj = new IterableWeakMap;
         break;
+      case 'State':
+        // TODO(cpcallen): this is just a little performance kludge so
+        // that the State constructor doesn't need a conditional in it.
+        // Find a more general solution to constructors requiring args.
+        obj = new Interpreter.State({type: 'Identifier'});
+        break;
       default:
         var protoRef;
         if (constructors[type]) {

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -96,8 +96,8 @@ function runTest(t, name, src1, src2, src3, expected, steps, noBuiltins) {
       var s = 0;
       while(intrp.step()) {
         if ((++s % steps) === 0) {
-            intrp = roundTrip(intrp);
-            trips++;
+          intrp = roundTrip(intrp);
+          trips++;
         }
       }
     }
@@ -253,6 +253,9 @@ exports.testRoundtripSimple = function(t) {
 /**
  * Run a round trip of serializing the Interpreter.SCOPE_REFERENCE
  * sentinel and and an Interpreter.PropertyIterator.
+ *
+ * BUG(#193): running this test causes *subsequent* benchmarks to run
+ *     about 15% slower for no obvious reason.  Investigate.
  * @param {!T} t The test runner object.
  */
 exports.testRoundtripScopeRefAndPropIter = function(t) {


### PR DESCRIPTION
Found two major performance issues:
* Step function lookup is *still* very slow, which probably explains why the interpreter was spending about 25% of its time in the `run` function.  Fixed this by looking up the step function in the `State` constructor, so it only needs to be done once per state object instead of once per step.
* For some reason, one of the serialisation test in the internal test harness somehow poisons node.js's state in a way that causes subsequent benchmarks (not using the same `Interpreter` instance) to run more slowly.  This explains the observed discrepancy between the test harness benchmark and the test db benchmark (which runs in a separate instance of node.js) that has existed for some time.

The poisonous test is useful for maintaining correctness, so I have left it in for now.  The fact that it causes serious performance penalties merits further investigation of the mechanism involved, rather than just tweaking the test until it doesn't; to that end I have filed bug #193.

Best observed performance on Fibonacci benchmark:

Condition | `benchFibbonacci10k` (test harness) | `test_fibonacci10k` (test database)
----------|---------------------------------------|------------------------------------
Before this PR | 2889ms | 2520ms
After this PR | 2307ms | 1909ms
After removing poisonous test | 1967ms | 1985ms