### PR TITLE
Fix bug in eval

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -555,7 +555,7 @@ Interpreter.prototype.initBuiltins_ = function() {
       intrp.populateScope_(ast, scope);
       thread.stateStack_[thread.stateStack_.length] =
           new Interpreter.State(ast, scope);
-      state.value = undefined;  // Default value if no explicit return.
+      thread.value = undefined;  // Default value if no explicit return.
       return Interpreter.FunctionResult.AwaitValue;
     }
   });

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -555,7 +555,7 @@ Interpreter.prototype.initBuiltins_ = function() {
       intrp.populateScope_(ast, scope);
       thread.stateStack_[thread.stateStack_.length] =
           new Interpreter.State(ast, scope);
-      thread.value = undefined;  // Default value if no explicit return.
+      thread.value = undefined;  // In case no ExpressionStatements evaluated.
       return Interpreter.FunctionResult.AwaitValue;
     }
   });

--- a/server/tests/db/test_01_es5.js
+++ b/server/tests/db/test_01_es5.js
@@ -1408,6 +1408,14 @@ tests.evalNoLeakingDecls = function() {
   console.assert(typeof n === 'undefined', 'evalNoLeakingDecls');
 };
 
+tests.evalEmptyBlock = function() {
+  // A bug in eval would cause it to return the value of the
+  // previously-evaluated ExpressionStatement if the eval program did
+  // not contain any ExpressionStatements.
+  'fail';
+  console.assert(eval('{}') === undefined, 'evalEmptyBlock');
+};
+
 tests.callEvalOrder = function() {
   var r = "";
   function log(x) {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1053,6 +1053,15 @@ module.exports = [
     `,
     expected: 'undefined' },
 
+  // A bug in eval would cause it to return the value of the
+  // previously-evaluated ExpressionStatement if the eval program did
+  // not contain any ExpressionStatements.
+  { name: 'evalEmptyBlock', src: `
+    'fail';
+    eval('{}');
+    `,
+    expected: undefined },
+  
   { name: 'callEvalOrder', src: `
     var r = "";
     function log(x) {


### PR DESCRIPTION
Fix a bug in eval which would cause it to return the value of the most recent previous ExpressionStatement if the eval program did not contain any ExpressionStatements.