### PR TITLE
Add post-parse "compilation" step

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3263,7 +3263,7 @@ Interpreter.State = function(node, scope, wantRef) {
   /** @const @type {!Interpreter.Scope} */
   this.scope = scope;
   /** @const @type {!Interpreter.StepFunction} */
-  this.stepFunc = stepFuncs_[node['type']];
+  this.stepFunc = node['stepFunc'];
   /** @private @const @type {boolean} */
   this.wantRef_ = wantRef || false;
   /** @type {Interpreter.Value} */

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -128,7 +128,7 @@ Serializer.deserialize = function(json, intrp) {
         // TODO(cpcallen): this is just a little performance kludge so
         // that the State constructor doesn't need a conditional in it.
         // Find a more general solution to constructors requiring args.
-        obj = new Interpreter.State({type: 'Identifier'});
+        obj = new Interpreter.State({});
         break;
       default:
         var protoRef;


### PR DESCRIPTION
Walk the AST after it is created, to populate it with various properties that will be used later—most notably, the step function, so no lookups in `stepFuncs_` will be required at interpretation time.

Brings best ever observed performance on `benchFibbonacci10k` to 1811ms (with `testRoundtripScopeRefAndPropIter` disabled).