### PR TITLE
Move eval call out of eval verb.

### DIFF
--- a/demo/core_10_base.js
+++ b/demo/core_10_base.js
@@ -402,56 +402,58 @@ $.user.think.dobj = 'any';
 $.user.think.prep = 'any';
 $.user.think.iobj = 'any';
 
-$.user.eval = function($$$cmd) {
+$.user.eval = function(cmd) {
   // Format:  ;1+1    -or-    eval 1+1
-  // To reduce the likelihood of clashes with identifiers in the evaled
-  // code, this function has only a single, awkwardly-named parameter
-  // and has no local variables of its own.  Conversely, however, we
-  // create a few local variables with short, convenient names as
-  // aliases for commonly-used values.
-  $$$cmd =
-      ($$$cmd.cmdstr[0] === ';') ? $$$cmd.cmdstr.substring(1) : $$$cmd.argstr;
-  $$$cmd = $.utils.code.rewriteForEval($$$cmd);
+  var src = (cmd.cmdstr[0] === ';') ? cmd.cmdstr.substring(1) : cmd.argstr;
+  src = $.utils.code.rewriteForEval(src);
+  var out;
   try {
-    var me = this;
-    var here = this.location;
-    $$$cmd = eval($$$cmd);
+    // Can't
+    out = this.eval.doEval_(src);
     try {
       // Attempt to print a source-legal representation.
-      $$$cmd = $.utils.code.toSource($$$cmd);
+      out = $.utils.code.toSource(out);
     } catch (e) {
       try {
         // Maybe it's something JSON can deal with (like an array).
-        $$$cmd = JSON.stringify($$$cmd);
+        out = JSON.stringify(out);
       } catch (e) {
         try {
           // Maybe it's a recursive data structure.
-          $$$cmd = String($$$cmd);
+          out = String(out);
         } catch (e) {
           // Maybe it's Object.create(null).
-          $$$cmd = '[Unprintable value]';
+          out = '[Unprintable value]';
         }
       }
     }
   } catch (e) {
     if (e instanceof Error) {
-      $$$cmd = String(e.name);
+      out = String(e.name);
       if (e.message) {
-        $$$cmd += ': ' + String(e.message);
+        out += ': ' + String(e.message);
       }
       if (e.stack) {
-        $$$cmd += '\n' + e.stack;
+        out += '\n' + e.stack;
       }
     } else {
-      $$$cmd = 'Unhandled exception: ' + String(e);
+      out = 'Unhandled exception: ' + String(e);
     }
   }
-  user.narrate('⇒ ' + $$$cmd);
+  user.narrate('⇒ ' + out);
 };
 $.user.eval.verb = 'eval|;.*';
 $.user.eval.dobj = 'any';
 $.user.eval.prep = 'any';
 $.user.eval.iobj = 'any';
+
+$.user.eval.doEval_ = function($$$src) {
+  // Execute eval in a scope with minimal variables.
+  var me = this;
+  var here = this.location;
+  return eval($$$src);
+};
+
 
 $.user.edit = function(cmd) {
   var url = $.www.editor.edit(cmd.iobj, cmd.iobjstr, cmd.dobjstr);

--- a/demo/core_10_base.js
+++ b/demo/core_10_base.js
@@ -409,7 +409,7 @@ $.user.eval = function(cmd) {
   var out;
   try {
     // Can't
-    out = this.eval.doEval_(src);
+    out = this.eval.doEval_(src, this, this.location);
     try {
       // Attempt to print a source-legal representation.
       out = $.utils.code.toSource(out);
@@ -447,10 +447,8 @@ $.user.eval.dobj = 'any';
 $.user.eval.prep = 'any';
 $.user.eval.iobj = 'any';
 
-$.user.eval.doEval_ = function($$$src) {
+$.user.eval.doEval_ = function($$$src, me, here) {
   // Execute eval in a scope with minimal variables.
-  var me = this;
-  var here = this.location;
   return eval($$$src);
 };
 

--- a/demo/core_10_base.js
+++ b/demo/core_10_base.js
@@ -448,7 +448,9 @@ $.user.eval.prep = 'any';
 $.user.eval.iobj = 'any';
 
 $.user.eval.doEval_ = function($$$src, me, here) {
-  // Execute eval in a scope with minimal variables.
+  // Execute eval in a scope with no variables.
+  // The '$$$src' parameter is awkwardly-named so as not to collide with user
+  // evaled code.  The 'me' and 'here' parameters are exposed to the user.
   return eval($$$src);
 };
 

--- a/static/code/common.js
+++ b/static/code/common.js
@@ -71,17 +71,17 @@ Code.Common.tokenizeSelector = function(text) {
     var index = whitespaceLength + i;
     if (state === null) {
       if (char === "'") {
-        Code.Common.pushUnparsed(buffer, index, tokens);
+        Code.Common.pushUnparsed_(buffer, index, tokens);
         state = 'sqStr';
       } else if (char === '"') {
-        Code.Common.pushUnparsed(buffer, index, tokens);
+        Code.Common.pushUnparsed_(buffer, index, tokens);
         state = 'dqStr';
       } else {
         buffer.push(char);
       }
     } else if (state === 'sqStr') {
       if (char === "'") {
-        Code.Common.pushString("'", buffer, index, tokens);
+        Code.Common.pushString_("'", buffer, index, tokens);
         state = null;
       } else {
         buffer.push(char);
@@ -91,7 +91,7 @@ Code.Common.tokenizeSelector = function(text) {
       }
     } else if (state === 'dqStr') {
       if (char === '"') {
-        Code.Common.pushString('"', buffer, index, tokens);
+        Code.Common.pushString_('"', buffer, index, tokens);
         state = null;
       } else {
         buffer.push(char);
@@ -110,9 +110,9 @@ Code.Common.tokenizeSelector = function(text) {
   if (state !== null) {
     // Convert state into quote type.
     var quotes = (state === 'sqStr' || state === 'sqSlash') ? "'" : '"';
-    Code.Common.pushString(quotes, buffer, index + 1, tokens);
+    Code.Common.pushString_(quotes, buffer, index + 1, tokens);
   } else if (buffer.length) {
-    Code.Common.pushUnparsed(buffer, index + 1, tokens);
+    Code.Common.pushUnparsed_(buffer, index + 1, tokens);
   }
 
   // Second step is to parse each 'unparsed' token and split out '[',  ']' and
@@ -271,8 +271,9 @@ Code.Common.tokenizeSelector = function(text) {
  * @param {!Array<string>} buffer Array of chars that make the string.
  * @param {number} index Char index of start of this token in original input.
  * @param {!Array<!Object>} tokens List of tokens.
+ * @private
  */
-Code.Common.pushString = function(quotes, buffer, index, tokens) {
+Code.Common.pushString_ = function(quotes, buffer, index, tokens) {
   var token = {
     type: 'str',
     raw: quotes + buffer.join('') + quotes,
@@ -301,8 +302,9 @@ Code.Common.pushString = function(quotes, buffer, index, tokens) {
  * @param {!Array<string>} buffer Array of chars that make the value.
  * @param {number} index Character index of this token in original input.
  * @param {!Array<!Object>} tokens List of tokens.
+ * @private
  */
-Code.Common.pushUnparsed = function(buffer, index, tokens) {
+Code.Common.pushUnparsed_ = function(buffer, index, tokens) {
   var raw = buffer.join('');
   buffer.length = 0;
   if (raw) {


### PR DESCRIPTION
Simplify code by isolating the eval() call in a minimal function.