### PR TITLE
Actually compile tests

### DIFF
--- a/server/compile.flag
+++ b/server/compile.flag
@@ -9,6 +9,9 @@
 --externs=externs/node_externs.js
 --externs=externs/weak_externs.js
 
+node_modules/buffer/package.json
+node_modules/buffer/buffer.js
+
 node_modules/events/package.json
 node_modules/events/events.js
 

--- a/server/externs/buffer/buffer.js
+++ b/server/externs/buffer/buffer.js
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Code City: Closure Compiler externs for node.js
+ *
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Fake implementation of node.js's buffer module to
+ *     satisfy Closure Compiler dependencies.  This is mostly an
+ *     excerpt from contrib/nodejs/buffer.js from
+ *     https://github.com/google/closure-compiler.git
+ * @author cpcallen@google.com (Christopher Allen)
+ */
+
+// TODO(cpcallen): Use official externs directly.
+
+/** @constructor */
+var Buffer = function() {};
+
+module.exports = Buffer;

--- a/server/externs/buffer/package.json
+++ b/server/externs/buffer/package.json
@@ -1,0 +1,5 @@
+{
+  "description": "Fake package.json for require('buffer')",
+  "main": "buffer.js",
+  "name": "buffer",
+}

--- a/server/externs/events/events.js
+++ b/server/externs/events/events.js
@@ -29,4 +29,18 @@ var events = {};
 /** @constructor */
 events.EventEmitter = function() {};
 
+/**
+ * @param {string} event
+ * @param {function(...)} listener
+ * @return {events.EventEmitter}
+ */
+events.EventEmitter.prototype.on = function(event, listener) {};
+
+/**
+ * @param {string} event
+ * @param {function(...)} listener
+ * @return {events.EventEmitter}
+ */
+events.EventEmitter.prototype.once = function(event, listener) {};
+
 module.exports = events;

--- a/server/externs/fs/fs.js
+++ b/server/externs/fs/fs.js
@@ -27,9 +27,7 @@
 
 // TODO(cpcallen): Use official externs directly.
 
-// TODO(cpcallen): Factor this out to a separate buffer module extern.
-/** @constructor */
-var Buffer = function() {};
+var Buffer = require('buffer');
 
 /** @const */
 var fs = {};

--- a/server/externs/net/net.js
+++ b/server/externs/net/net.js
@@ -23,9 +23,27 @@
  * @author cpcallen@google.com (Christopher Allen)
  */
 
+var Buffer = require('buffer');
 var events = require('events');
 
 var net = {};
+
+/**
+ * @typedef {{port: (number|undefined),
+ *            host: (string|undefined),
+ *            localAddress: (string|undefined),
+ *            path: (string|undefined),
+ *            allowHalfOpen: (boolean|undefined)}}
+ */
+net.ConnectOptions;
+
+/**
+ * @param {net.ConnectOptions|number|string} arg1
+ * @param {(function(...)|string)=} arg2
+ * @param {function(...)=} arg3
+ * @return {!net.Socket}
+ */
+net.createConnection = function(arg1, arg2, arg3) {};
 
 ///////////////////////////////////////////////////////////////////////////////
 // net.Server
@@ -73,5 +91,12 @@ net.Server.prototype.on = function(event, listener) {};
  */
 net.Socket = function(options) {};
 
+/**
+ * @param {string|Buffer} data
+ * @param {(string|function(...))=} encoding
+ * @param {function(...)=} callback
+ * @return {void}
+ */
+net.Socket.prototype.write = function(data, encoding, callback) {};
 
 module.exports = net;

--- a/server/externs/node_externs.js
+++ b/server/externs/node_externs.js
@@ -36,6 +36,9 @@ var __dirname;
 /** @type {!Object} */
 var exports;
 
