### PR TITLE
Fix compiler warnings

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1115,7 +1115,8 @@ Interpreter.prototype.initArray_ = function() {
         if (obj.has(String(k), perms)) {
           var v = obj.get(String(k), perms);
           if (v === searchElement ||
-              (Number.isNaN(v) && Number.isNaN(searchElement))) {
+              (Number.isNaN(/** @type{?} */(v)) &&
+               Number.isNaN(/** @type{?} */(searchElement)))) {
             return true;
           }
         }


### PR DESCRIPTION
`closure-compiler` thinks that the arguments to `Number.isNaN` should (like those to most other `Number` functions) be a number.  But actually any type is fine, and exactly what we want here, tell it not to worry.