### PR TITLE
Make the base of an environment reference be the Scope object containing the referee

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2982,21 +2982,6 @@ Interpreter.FunctionResult.CallAgain = new Interpreter.FunctionResult;
 Interpreter.FunctionResult.Sleep = new Interpreter.FunctionResult;
 
 /**
- * Class for unique sentinel values passed to various functions.
- * Declared so that sentinel values can have a specific type that we
- * can type-check against (though as they share a single type you
- * could still pass the wrong sentinel value to a function).
- * @constructor
- */
-Interpreter.Sentinel = function Sentinel() {};
-
-/**
- * Unique sentinel for indicating that a reference is a variable on the scope,
- * not an object property.
- */
-Interpreter.SCOPE_REFERENCE = new Interpreter.Sentinel();
-
-/**
  * Interpreter statuses.
  * @enum {number}
  */

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3175,9 +3175,6 @@ Interpreter.Scope.prototype.createImmutableBinding = function(name, value) {
  *     prototypes.)
  */
 Interpreter.Scope.prototype.set = function(name, value) {
-  if (!(name in this.vars)) {
-    throw Error(name + ' not defined??');
-  }
   if (this.notWritable.has(name)) {
     return new TypeError('Assignment to constant variable: ' + name);
   }
@@ -3194,9 +3191,6 @@ Interpreter.Scope.prototype.set = function(name, value) {
  *     in this scope.
  */
 Interpreter.Scope.prototype.get = function(name) {
-  if (!(name in this.vars)) {
-    throw Error(name + ' not defined??');
-  }
   return this.vars[name];
 };
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2732,7 +2732,7 @@ Interpreter.prototype.isUnresolvableReference = function(scope, ref, perms) {
 Interpreter.prototype.getValue = function(ref, perms) {
   var base = ref[0];
   var name = ref[1];
-  if (base === null) {  // Unresolvable reference
+  if (base === null) {  // Unresolvable reference.
     throw new this.Error(perms, this.REFERENCE_ERROR, name + ' is not defined');
   } else if (base instanceof Interpreter.Scope) {  // An environment reference.
     return base.get(name);
@@ -2750,7 +2750,7 @@ Interpreter.prototype.getValue = function(ref, perms) {
 Interpreter.prototype.setValue = function(ref, value, perms) {
   var base = ref[0];
   var name = ref[1];
-  if (base === null) {  // Unresolvable reference
+  if (base === null) {  // Unresolvable reference.
     throw new this.Error(perms, this.REFERENCE_ERROR, name + ' is not defined');
   } else if (base instanceof Interpreter.Scope) {  // An environment reference.
     var err = base.set(name, value);
@@ -3205,9 +3205,9 @@ Interpreter.Scope.prototype.get = function(name) {
  */
 Interpreter.Scope.prototype.resolve = function(name) {
   for (var s = this; s; s = s.outerScope) {
-    if (name in s.vars) break;
+    if (name in s.vars) return s;
   }
-  return s;
+  return null;
 };
 /**
  * Source is an encapsulated hunk of source text.  Source objects can

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3174,6 +3174,23 @@ Interpreter.Scope.prototype.createImmutableBinding = function(name, value) {
 };
 
 /**
+ * Searches through this scope and its outer scopes to find a binding
+ * for name, and returns the scope containing that binding or null if
+ * name is not bound.
+ *
+ * Based on the Identifier Resolution algorithm of ES5.1 §10.3.1, or
+ * equivalently the ResolveBinding specification function from ES6
+ * §8.3.1.
+ * @param {string} name Name of variable.
+ * @return {?Interpreter.Scope} The scope that binds name, or null if none.
+ */
+Interpreter.Scope.prototype.resolve = function(name, value) {
+  for (var s = this; s; s = s.outerScope) {
+    if (name in s.vars) break;
+  }
+  return s;
+};
+/**
  * Source is an encapsulated hunk of source text.  Source objects can
  * be sliced to obtain a Source object representing a substring of the
  * original source text.  Such sliced objects "remember" their

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3121,8 +3121,8 @@ Interpreter.Scope.prototype.hasBinding = function(name) {
 };
 
 /**
- * Creates a mutable binding in the given scope and initialises it to
- * undefined or the provided valued.
+ * Creates a mutable binding in this scope and initialises it to
+ * undefined or the provided value.
  *
  * Based on CreateMutableBinding for declarative environment records,
  * from ES5.1 §10.2.1.1.2 / ES6 §8.1.1.1.2.
@@ -3137,8 +3137,8 @@ Interpreter.Scope.prototype.createMutableBinding = function(name, value) {
 };
 
 /**
- * Creates an immutable binding in the given scope and initialises it
- * to the provided valued.
+ * Creates an immutable binding in this scope and initialises it
+ * to the provided value.
  *
  * Based on CreateImmutableBinding for declarative environment records,
  * from ES5.1 §10.2.1.1.7 / ES6 §8.1.1.1.3.
@@ -3151,6 +3151,46 @@ Interpreter.Scope.prototype.createImmutableBinding = function(name, value) {
   }
   this.vars[name] = value;
   this.notWritable.add(name);
+};
+
+/**
+ * Updates a mutable binding in this scope to the the provided value.
+ *
+ * Based on SetMutableBinding for declarative environment records,
+ * from ES5.1 §10.2.1.1.3 / ES6 §8.1.1.1.5.
+ * @param {string} name Name of variable.
+ * @param {Interpreter.Value} value New value to set it to.
+ * @return {Error|undefined} If an error occurs, a (native) Error
+ *     object is returned.  It shoud be converted into a user error
+ *     (e.g., by errorNativeToPseudo) and thrown.  (This is done
+ *     because Scope is not an inner class of interpreter, and thus
+ *     this method has no access to the Error constructor or error
+ *     prototypes.)
+ */
+Interpreter.Scope.prototype.set = function(name, value) {
+  if (!(name in this.vars)) {
+    throw Error(name + ' not defined??');
+  }
+  if (this.notWritable.has(name)) {
+    return new TypeError('Assignment to constant variable: ' + name);
+  }
+  this.vars[name] = value;
+};
+
+/**
+ * Returns the value of a binding in this scope.
+ *
+ * Based on GetBindingValue for declarative environment records, from
+ * ES5.1 §10.2.1.1.4 / ES6 §8.1.1.1.6.
+ * @param {string} name Name of variable.
+ * @return {Interpreter.Value} The current value of the named variable
+ *     in this scope.
+ */
+Interpreter.Scope.prototype.get = function(name) {
+  if (!(name in this.vars)) {
+    throw Error(name + ' not defined??');
+  }
+  return this.vars[name];
 };
 
 /**

--- a/server/serialize.js
+++ b/server/serialize.js
@@ -97,9 +97,6 @@ Serializer.deserialize = function(json, intrp) {
       case 'Object':
         obj = {};
         break;
-      case 'ScopeReference':
-        obj = Interpreter.SCOPE_REFERENCE;
-        break;
       case 'Function':
         obj = functionHash[jsonObj['id']];
         if (!obj) {
@@ -310,15 +307,7 @@ Serializer.serialize = function(intrp) {
         continue;  // No need to index properties.
       default:
         var type = types.get(proto);
-        if (type === 'Sentinel') {
-          switch (obj) {
-            case Interpreter.SCOPE_REFERENCE:
-              jsonObj['type'] = 'ScopeReference';
-              break;
-            default:
-              throw new Error("Unknown sentinel value encountered");
-          }
-        } else if (type) {
+        if (type) {
           jsonObj['type'] = type;
         } else {
           jsonObj['proto'] = encodeValue(proto);
@@ -421,7 +410,6 @@ Serializer.getTypesDeserialize_ = function (intrp) {
   return {
     'Interpreter': Interpreter,
     'Scope': Interpreter.Scope,
-    'Sentinel': Interpreter.Sentinel,
     'State': Interpreter.State,
     'Thread': Interpreter.Thread,
     'PropertyIterator': Interpreter.PropertyIterator,

--- a/server/tests/interpreter_unit_test.js
+++ b/server/tests/interpreter_unit_test.js
@@ -153,6 +153,9 @@ exports.testScope = function(t) {
   t.expect("inner.hasBinding('foo') [1]", inner.hasBinding('foo'), false);
   t.expect("outer.resolve('foo') [1]", outer.resolve('foo'), outer);
   t.expect("inner.resolve('foo') [1]", inner.resolve('foo'), outer);
+  t.expect("outer.get('foo') [1]", outer.get('foo'), 42);
+  t.expect("getValueFromScope(outer, 'foo', ...) [1]",
+      intrp.getValueFromScope(outer, 'foo', intrp.ROOT), 42);
   t.expect("getValueFromScope(inner, 'foo', ...) [1]",
       intrp.getValueFromScope(inner, 'foo', intrp.ROOT), 42);
 
@@ -164,7 +167,8 @@ exports.testScope = function(t) {
   }
 
   // 2: Set outer binding.
-  intrp.setValueToScope(inner, 'foo', 69, intrp.ROOT);
+  outer.set('foo', 69, intrp.ROOT, intrp);
+  t.expect("outer.get('foo') [2]", outer.get('foo'), 69);
   t.expect("getValueFromScope(inner, 'foo', ...) [2]",
       intrp.getValueFromScope(inner, 'foo', intrp.ROOT), 69);
   t.expect("getValueFromScope(outer, 'foo', ...) [2]",
@@ -176,23 +180,29 @@ exports.testScope = function(t) {
   t.expect("inner.hasBinding('foo') [3]", inner.hasBinding('foo'), true);
   t.expect("outer.resolve('foo') [3]", outer.resolve('foo'), outer);
   t.expect("inner.resolve('foo') [3]", inner.resolve('foo'), inner);
+  t.expect("outer.get('foo') [3]", outer.get('foo'), 69);
+  t.expect("inner.get('foo') [3]", inner.get('foo'), 105);
   t.expect("getValueFromScope(inner, 'foo', ...) [3]",
       intrp.getValueFromScope(inner, 'foo', intrp.ROOT), 105);
   t.expect("getValueFromScope(outer, 'foo', ...) [3]",
       intrp.getValueFromScope(outer, 'foo', intrp.ROOT), 69);
 
+  // 4: Try to create duplicate binding.
   try {
-    inner.createImmutableBinding('foo', 105);
-    t.fail("inner.createImmutableBinding('foo', ...) [3]", "Didn't throw.");
+    outer.createMutableBinding('foo', 17);
+    t.fail("outer.createMutableBinding('foo', ...) [4]", "Didn't throw.");
   } catch (e) {
-    t.pass("inner.createImmutableBinding('foo', ...) [3]");
+    t.pass("outer.createMutableBinding('foo', ...) [4]");
   }
 
+  // 5: Try to set immutable binding (two different ways)
+  t.assert("inner.set('foo', 37) instanceof TypeError",
+           inner.set('foo', 37) instanceof TypeError);
   try {
-    intrp.setValueToScope(inner, 'foo', 17, intrp.ROOT);
-    t.fail("setValueToScope(inner, 'foo', ...) [3]", "Didn't throw.");
+    intrp.setValueToScope(inner, 'foo', 37, intrp.ROOT);
+    t.fail("setValueToScope(inner, 'foo', 37, ...) [5]", "Didn't throw.");
   } catch (e) {
-    t.pass("setValueToScope(inner, 'foo', ...) [3]");
+    t.pass("setValueToScope(inner, 'foo', 37, ...) [5]");
   }
 };
 

--- a/server/tests/interpreter_unit_test.js
+++ b/server/tests/interpreter_unit_test.js
@@ -144,11 +144,15 @@ exports.testScope = function(t) {
 
   // 0: Initial condition.
   t.expect("outer.hasBinding('foo') [0]", outer.hasBinding('foo'), false);
+  t.expect("outer.resolve('foo') [0]", outer.resolve('foo'), null);
+  t.expect("inner.resolve('foo') [0]", inner.resolve('foo'), null);
 
   // 1: Create outer binding.
   outer.createMutableBinding('foo', 42);
   t.expect("outer.hasBinding('foo') [1]", outer.hasBinding('foo'), true);
   t.expect("inner.hasBinding('foo') [1]", inner.hasBinding('foo'), false);
+  t.expect("outer.resolve('foo') [1]", outer.resolve('foo'), outer);
+  t.expect("inner.resolve('foo') [1]", inner.resolve('foo'), outer);
   t.expect("getValueFromScope(inner, 'foo', ...) [1]",
       intrp.getValueFromScope(inner, 'foo', intrp.ROOT), 42);
 
@@ -170,6 +174,8 @@ exports.testScope = function(t) {
   inner.createImmutableBinding('foo', 105);
   t.expect("outer.hasBinding('foo') [3]", outer.hasBinding('foo'), true);
   t.expect("inner.hasBinding('foo') [3]", inner.hasBinding('foo'), true);
+  t.expect("outer.resolve('foo') [3]", outer.resolve('foo'), outer);
+  t.expect("inner.resolve('foo') [3]", inner.resolve('foo'), inner);
   t.expect("getValueFromScope(inner, 'foo', ...) [3]",
       intrp.getValueFromScope(inner, 'foo', intrp.ROOT), 105);
   t.expect("getValueFromScope(outer, 'foo', ...) [3]",


### PR DESCRIPTION
Until now, references have been stored as [_base_, _name_] pairs, where _base_ is an object (or primitive) in the case of a property reference or the `SCOPE_REFERENCE` sentinel value in the case of an environment reference.

The spec describes environment references as having their _base_ value be the environment record (i.e., `Scope` object) in which _name_ is actually found; the search through the linked list of environment records (i.e., `Scope` objects) is done at the time the reference is created rather than when it is used, and unresolvable references are represented as having _base_ be undefined.

This PR changes our reference values to accord with the spec.  This has a few benefits:
* It isn't necessary to pass the current innermost `Scope` to `getValue` and `setValue`.
* Evaluating an expressions like `n++` and `a += b` does not entail searching for the variable being updated twice.
* We can eliminate `SCOPE_REFERENCE` and the `Sentinel` class (which also simplifies the serializer).

This change appears to be performance-neutral for the `benchFibbonacci10k` benchmark (or at least within the noise margin).

This work also lead to the discovery of a bunch of problems with property references with scalar bases and MemberExpression which were fixed in PR #191.