+/** @param {boolean=} full */
+var gc = function(full) {};
+
 /** @type {!Object} */
 var module;
 

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -38,18 +38,9 @@ acorn.plugins.alwaysStrict = function(parser, configValue) {
 };
 
 /**
- * @typedef {{
- *     noLog: (!Array<string>|undefined),
- *     trimEval: (boolean|undefined),
- *     trimProgram: (boolean|undefined),
- * }}
- */
-var InterpreterOptions;
-
-/**
  * Create a new interpreter.
  * @constructor
- * @param {!InterpreterOptions=} options
+ * @param {!Interpreter.Options=} options
  */
 var Interpreter = function(options) {
   this.options = options || {};
@@ -2983,6 +2974,16 @@ Interpreter.FunctionResult.CallAgain = new Interpreter.FunctionResult;
  * @const
  */
 Interpreter.FunctionResult.Sleep = new Interpreter.FunctionResult;
+
+/**
+ * Options object for Interpreter constructor.
+ * @typedef {{
+ *     noLog: (!Array<string>|undefined),
+ *     trimEval: (boolean|undefined),
+ *     trimProgram: (boolean|undefined),
+ * }}
+ */
+Interpreter.Options;
 
 /**
  * Interpreter statuses.

--- a/server/node_modules/buffer
+++ b/server/node_modules/buffer
@@ -1,0 +1,1 @@
+../externs/buffer

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -73,7 +73,7 @@ function runTest(t, name, src, expected) {
  * @param {string} src The code to be evaled.
  * @param {number|string|boolean|null|undefined} expected The expected
  *     completion value.
- * @param {!InterpreterOptions=} options Interpreter constructor options.
+ * @param {!Interpreter.Options=} options Interpreter constructor options.
  * @param {boolean=} init Load the standard startup files (Default: true.)
  */
 function runCustomTest(t, name, src, expected, options, init) {
@@ -166,9 +166,9 @@ async function runAsyncTest(t, name, src, expected, initFunc, sideFunc) {
   var resolve, reject, result;
   var p = new Promise(function(res, rej) { resolve = res; reject = rej; });
   intrp.global.createMutableBinding(
-      'resolve', intrp.createNativeFunction('resolve', resolve));
+      'resolve', intrp.createNativeFunction('resolve', resolve, false));
   intrp.global.createMutableBinding(
-      'reject', intrp.createNativeFunction('reject', reject));
+      'reject', intrp.createNativeFunction('reject', reject, false));
 
   try {
     intrp.createThreadForSrc(src);
@@ -650,6 +650,7 @@ exports.testAeca = function(t) {
 /**
  * Run a test of asynchronous functions:
  * @param {!T} t The test runner object.
+ * @suppress {visibility}
  */
 exports.testAsync = function(t) {
   // Function to install an async NativeFunction on new Interpreter

--- a/server/tests/interpreter_unit_test.js
+++ b/server/tests/interpreter_unit_test.js
@@ -98,9 +98,9 @@ exports.testNativeToPseudo = function(t) {
   var arr = [];
   for (var k in props) {
     if (!props.hasOwnProperty(k)) continue;
-    arr[k] = props[k];
+    arr[/** @type{?} */(k)] = props[k];
   }
-  var pArr = intrp.nativeToPseudo(arr);
+  var pArr = intrp.nativeToPseudo(arr, intrp.ROOT);
   for (var k in props) {
     if (!props.hasOwnProperty(k)) continue;
     var name = 'testNativeToPseudo(array)["' + k + '"]';
@@ -123,7 +123,7 @@ exports.testNativeToPseudo = function(t) {
     var name = 'testNativeToPseudo(' + Err.prototype.name + ')';
     var errName, errMessage = 'test ' + Err.prototype.name;
     var error = Err(errMessage);
-    var pError = intrp.nativeToPseudo(error);
+    var pError = intrp.nativeToPseudo(error, intrp.ROOT);
 
     t.expect(name + ' instanceof intrp.Error',
         pError instanceof intrp.Error, true);
@@ -155,9 +155,9 @@ exports.testScope = function(t) {
   t.expect("inner.resolve('foo') [1]", inner.resolve('foo'), outer);
   t.expect("outer.get('foo') [1]", outer.get('foo'), 42);
   t.expect("getValueFromScope(outer, 'foo', ...) [1]",
-      intrp.getValueFromScope(outer, 'foo', intrp.ROOT), 42);
+      intrp.getValueFromScope(outer, 'foo'), 42);
   t.expect("getValueFromScope(inner, 'foo', ...) [1]",
-      intrp.getValueFromScope(inner, 'foo', intrp.ROOT), 42);
+      intrp.getValueFromScope(inner, 'foo'), 42);
 
   try {
     outer.createMutableBinding('foo', 42);
@@ -167,12 +167,12 @@ exports.testScope = function(t) {
   }
 
   // 2: Set outer binding.
-  outer.set('foo', 69, intrp.ROOT, intrp);
+  outer.set('foo', 69);
   t.expect("outer.get('foo') [2]", outer.get('foo'), 69);
   t.expect("getValueFromScope(inner, 'foo', ...) [2]",
-      intrp.getValueFromScope(inner, 'foo', intrp.ROOT), 69);
+      intrp.getValueFromScope(inner, 'foo'), 69);
   t.expect("getValueFromScope(outer, 'foo', ...) [2]",
-      intrp.getValueFromScope(outer, 'foo', intrp.ROOT), 69);
+      intrp.getValueFromScope(outer, 'foo'), 69);
 
   // 3: Create inner binding.
   inner.createImmutableBinding('foo', 105);
@@ -183,9 +183,9 @@ exports.testScope = function(t) {
   t.expect("outer.get('foo') [3]", outer.get('foo'), 69);
   t.expect("inner.get('foo') [3]", inner.get('foo'), 105);
   t.expect("getValueFromScope(inner, 'foo', ...) [3]",
-      intrp.getValueFromScope(inner, 'foo', intrp.ROOT), 105);
+      intrp.getValueFromScope(inner, 'foo'), 105);
   t.expect("getValueFromScope(outer, 'foo', ...) [3]",
-      intrp.getValueFromScope(outer, 'foo', intrp.ROOT), 69);
+      intrp.getValueFromScope(outer, 'foo'), 69);
 
   // 4: Try to create duplicate binding.
   try {
@@ -199,7 +199,7 @@ exports.testScope = function(t) {
   t.assert("inner.set('foo', 37) instanceof TypeError",
            inner.set('foo', 37) instanceof TypeError);
   try {
-    intrp.setValueToScope(inner, 'foo', 37, intrp.ROOT);
+    intrp.setValueToScope(inner, 'foo', 37);
     t.fail("setValueToScope(inner, 'foo', 37, ...) [5]", "Didn't throw.");
   } catch (e) {
     t.pass("setValueToScope(inner, 'foo', 37, ...) [5]");

--- a/server/tests/run.js
+++ b/server/tests/run.js
@@ -24,8 +24,27 @@
  */
 'use strict';
 
-// Force compilation of server (for syntax/type checking):
-const server = require('../codecity');
+// Force closure-compiler to compile server and testst/benchmarks (for
+// syntax/type checking).  Server could be compiled separately but
+// it's faster to have do both in one run.  Tests and benchmark files
+// need to be enumerated explicitly because closure-compiler ignores
+// require statements with arguments that are not a string literal.
+const compileTargets = [
+  require('../codecity'),
+
+  require('./interpreter_test'),
+  require('./interpreter_unit_test'),
+  require('./interpreter_test'),
+  require('./iterable_weakmap_test'),
+  require('./iterable_weakset_test'),
+  require('./registry_test'),
+  require('./serialize_test'),
+
+  require('./interpreter_bench'),
+  require('./serialize_bench'),
+];
+
+// Force compilation of tests/benchmarks (for synta
 
 const fs = require('fs');
 const {T, B} = require('./testing');
@@ -38,6 +57,9 @@ async function runBenchmarks(files) {
   for (var i = 0; i < files.length; i++) {
     var benchmarks = require(files[i]);
     var b = new B;
+    if (compileTargets.indexOf(benchmarks) === -1) {
+      b.result('WARN', files[i] + ' is not being checked by closure-compiler');
+    }
     for (var k in benchmarks) {
       if (k.startsWith('bench') && typeof benchmarks[k] === 'function') {
         try {
@@ -59,6 +81,9 @@ async function runTests(files) {
 
   for (var i = 0; i < files.length; i++) {
     var tests = require(files[i]);
+    if (compileTargets.indexOf(tests) === -1) {
+      t.result('WARN', files[i] + ' is not being checked by closure-compiler');
+    }
     for (var k in tests) {
       if (k.startsWith('test') && typeof tests[k] === 'function') {
         try {

--- a/server/tests/run.js
+++ b/server/tests/run.js
@@ -57,7 +57,7 @@ async function runBenchmarks(files) {
   for (var i = 0; i < files.length; i++) {
     var benchmarks = require(files[i]);
     var b = new B;
-    if (compileTargets.indexOf(benchmarks) === -1) {
+    if (!compileTargets.includes(benchmarks)) {
       b.result('WARN', files[i] + ' is not being checked by closure-compiler');
     }
     for (var k in benchmarks) {
@@ -81,7 +81,7 @@ async function runTests(files) {
 
   for (var i = 0; i < files.length; i++) {
     var tests = require(files[i]);
-    if (compileTargets.indexOf(tests) === -1) {
+    if (!compileTargets.includes(tests)) {
       t.result('WARN', files[i] + ' is not being checked by closure-compiler');
     }
     for (var k in tests) {

--- a/server/tests/serialize_test.js
+++ b/server/tests/serialize_test.js
@@ -74,7 +74,7 @@ function roundTrip(intrp) {
  *     Speeds up tests with many roundtrips that do not need builtins.
  */
 function runTest(t, name, src1, src2, src3, expected, steps, noBuiltins) {
-  var intrp = noBuiltins ? new Interpreter :  intrp = getInterpreter();
+  var intrp = noBuiltins ? new Interpreter : getInterpreter();
   try {
     if (src1) {
       var thread = intrp.createThreadForSrc(src1).thread;
@@ -174,9 +174,9 @@ async function runAsyncTest(t, name, src1, src2, expected, initFunc) {
   var resolve, reject, result;
   var p = new Promise(function(res, rej) { resolve = res; reject = rej; });
   intrp1.global.createMutableBinding(
-      'resolve', intrp1.createNativeFunction('resolve', resolve));
+      'resolve', intrp1.createNativeFunction('resolve', resolve, false));
   intrp1.global.createMutableBinding(
-      'reject', intrp1.createNativeFunction('reject', reject));
+      'reject', intrp1.createNativeFunction('reject', reject, false));
 
   try {
     intrp1.start();
@@ -209,9 +209,9 @@ async function runAsyncTest(t, name, src1, src2, expected, initFunc) {
   // New promise.
   p = new Promise(function(res, rej) { resolve = res; reject = rej; });
   intrp2.global.createMutableBinding(
-      'resolve', intrp2.createNativeFunction('resolve', resolve));
+      'resolve', intrp2.createNativeFunction('resolve', resolve, false));
   intrp2.global.createMutableBinding(
-      'reject', intrp2.createNativeFunction('reject', reject));
+      'reject', intrp2.createNativeFunction('reject', reject, false));
 
   try {
     Serializer.deserialize(JSON.parse(json), intrp2);
@@ -366,8 +366,8 @@ exports.testRoundtripAsync = async function(t) {
 
   //  Run a test of the server re-listening to sockets after being
   //  deserialized.
-  var name = 'testPostRestoreNetworkInbound';
-  var src1 = `
+  name = 'testPostRestoreNetworkInbound';
+  src1 = `
       var data = '', conn = {};
       conn.onReceive = function(d) {
         data += d;
@@ -379,7 +379,7 @@ exports.testRoundtripAsync = async function(t) {
       CC.connectionListen(8888, conn);
       resolve();
    `;
-  var src2 = `
+  src2 = `
       send();
    `;
   var initFunc = function(intrp) {


### PR DESCRIPTION
It turns out that although the changes made in PR #200 resulted in run.js and a few other files being compiled, closure-compiler was ignoring all the _test.js and _bench.js files because they were loaded dynamically and it only looks at require calls which have a string literal argument.

The fix is inelegant but should be reasonably robust.