### PR TITLE
Set RegExp and Date value at construction time

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1811,9 +1811,8 @@ Interpreter.prototype.initDate_ = function() {
     }
     // Called as new Date().
     var args = [null].concat(Array.from(arguments));
-    var date = new intrp.Date(intrp.thread.perms());
-    date.date = new (Function.prototype.bind.apply(Date, args));
-    return date;
+    var date = new (Function.prototype.bind.apply(Date, args));
+    return new intrp.Date(date, intrp.thread.perms());
   };
   this.createNativeFunction('Date', wrapper, true);
 
@@ -3860,10 +3859,11 @@ Interpreter.prototype.Array = function(owner, proto) {
 /**
  * @constructor
  * @extends {Interpreter.prototype.Object}
+ * @param {!Date} date
  * @param {?Interpreter.Owner=} owner
  * @param {?Interpreter.prototype.Object=} proto
  */
-Interpreter.prototype.Date = function(owner, proto) {
+Interpreter.prototype.Date = function(date, owner, proto) {
   /** @type {!Date} */
   this.date;
   throw Error('Inner class constructor not callable on prototype');
@@ -4846,14 +4846,16 @@ Interpreter.prototype.installTypes = function() {
    * Class for a date.
    * @constructor
    * @extends {Interpreter.prototype.Date}
+   * @param {!Date} date Date value for this Date object.
    * @param {?Interpreter.Owner=} owner Owner object or null.
    * @param {?Interpreter.prototype.Object=} proto Prototype object or null.
    */
-  intrp.Date = function(owner, proto) {
+  intrp.Date = function(date, owner, proto) {
+    if (!date) return;  // Deserializing
     intrp.Object.call(/** @type {?} */ (this), owner,
         (proto === undefined ? intrp.DATE : proto));
     /** @type {Date} */
-    this.date = null;
+    this.date = date;
   };
 
   intrp.Date.prototype = Object.create(intrp.Object.prototype);

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2406,7 +2406,7 @@ Interpreter.prototype.createNativeFunction = function(
  * all standard native types), and handles additional properties on
  * arrays, regexps and errors (just as for plain objects).  Ignores
  * prototype and inherited properties.  Efficiently handles
- * sparse arrays.  Does NOT handle cyclic
+ * sparse arrays.  Does NOT handle cyclic structures.
  * @param {*} nativeObj The native JS object to be converted.
  * @return {Interpreter.Value} The equivalent JS interpreter object.
  * @param {!Interpreter.Owner} owner Owner for new object.


### PR DESCRIPTION
Since `Date` and `RegExp` object are immutable in ES5.1, set their internal values in the constructor.

I've also inlined the former `intrp.RegExp.prototype.populate` method into the `intrp.RegExp` constructor—but I note that, in ES6, `RegExp.prototype.compile` was added to Appendix B, making RegExps internal state mutable.  If we intend to support that then we should probably keep `.populate` as its own method for now.