### PR TITLE
Add ‘inspect’ command to every $.physical

### DIFF
--- a/demo/core_10_base.js
+++ b/demo/core_10_base.js
@@ -210,8 +210,20 @@ $.physical.lookJssp.jssp = [
   '  </tr>',
   '</table>'].join('\n');
 
+$.physical.inspect = function(cmd) {
+  // Open this object in the code editor.
+  // TODO: Deal with selectors that include '#' (part of a bigger problem).
+  var link = '/code?' + $.utils.selector.getSelector(this);
+  user.writeJson({type: "link", href: link});
+};
+$.physical.inspect.verb = 'inspect';
+$.physical.inspect.dobj = 'this';
+$.physical.inspect.prep = 'none';
+$.physical.inspect.iobj = 'none';
+
 $.physical.getCommands = function(who) {
-  return ['look ' + this.name];
+  return ['look ' + this.name,
+          'inspect ' + this.name];
 };
 
 $.physical.tell = function(json) {

--- a/demo/core_10_base.js
+++ b/demo/core_10_base.js
@@ -212,8 +212,7 @@ $.physical.lookJssp.jssp = [
 
 $.physical.inspect = function(cmd) {
   // Open this object in the code editor.
-  // TODO: Deal with selectors that include '#' (part of a bigger problem).
-  var link = '/code?' + $.utils.selector.getSelector(this);
+  var link = '/code?' + encodeURIComponent($.utils.selector.getSelector(this));
   user.writeJson({type: "link", href: link});
 };
 $.physical.inspect.verb = 'inspect';

--- a/static/client/log.js
+++ b/static/client/log.js
@@ -377,6 +377,18 @@ CCC.Log.renderJson = function(json) {
       div.appendChild(document.createTextNode(text));
       CCC.Common.autoHyperlink(div);
       return div;
+    case 'link':
+      // {type: "link", href: "https://example.com/"}
+      var div = document.createElement('div');
+      var a = document.createElement('a');
+      a.href = json.href;
+      a.target = '_blank';
+      a.appendChild(document.createTextNode(json.href));
+      div.appendChild(a);
+      // Note: this opens the link in a new tab regardless of whether the user
+      // is in world or log view.
+      window.open(json.href);
+      return div;
   }
   // Unknown XML.
   return undefined;

--- a/static/code/code.js
+++ b/static/code/code.js
@@ -33,7 +33,7 @@ Code.DEFAULT = '$';
  * E.g. '$.foo["bar"]'
  */
 Code.selector = location.search ?
-    decodeURI(location.search.substring(1)) : Code.DEFAULT;
+    decodeURIComponent(location.search.substring(1)) : Code.DEFAULT;
 
 /**
  * Got a ping from someone.  Check sessionStorage to see if selector has
@@ -49,7 +49,8 @@ Code.receiveMessage = function(event) {
   Code.selector = selector;
   if (event) {
     // Change the URL if this is NOT the result of a forwards/back navigation.
-    history.pushState(selector, selector, '/code?' + encodeURI(selector));
+    history.pushState(selector, selector,
+                      '/code?' + encodeURIComponent(selector));
   }
   // Propagate the ping down the tree of frames.
   try {

--- a/static/code/explorer.js
+++ b/static/code/explorer.js
@@ -623,7 +623,7 @@ Code.Explorer.addPanel = function(component) {
   var panelsScroll = document.getElementById('panelsScroll');
   var iframe = document.createElement('iframe');
   iframe.id = 'objectPanel' + Code.Explorer.panelCount;
-  iframe.src = '/static/code/objectPanel.html#' + encodeURI(component);
+  iframe.src = '/static/code/objectPanel.html#' + encodeURIComponent(component);
   iframe.setAttribute('data-component', component);
   var spacer = document.getElementById('panelSpacer');
   panelsScroll.insertBefore(iframe, spacer);

--- a/static/code/objectPanel.js
+++ b/static/code/objectPanel.js
@@ -96,7 +96,7 @@ Code.ObjectPanel.addLink = function(part, type, section) {
   var newParts = Code.ObjectPanel.parts.concat(part);
   var selector = Code.Common.partsToSelector(newParts);
   var a = document.createElement('a');
-  a.href = '/code?' + encodeURI(selector);
+  a.href = '/code?' + encodeURIComponent(selector);
   a.target = '_blank';
   a.setAttribute('data-link', JSON.stringify(part));
   a.addEventListener('click', Code.ObjectPanel.click);
@@ -223,7 +223,7 @@ Code.ObjectPanel.caseInsensitiveComp = function(a, b) {
   document.head.appendChild(script);
 
   // Fill in the object name.
-  Code.ObjectPanel.parts = JSON.parse(decodeURI(hash));
+  Code.ObjectPanel.parts = JSON.parse(decodeURIComponent(hash));
   var div = document.getElementById('objectTitle');
   var lastPart = Code.ObjectPanel.parts[Code.ObjectPanel.parts.length - 1];
   var name;


### PR DESCRIPTION
Opens the code editor.

Attempts to reuse existing windows were not successful.  At issue is that if a window is already open (as a tab), there is no way to switch to that tab from JS.  The API window.focus() doesn't function in Chrome or Firefox.  Thus 'inspect' would just do nothing and the user would have to go hunting for the right tab.

Thus I'm just opening a fresh window every time.