### PR TITLE
Formalise builtins registry

### DIFF
--- a/server/compile.flag
+++ b/server/compile.flag
@@ -38,6 +38,7 @@ node_modules/weak/**.js
 
 iterable_weakmap.js
 iterable_weakset.js
+registry.js
 interpreter.js
 serialize.js
 codecity.js

--- a/server/iterable_weakmap.js
+++ b/server/iterable_weakmap.js
@@ -43,9 +43,6 @@ const weak = require('weak');
 
 /**
  * Declared to quiet closure-compiler warnings.
- * @param {!WeakRef<T>} ref
- * @return {T}
- * @template T
  */
 weak.get;
 

--- a/server/iterable_weakset.js
+++ b/server/iterable_weakset.js
@@ -43,9 +43,6 @@ const weak = require('weak');
 
 /**
  * Declared to quiet closure-compiler warnings.
- * @param {!WeakRef<T>} ref
- * @return {T}
- * @template T
  */
 weak.get;
 

--- a/server/registry.js
+++ b/server/registry.js
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Code City: Registry
+ *
+ * Copyright 2018 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview The Registry class, for e.g. registering built-ins.
+ * @author cpcallen@google.com (Christohper Allen)
+ */
+'use strict';
+
+/**
+ * Class for a registry provinding a bidirectional mapping between
+ * string-valued keys and arbitrary values.
+ * @constructor
+ * @template T
+ */
+class Registry {
+  constructor() {
+    /** @private @const @type {!Object<string, T>} */
+    this.values_ = Object.create(null);
+    /** @private @const @type {!Map<T, string>} */
+    this.keys_ = new Map();
+  }
+
+  /**
+   * Look up a registered value.  Throws an error if the given key has
+   * not been registered.
+   * @param {string} key The key to get the registered value for.
+   * @return {T} The registered value.
+   */
+  get(key) {
+    if (!this.has(key)) {
+      throw Error('Key "' + key + '" not registered');
+    }
+    return this.values_[key];
+  }
+
+  /**
+   * Look up the key for a registered value.  Throws an error if the
+   * given value has not been registered.  If the value has been
+   * registered with more than one key then one of those keys will be
+   * returned but there is no guarantee which.
+   * @param {T} value The value to get the key for.
+   * @return {string} The key for value, or undefined if value never registered.
+   */
+  getKey(value) {
+    if (!this.keys_.has(value)) {
+      throw Error('Value ' + value + ' not registered');
+    }
+    return this.keys_.get(value);
+  }
+
+  /**
+   * Check if a key exists in the registry.
+   * @param {string} key The key to check.
+   * @return {boolean} True iff key has previously been registered.
+   */
+  has(key) {
+    return key in this.values_;
+  }
+
+  /**
+   * Register a value.  Throws an error if the given key has already
+   * been used for a previous registration.
+   * @param {string} key The key to register value with.
+   * @param {T} value The value to be registered.
+   */
+  set(key, value) {
+    if (key in this.values_) {
+      throw Error('Key "' + key + '" already registered');
+    }
+    this.values_[key] = value;
+    this.keys_.set(value, key);
+  }
+}
+
+module.exports = Registry;

--- a/server/tests/registry_test.js
+++ b/server/tests/registry_test.js
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Code City: Registry tests
+ *
+ * Copyright 2018 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Unit tests for the Registry class.
+ * @author cpcallen@google.com (Christopher Allen)
+ */
+'use strict';
+
+const Registry = require('../registry');
+const {T} = require('./testing');
+
+/**
+ * Unit tests for the Interpreter.Registry class.
+ * @param {!T} t The test runner object.
+ */
+exports.testRegistry = function(t) {
+  const reg = new Registry;
+  const obj = {};
+  
+  // 0: Initial condition.
+  t.expect("reg.has('foo') [0]", reg.has('foo'), false);
+  try {
+    reg.get('foo');
+    t.fail("reg.get('foo') [0]", "Didn't throw.");
+  } catch(e) {
+    t.pass("reg.get('foo') [0]");
+  }
+  try {
+    reg.getKey(obj);
+    t.fail("reg.getKey(obj) [0]", "Didn't throw.");
+  } catch(e) {
+    t.pass("reg.getKey(obj) [0]");
+  }
+
+  // 1: Register obj as 'foo'.
+  reg.set('foo', obj);
+  t.expect("reg.has('foo') [1]", reg.has('foo'), true);
+  t.expect("reg.get('foo') [1]", reg.get('foo'), obj);
+  t.expect("reg.getKey(obj) [1]", reg.getKey(obj), 'foo');
+
+  // 2: Register another object as 'foo'.
+  try {
+    reg.set('foo', {});
+    t.fail("reg.set('foo', {}) [2]", "Didn't throw.");
+  } catch(e) {
+    t.pass("reg.set('foo', {}) [2]");
+  }
+  t.expect("reg.has('foo') [2]", reg.has('foo'), true);
+  t.expect("reg.get('foo') [2]", reg.get('foo'), obj);
+  t.expect("reg.getKey(obj) [2]", reg.getKey(obj), 'foo');
+  try {
+    reg.getKey({});
+    t.fail("reg.getKey({}) [2]", "Didn't throw.");
+  } catch(e) {
+    t.pass("reg.getKey({}) [2]");
+  }
+};


### PR DESCRIPTION
Database dumper will need to be able to look up the names of builtins, so create a Registry class providing bidirectional mapping and use it for .builtins_ (which loses the underscore, because it will need to be public).