### PR TITLE
WIP: Dumper

### DIFF
--- a/server/compile.flag
+++ b/server/compile.flag
@@ -46,4 +46,5 @@ interpreter.js
 serialize.js
 code.js
 selector.js
+dump.js
 codecity.js

--- a/server/dump.js
+++ b/server/dump.js
@@ -656,4 +656,5 @@ exports.dump = dump;
 // For unit testing only!
 exports.testOnly = {
   Dumper: Dumper,
+  BindingInfo: BindingInfo,
 }

--- a/server/dump.js
+++ b/server/dump.js
@@ -55,7 +55,7 @@ var SpecEntry;
  */
 var ContentEntry = function() {};
 
-/** 
+/**
  * Path is a string like "eval", "Object.prototype" or
  * "$.util.command" identifying the variable or property binding this
  * entry applies to.
@@ -155,6 +155,7 @@ var Config = function(spec) {
       contents: [],
       rest: Boolean(se.rest)
     };
+    this.entries.push(entry);
     if (se.contents) {
       for (var i = 0; i < se.contents.length; i++) {
         var sc = se.contents[i];
@@ -164,6 +165,7 @@ var Config = function(spec) {
         } else {
           content = {path: sc.path, do: sc.do, reorder: Boolean(sc.reorder)};
         }
+        entry.contents.push(content);
         var parts = toParts(content.path);
         var /** ?ConfigNode */ cn = this.tree;
         for (var j = 0; j < parts.length; j++) {
@@ -182,8 +184,52 @@ var Config = function(spec) {
   }
 };
 
+/**
+ * Dump-state information for a single scope.
+ * @constructor
+ * @param {!Interpreter.Scope} scope The scope to keep state for.
+ */
+function ScopeInfo(scope) {
+  this.scope = scope;
+}
+
+/**
+ * Dump-state information for a single object.
+ * @constructor
+ * @param {!Interpreter.prototype.Object} obj The object to keep state for.
+ */
+function ObjectInfo(obj) {
+  this.obj = obj;
+}
+
 var dump = function(intrp, spec) {
   var config = new Config(spec);
+  var /** !Map<!Interpreter.Scope,!ScopeInfo> */ scopeInfo = new Map;
+  var /** !Map<!Interpreter.prototype.Object,!ObjectInfo> */ objInfo = new Map;
+
+  /**
+   * Get interned ScopeInfo for sope.
+   * @param {!Interpreter.Scope} scope The scope to get info for.
+   * @return {!ScopeInfo} The ScopeInfo for scope.
+   */
+  function getScopeInfo(scope) {
+    if (scopeInfo.has(scope)) return scopeInfo.get(scope);
+    var si = new ScopeInfo(scope);
+    scopeInfo.set(scope, si);
+    return si;
+  }
+
+  /**
+   * Get interned ObjectInfo for sope.
+   * @param {!Interpreter.prototype.Object} obj The object to get info for.
+   * @return {!ObjectInfo} The ObjectInfo for obj.
+   */
+  function getObjectInfo(obj) {
+    if (objInfo.has(obj)) return objInfo.get(obj);
+    var oi = new ObjectInfo(obj);
+    objInfo.set(obj, oi);
+    return oi;
+  }
 
 };
 

--- a/server/dump.js
+++ b/server/dump.js
@@ -170,7 +170,7 @@ Dumper.prototype.toExpr = function(value, selector) {
   } else if (value instanceof intrp.Date) {
     return this.dateToExpr(value);
   } else if (value instanceof intrp.RegExp) {
-    return this.regExpToExpr(value);
+    return this.regExpToExpr(value, info);
   } else {
     return this.objectToExpr(value);
   }
@@ -303,9 +303,19 @@ Dumper.prototype.dateToExpr = function(date) {
 /**
  * Get a source text representation of a given RegExp object.
  * @param {!Interpreter.prototype.RegExp} re RegExp to be recreated.
+ * @param {!ObjectInfo} info Dump-state info about arr.
  * @return {string} An eval-able representation of obj.
  */
-Dumper.prototype.regExpToExpr = function(re) {
+Dumper.prototype.regExpToExpr = function(re, info) {
+  // Some properties are implicitly pre-set.
+  info.done['source'] = Do.SET;
+  info.done['global'] = Do.SET;
+  info.done['ignoreCase'] = Do.SET;
+  info.done['multiline'] = Do.SET;
+  // Can skip .lastIndex iff it is 0.
+  if (re.get('lastIndex', this.intrp.ROOT) === 0) {
+    info.done['lastIndex'] = Do.SET;
+  }
   return re.regexp.toString();
 };
 

--- a/server/dump.js
+++ b/server/dump.js
@@ -349,15 +349,15 @@ Dumper.prototype.dumpBinding = function(selector, todo) {
 
   // Begin with var if declaring a variable.
   if (doDecl && selector.isVar()) output.push('var ');
-  // Mention name we are declaring / initializing (if we are doing either).
-  if (doDecl || doInit) output.push(selector.toExpr());
-  // Add initialiser.
   if (doInit) {
     var value = this.getValueForSelector(selector);
-    output.push(' = ', this.toExpr(value, selector));
-  } else if (doDecl && !selector.isVar()) {
-    // Can't "declare" a property, but can make sure it exists.
-    output.push(' = undefined');
+    output.push(selector.toSetExpr(this.toExpr(value, selector)));
+  } else if (doDecl) {
+    if (selector.isVar()) {
+      output.push(selector.toExpr());
+    } else {  // Can't "declare" a property, but can make sure it exists.
+      output.push(selector.toSetExpr('undefined'));
+    }
   }
   // End line if non-empty.
   if (output.length > 0) output.push(';\n');

--- a/server/dump.js
+++ b/server/dump.js
@@ -212,6 +212,7 @@ var Config = function(spec) {
  */
 function ScopeInfo(scope) {
   this.scope = scope;
+  this.done /** !Object<string, Do> */ = Object.create(null);
 }
 
 /**
@@ -223,34 +224,48 @@ function ObjectInfo(obj) {
   this.obj = obj;
 }
 
+/**
+ * Dumper encapsulates all the state required to keep track of what
+ * has and hasn't yet been written when dumping an Interpreter.
+ * @constructor
+ * @param {!Interpreter} intrp
+ * @param {!Array<SpecEntry>} spec
+ */
+var Dumper = function(intrp, spec) {
+  this.config = new Config(spec);
+  /** @type {!Map<!Interpreter.Scope,!ScopeInfo>} */
+  this.scopeInfo = new Map;
+  /** @type {!Map<!Interpreter.prototype.Object,!ObjectInfo>} */
+  this.objInfo = new Map;
+};
+
+/**
+ * Get interned ScopeInfo for sope.
+ * @param {!Interpreter.Scope} scope The scope to get info for.
+ * @return {!ScopeInfo} The ScopeInfo for scope.
+ */
+Dumper.prototype.getScopeInfo = function(scope) {
+  if (this.scopeInfo.has(scope)) return this.scopeInfo.get(scope);
+  var si = new ScopeInfo(scope);
+  this.scopeInfo.set(scope, si);
+  return si;
+};
+
+/**
+ * Get interned ObjectInfo for sope.
+ * @param {!Interpreter.prototype.Object} obj The object to get info for.
+ * @return {!ObjectInfo} The ObjectInfo for obj.
+ */
+Dumper.prototype.getObjectInfo = function(obj) {
+  if (this.objInfo.has(obj)) return this.objInfo.get(obj);
+  var oi = new ObjectInfo(obj);
+  this.objInfo.set(obj, oi);
+  return oi;
+};
+
 var dump = function(intrp, spec) {
-  var config = new Config(spec);
-  var /** !Map<!Interpreter.Scope,!ScopeInfo> */ scopeInfo = new Map;
-  var /** !Map<!Interpreter.prototype.Object,!ObjectInfo> */ objInfo = new Map;
-
-  /**
-   * Get interned ScopeInfo for sope.
-   * @param {!Interpreter.Scope} scope The scope to get info for.
-   * @return {!ScopeInfo} The ScopeInfo for scope.
-   */
-  function getScopeInfo(scope) {
-    if (scopeInfo.has(scope)) return scopeInfo.get(scope);
-    var si = new ScopeInfo(scope);
-    scopeInfo.set(scope, si);
-    return si;
-  }
-
-  /**
-   * Get interned ObjectInfo for sope.
-   * @param {!Interpreter.prototype.Object} obj The object to get info for.
-   * @return {!ObjectInfo} The ObjectInfo for obj.
-   */
-  function getObjectInfo(obj) {
-    if (objInfo.has(obj)) return objInfo.get(obj);
-    var oi = new ObjectInfo(obj);
-    objInfo.set(obj, oi);
-    return oi;
-  }
+  var dumper = new Dumper(intrp, spec);
+  
 
 };
 

--- a/server/dump.js
+++ b/server/dump.js
@@ -329,9 +329,7 @@ Dumper.prototype.dumpBinding = function(selector, todo) {
   var /** string */ name;
 
   // Find info for scope/object on which we will be creating a binding.
-  if (selector.length < 1) {
-    throw RangeError("Can't bind nothing");
-  } else if (selector.length === 1) {
+  if (selector.isVar()) {
     name = selector[0];
     info = this.getScopeInfo(this.scope);
   } else {
@@ -350,14 +348,14 @@ Dumper.prototype.dumpBinding = function(selector, todo) {
   var doInit = (todo >= Do.SET && done < Do.SET);
 
   // Begin with var if declaring a variable.
-  if (doDecl && selector.length === 1) output.push('var ');
+  if (doDecl && selector.isVar()) output.push('var ');
   // Mention name we are declaring / initializing (if we are doing either).
   if (doDecl || doInit) output.push(selector.toExpr());
   // Add initialiser.
   if (doInit) {
     var value = this.getValueForSelector(selector);
     output.push(' = ', this.toExpr(value, selector));
-  } else if (doDecl && selector.length > 1) {
+  } else if (doDecl && !selector.isVar()) {
     // Can't "declare" a property, but can make sure it exists.
     output.push(' = undefined');
   }

--- a/server/dump.js
+++ b/server/dump.js
@@ -332,11 +332,14 @@ Dumper.prototype.getObjectInfo = function(obj) {
  * specified by selector.  If selector does not correspond to a valid
  * binding an error is thrown.
  * @param {!Selector} selector A selector, specifiying a binding.
+ * @param {!Interpreter.Scope=} scope Scope which selector is relative
+ *     to.  Defaults to global scope.
  * @return {Interpreter.Value} The value of that binding.
  */
-Dumper.prototype.getValueForSelector = function(selector) {
+Dumper.prototype.getValueForSelector = function(selector, scope) {
   if (selector.length < 1) throw RangeError('Zero-length selector??');
-  var v = this.intrp.global.get(selector[0]);
+  if (!scope) scope = this.intrp.global;
+  var v = scope.get(selector[0]);
   for (var i = 1; i < selector.length; i++) {
     var key = selector[i];
     if (!(v instanceof this.intrp.Object)) {

--- a/server/dump.js
+++ b/server/dump.js
@@ -340,15 +340,14 @@ Dumper.prototype.dumpBinding = function(parts, todo) {
     info = this.getObjectInfo(obj);
     var propName = parts[parts.length - 1];
     info.done[propName] = (todo === Do.DECL) ? Do.DECL : Do.SET;
-    if (todo === Do.DECL) {
-      // Can't "declare" a property, but can make sure it exists.
-      line.push(' = undefined');
-    }
   }
   line.push(fromParts(parts));
 
-  // Add initialiser if not just declaring.
-  if (todo >= Do.SET) {
+  if (todo === Do.DECL && parts.length > 1) {
+    // Can't "declare" a property, but can make sure it exists.
+    line.push(' = undefined');
+  } else if (todo >= Do.SET) {
+    // Add initialiser.
     var value = this.getValueForParts(parts);
     line.push(' = ', this.toExpr(value, parts));
   }

--- a/server/dump.js
+++ b/server/dump.js
@@ -24,7 +24,8 @@
  */
 'use strict';
 
-const Interpreter = require('./interpreter.js');
+var code = require('./code');
+var Interpreter = require('./interpreter');
 
 /**
  * Break a selector into an array of parts.
@@ -261,6 +262,32 @@ Dumper.prototype.getObjectInfo = function(obj) {
   var oi = new ObjectInfo(obj);
   this.objInfo.set(obj, oi);
   return oi;
+};
+
+/**
+ * Get a source text representation of a given primitive value.
+ * @param {undefined|null|boolean|number|string} value Primitive JS value.
+ * @return {string} An eval-able representation of the value.
+ */
+var primitiveToSource = function(value) {
+  switch (typeof value) {
+    case 'undefined':
+    case 'boolean':
+      return String(value);
+    case 'number':
+      // TODO(cpcallen): is this correct?  See
+      //     https://stackoverflow.com/q/51202901
+      if (Object.is(value, -0)) return '-0';
+      return String(value);
+    case 'string':
+      return code.quote(value);
+    default:
+      if (value === null) {
+        return 'null';
+      } else {
+        throw TypeError('primitiveToSource called on non-primitive value');
+      }
+  }
 };
 
 var dump = function(intrp, spec) {

--- a/server/dump.js
+++ b/server/dump.js
@@ -305,23 +305,28 @@ Dumper.prototype.getValueForParts = function(parts) {
  * @return {string} An eval-able representation of the value.
  */
 Dumper.prototype.toExpr = function(value) {
-  if (value instanceof Interpreter.prototype.Object) {
-    var oi = this.getObjectInfo(value);
-
-    // TODO(cpcallen): implement references.
-
-    // Object not yet created.
-    // TODO(cpcallen): check class.
-    switch (value.proto) {
-      case this.intrp.OBJECT:
-        return '{}';
-      case null:
-        return 'Object.create(null)';
-      default:
-        return 'Object.create(' + this.toExpr(value.proto) + ')';
-    }
-  } else {
+  var intrp = this.intrp;
+  if (!(value instanceof intrp.Object)) {
     return this.primitiveToExpr(value);
+  }
+
+  // TODO(cpcallen): implement references.
+
+  // Object not yet referenced.  Is it a builtin?
+  var key = intrp.builtins.getKey(value);
+  if (key) return 'new ' + quote(key);
+
+  // Object not yet created.
+  if (value instanceof intrp.Function) {
+    return this.functionToExpr(value);
+  } else if (value instanceof intrp.Array) {
+    return this.arrayToExpr(value);
+  } else if (value instanceof intrp.Date) {
+    return this.dateToExpr(value);
+  } else if (value instanceof intrp.RegExp) {
+    return this.regExpToExpr(value);
+  } else {
+    return this.objectToExpr(value);
   }
 };
 
@@ -367,6 +372,63 @@ Dumper.prototype.primitiveToExpr = function(value) {
         throw TypeError('primitiveToSource called on non-primitive value');
       }
   }
+};
+
+/**
+ * Get a source text representation of a given Object.  May or may not
+ * include all properties, etc.
+ * @param {!Interpreter.prototype.Object} obj Object to be recreated.
+ * @return {string} An eval-able representation of obj.
+ */
+Dumper.prototype.objectToExpr = function(obj) {
+  switch (obj.proto) {
+    case this.intrp.OBJECT:
+      return '{}';
+    case null:
+      return 'Object.create(null)';
+    default:
+      return 'Object.create(' + this.toExpr(obj.proto) + ')';
+  }
+};
+
+/**
+ * Get a source text representation of a given Function object.
+ * @param {!Interpreter.prototype.Function} func Function object to be
+ *     recreated.
+ * @return {string} An eval-able representation of obj.
+ */
+Dumper.prototype.functionToExpr = function(func) {
+  if (!(func instanceof this.intrp.UserFunction)) {
+    throw Error('Unable to dump non-UserFunction');
+  }
+  return func.toString();
+};
+
+/**
+ * Get a source text representation of a given Array object.
+ * @param {!Interpreter.prototype.Array} arr Array object to be recreated.
+ * @return {string} An eval-able representation of obj.
+ */
+Dumper.prototype.arrayToExpr = function(arr) {
+  return '[]';
+};
+
+/**
+ * Get a source text representation of a given Date object.
+ * @param {!Interpreter.prototype.Date} date Date object to be recreated.
+ * @return {string} An eval-able representation of obj.
+ */
+Dumper.prototype.dateToExpr = function(date) {
+  return "new Date('" + date.date.toISOString() + "')";
+};
+
+/**
+ * Get a source text representation of a given RegExp object.
+ * @param {!Interpreter.prototype.RegExp} re RegExp to be recreated.
+ * @return {string} An eval-able representation of obj.
+ */
+Dumper.prototype.regExpToExpr = function(re) {
+  return re.regexp.toString();
 };
 
 /**

--- a/server/dump.js
+++ b/server/dump.js
@@ -64,37 +64,8 @@ var ContentEntry = function() {};
 ContentEntry.prototype.path;
 
 /**
- * Do is one of 'prune', 'defer', 'decl', 'set', 'recurse' (default:
- * 'recurse'), specifying what should be done for the specified path.
- * The choices are:
- *
- * - 'prune' will skip the named binding entirely (unless it or an
- *    extension of it is explicitly mentioned in a later config
- *    directive); if the data accessible via the named binding is not
- *    accessible via any other (non-pruned) path from the global scope
- *    it will consequently not be included in the dump.  This option is
- *    intended to cause data loss, so be careful!
- *
- * - 'defer' will skip the named binding for now, but it will be
- *   included in the file with rest: true.
- *
- * - 'decl' will ensure that the specified path exists, but will leave
- *   the value undefined.  If the path is a property, it will not
- *   (yet) be made non-configurable.
- *
- * - 'set' will do what 'decl' does and then ensure that the specified
- *   path is set to its final value (if primitive) or an object of the
- *   correct class (if non-primitive).  It will also ensure the final
- *   property attributes (enumerable, writable and/or configurable)
- *   are set.  If a new object is created to be the value of the
- *   specified path it will not (yet) have its properties or internal
- *   set/map data set (but immutable internal data, such as function
- *   code, must be set at this time).
- *
- * - 'recurse' will do what 'set' does and then additionally do the
- *   same, recursively, to properties and set/map data of the object
- *   which is the value of the specified path.
- * @type {string}
+ * Do is what to to do with the specified path.
+ * @type {Do}
  */
 ContentEntry.prototype.do;
 
@@ -114,6 +85,56 @@ ContentEntry.prototype.do;
  * @type {boolean|undefined}
  */
 ContentEntry.prototype.reorder;
+
+/**
+ * Possible things to do (or have done) with a variable / property
+ * binding.
+ * @enum {number}
+ */
+var Do = {
+  /** 
+   * Skip the named binding entirely (unless it or an extension of it
+   * is explicitly mentioned in a later config directive); if the data
+   * accessible via the named binding is not accessible via any other
+   * (non-pruned) path from the global scope it will consequently not
+   * be included in the dump.  This option is intended to cause data
+   * loss, so be careful!
+   */
+  PRUNE: 1,
+  
+  /**
+   * Skip the named binding for now, but include it in a later file
+   * (whichever has rest: true).
+   */
+  SKIP: 2,
+
+  /**
+   * Ensure that the specified path exists, but do not yet set it to
+   * its final value.  If the path is a property, it will not (yet) be
+   * made non-configurable.
+   */
+  DECL: 3,
+
+  /**
+   * Ensure theat the specified path exists and has been set to its
+   * final value (if primitive) or an object of the correct class (if
+   * non-primitive).  It will also ensure the final property
+   * attributes (enumerable, writable and/or configurable) are set.
+   *
+   * If a new object is created to be the value of the specified path
+   * it will not (yet) have its properties or internal set/map data
+   * set (but immutable internal data, such as function code, must be
+   * set at this time).
+   */
+  SET: 4,
+
+  /**
+   * Ensure the specified path is has been set to its final value (and
+   * marked immuable, if applicable) and that the same has been done
+   * recursively to all bindings reachable via path.
+   */
+  RECURSE: 5,
+};
 
 /**
  * @constructor
@@ -161,7 +182,7 @@ var Config = function(spec) {
         var sc = se.contents[i];
         if (typeof sc === 'string') {
           var /** !ContentEntry */ content =
-              {path: sc, do: 'recurse', reorder: false};
+              {path: sc, do: Do.RECURSE, reorder: false};
         } else {
           content = {path: sc.path, do: sc.do, reorder: Boolean(sc.reorder)};
         }
@@ -234,3 +255,4 @@ var dump = function(intrp, spec) {
 };
 
 exports.dump = dump;
+exports.Do = Do;

--- a/server/dump.js
+++ b/server/dump.js
@@ -271,3 +271,8 @@ var dump = function(intrp, spec) {
 
 exports.dump = dump;
 exports.Do = Do;
+
+// For unit testing only!
+exports.testOnly = {
+  primitiveToSource: primitiveToSource,
+}

--- a/server/dump.js
+++ b/server/dump.js
@@ -93,7 +93,7 @@ ContentEntry.prototype.reorder;
  * @enum {number}
  */
 var Do = {
-  /** 
+  /**
    * Skip the named binding entirely (unless it or an extension of it
    * is explicitly mentioned in a later config directive); if the data
    * accessible via the named binding is not accessible via any other
@@ -102,7 +102,7 @@ var Do = {
    * loss, so be careful!
    */
   PRUNE: 1,
-  
+
   /**
    * Skip the named binding for now, but include it in a later file
    * (whichever has rest: true).

--- a/server/dump.js
+++ b/server/dump.js
@@ -37,10 +37,17 @@ var toParts = function(selector) {
 
 /**
  * @typedef {{filename: string,
- *            contents: (!Array<string|ContentEntry>|undefined),
- *            rest: (boolean|undefined)}}
+ *            contents: !Array<!ContentEntry>,
+ *            rest: boolean}}
  */
 var ConfigEntry;
+
+/**
+ * @typedef {{filename: string,
+ *            contents: (!Array<string|!ContentEntry>|undefined),
+ *            rest: (boolean|undefined)}}
+ */
+var SpecEntry;
 
 /**
  * The type of the values of contents: entries of the config spec.
@@ -131,23 +138,31 @@ ConfigNode.prototype.kidFor = function(name) {
 
 /**
  * @constructor
- * @param {!Array<ConfigEntry>} spec
+ * @param {!Array<SpecEntry>} spec
  */
 var Config = function(spec) {
-  /** @type {!Array<ConfigEntry>} */
-  this.spec = spec;
+  /** @type {!Array<!ConfigEntry>} */
+  this.entries = [];
   /** @type {number|undefined} */
   this.defaultFileNo = undefined;
   /** @type {!ConfigNode} */
   this.tree = new ConfigNode;
 
   for (var fileNo = 0; fileNo < spec.length; fileNo++) {
-    var entry = spec[fileNo];
-    if (entry.contents) {
-      for (var i = 0; i < entry.contents.length; i++) {
-        var content = entry.contents[i];
-        if (typeof content === 'string') {
-          content = {path: content, do: 'recurse'};
+    var /** !SpecEntry */ se = spec[fileNo];
+    var /** !ConfigEntry */ entry = {
+      filename: se.filename,
+      contents: [],
+      rest: Boolean(se.rest)
+    };
+    if (se.contents) {
+      for (var i = 0; i < se.contents.length; i++) {
+        var sc = se.contents[i];
+        if (typeof sc === 'string') {
+          var /** !ContentEntry */ content =
+              {path: sc, do: 'recurse', reorder: false};
+        } else {
+          content = {path: sc.path, do: sc.do, reorder: Boolean(sc.reorder)};
         }
         var parts = toParts(content.path);
         var /** ?ConfigNode */ cn = this.tree;

--- a/server/dump.js
+++ b/server/dump.js
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Code City: serialisation to eval-able JS
+ *
+ * Copyright 2018 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Saving the state of the interpreter as eval-able JS.
+ * @author cpcallen@google.com (Christohper Allen)
+ */
+'use strict';
+
+const Interpreter = require('./interpreter.js');
+
+/**
+ * Break a selector into an array of parts.
+ * @param {string} selector The selector
+ * @return {!Array<string>} The parts
+ */
+var toParts = function(selector) {
+  return selector.split('.');
+};
+
+/**
+ * @typedef {{filename: string,
+ *            contents: (!Array<string|ContentEntry>|undefined),
+ *            rest: (boolean|undefined)}}
+ */
+var ConfigEntry;
+
+/**
+ * The type of the values of contents: entries of the config spec.
+ * @record
+ */
+var ContentEntry = function() {};
+
+/** 
+ * Path is a string like "eval", "Object.prototype" or
+ * "$.util.command" identifying the variable or property binding this
+ * entry applies to.
+ * @type {string}
+ */
+ContentEntry.prototype.path;
+
+/**
+ * Do is one of 'prune', 'defer', 'decl', 'set', 'recurse' (default:
+ * 'recurse'), specifying what should be done for the specified path.
+ * The choices are:
+ *
+ * - 'prune' will skip the named binding entirely (unless it or an
+ *    extension of it is explicitly mentioned in a later config
+ *    directive); if the data accessible via the named binding is not
+ *    accessible via any other (non-pruned) path from the global scope
+ *    it will consequently not be included in the dump.  This option is
+ *    intended to cause data loss, so be careful!
+ *
+ * - 'defer' will skip the named binding for now, but it will be
+ *   included in the file with rest: true.
+ *
+ * - 'decl' will ensure that the specified path exists, but will leave
+ *   the value undefined.  If the path is a property, it will not
+ *   (yet) be made non-configurable.
+ *
+ * - 'set' will do what 'decl' does and then ensure that the specified
+ *   path is set to its final value (if primitive) or an object of the
+ *   correct class (if non-primitive).  It will also ensure the final
+ *   property attributes (enumerable, writable and/or configurable)
+ *   are set.  If a new object is created to be the value of the
+ *   specified path it will not (yet) have its properties or internal
+ *   set/map data set (but immutable internal data, such as function
+ *   code, must be set at this time).
+ *
+ * - 'recurse' will do what 'set' does and then additionally do the
+ *   same, recursively, to properties and set/map data of the object
+ *   which is the value of the specified path.
+ * @type {string}
+ */
+ContentEntry.prototype.do;
+
+/**
+ * Reorder is a boolean (default: false) specifying whether it is
+ * acceptable to allow property or set/map entry entries to be created
+ * (by the output JS) in a different order than they apear in the
+ * interpreter instance being serialised.  If false, output may
+ * contain placeholder entries like:
+ *
+ *     var obj = {};
+ *     obj.foo = undefined;  // placeholder
+ *     obj.bar = function() { ... };
+ *
+ * to allow obj.foo to be defined later while still
+ * preserving property order.
+ * @type {boolean|undefined}
+ */
+ContentEntry.prototype.reorder;
+
+/**
+ * @constructor
+ */
+var ConfigNode = function() {
+  /** @type {number|undefined} */
+  this.firstFileNo = undefined;
+  /** @type {!Object<string, !ConfigNode>} */
+  this.kids = Object.create(null);
+};
+
+/**
+ * @param {string} name
+ * @return {ConfigNode}
+ */
+ConfigNode.prototype.kidFor = function(name) {
+  if (!this.kids[name]) {
+    this.kids[name] = new ConfigNode;
+  }
+  return this.kids[name];
+};
+
+/**
+ * @constructor
+ * @param {!Array<ConfigEntry>} spec
+ */
+var Config = function(spec) {
+  /** @type {!Array<ConfigEntry>} */
+  this.spec = spec;
+  /** @type {number|undefined} */
+  this.defaultFileNo = undefined;
+  /** @type {!ConfigNode} */
+  this.tree = new ConfigNode;
+
+  for (var fileNo = 0; fileNo < spec.length; fileNo++) {
+    var entry = spec[fileNo];
+    if (entry.contents) {
+      for (var i = 0; i < entry.contents.length; i++) {
+        var content = entry.contents[i];
+        if (typeof content === 'string') {
+          content = {path: content, do: 'recurse'};
+        }
+        var parts = toParts(content.path);
+        var /** ?ConfigNode */ cn = this.tree;
+        for (var j = 0; j < parts.length; j++) {
+          cn = cn.kidFor(parts[j]);
+        }
+        // Now cn is final ConfigNode for path (often a leaf).
+        cn.firstFileNo = fileNo;
+      }
+    }
+    if (spec[fileNo].rest) {
+      if (this.defaultFileNo !== undefined) {
+        throw Error('Only one rest entry permitted');
+      }
+      this.defaultFileNo = fileNo;
+    }
+  }
+};
+
+var dump = function(intrp, spec) {
+  var config = new Config(spec);
+
+};
+
+exports.dump = dump;

--- a/server/dump.js
+++ b/server/dump.js
@@ -231,6 +231,8 @@ Dumper.prototype.primitiveToExpr = function(value) {
 Dumper.prototype.builtinToExpr = function(obj, key, info) {
   if (obj instanceof this.intrp.Function) {
     // The .length property and .name properties are pre-set.
+    // BUG(cpcallen): Actually, .name can be changed, so we should
+    // compare it to the value in a pristine Interpreter.
     info.done['length'] = Do.SET;
     info.done['name'] = Do.SET;
   }
@@ -267,7 +269,7 @@ Dumper.prototype.functionToExpr = function(func, info) {
   }
   // The .length property will be set implicitly.
   info.done['length'] = Do.SET;
-  // TODO(cpcallen): .name is only set in certain circumstances.
+  // BUG(cpcallen): .name is only set in certain circumstances.
   info.done['name'] = Do.SET;
   return func.toString();
 };

--- a/server/dump.js
+++ b/server/dump.js
@@ -239,6 +239,11 @@ var Dumper = function(intrp, spec) {
   this.scopeInfo = new Map;
   /** @type {!Map<!Interpreter.prototype.Object,!ObjectInfo>} */
   this.objInfo = new Map;
+  /**
+   * Which scope are we presently outputting code in the context of?
+   * @type {!Interpreter.Scope}
+   */
+  this.scope = intrp.global;
 };
 
 /**
@@ -355,6 +360,25 @@ Dumper.prototype.primitiveToExpr = function(value) {
         throw TypeError('primitiveToSource called on non-primitive value');
       }
   }
+};
+
+/**
+ * Returns true if a given name is shadowed in the current scope.
+ * @param {string} name Variable name that might be shadowed.
+ * @param {!Interpreter.Scope=} scope Scope in which name is defind
+ *     (default: the global scope).
+ * @return {boolean} True iff name is bound in a scope between the
+ *     current scope (this.scope) (inclusive) and scope (exclusive).
+ */
+Dumper.prototype.isShadowed = function(name, scope) {
+  scope = scope || this.intrp.global;
+  for (var s = this.scope; s !== scope; s = s.outerScope) {
+    if (s === null) {
+      throw Error("Looking for name '" + name + "' from non-enclosing scope??");
+    }
+    if (s.hasBinding(name)) return true;
+  }
+  return false;
 };
 
 var dump = function(intrp, spec) {

--- a/server/dump.js
+++ b/server/dump.js
@@ -43,8 +43,9 @@ var dump = function(intrp, spec) {
 // Dumper.
 
 /**
- * Dumper encapsulates all the state required to keep track of what
- * has and hasn't yet been written when dumping an Interpreter.
+ * Dumper encapsulates all machinery to dump an Interpreter object to
+ * eval-able JS, including maintaining all the dump-state info
+ * required to keep track of what has and hasn't yet been dumped.
  * @constructor
  * @param {!Interpreter} intrp The interpreter to be dumped.
  * @param {!Array<SpecEntry>} spec The dump specification.
@@ -64,8 +65,20 @@ var Dumper = function(intrp, spec) {
 };
 
 /**
- * Get a source text to declare and optionally initialise a particular
- * binding.
+ * Generate JS source text to declare and optionally initialise a
+ * particular binding (as specified by a Selector).
+ * 
+ * E.g., if foo = [42, 69, 105], then:
+ *
+ * myDumper.dumpBinding(new Selector('foo'), Do.DECL)
+ * // => 'var foo;\n'
+ * myDumper.dumpBinding(new Selector('foo'), Do.SET)
+ * // => 'foo = [];\n'
+ * myDumper.dumpBinding(new Selector('foo[0]'), Do.SET)
+ * // => 'foo[0] = 42;\n'
+ * myDumper.dumpBinding(new Selector('foo'), Do.RECURSE)
+ * // => 'foo[1] = 69;\nfoo[2] = 105;\n'
+ *
  * @param {!Selector} selector The selector for the binding to be dumped.
  * @param {Do} todo How much to dump.  Must be >= Do.DECL.
  * @return {string} An eval-able program to initialise the specified binding.

--- a/server/registry.js
+++ b/server/registry.js
@@ -52,17 +52,15 @@ class Registry {
   }
 
   /**
-   * Look up the key for a registered value.  Throws an error if the
+   * Look up the key for a registered value.  Returns undefined if the
    * given value has not been registered.  If the value has been
    * registered with more than one key then one of those keys will be
    * returned but there is no guarantee which.
    * @param {T} value The value to get the key for.
-   * @return {string} The key for value, or undefined if value never registered.
+   * @return {string|undefined} The key for value, or undefined if
+   *     value never registered.
    */
   getKey(value) {
-    if (!this.keys_.has(value)) {
-      throw Error('Value ' + value + ' not registered');
-    }
     return this.keys_.get(value);
   }
 

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -209,7 +209,7 @@ exports.testDumper = function(t) {
   }
 
   // Test dump.
-  intrp = new Interpreter;
+  intrp = new Interpreter({noLog: ['net', 'unhandled']});
 
   // Hack to install stubs for builtins found in codecity.js.
   for (const bi of ['CC.log', 'CC.checkpoint', 'CC.shutdown']) {

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -158,6 +158,7 @@ exports.testDumperPrototypeDumpBinding = function(t) {
   intrp.run();
   const func = intrp.global.get('foo');
 
+  // Check generated output for (and post-dump status of) specific bindings.
   const cases = [  // Order matters.
     ['Object', Do.DECL, 'var Object;\n'],
     ['Object', Do.DECL, ''],
@@ -180,7 +181,6 @@ exports.testDumperPrototypeDumpBinding = function(t) {
     ['date', Do.SET, "var date = new Date('1975-07-27T00:00:00.000Z');\n"],
     ['re', Do.SET, 'var re = /foo/gi;\n'],
   ];
-
   for (const tc of cases) {
     const s = new Selector(tc[0]);
     // Check output code.
@@ -193,6 +193,29 @@ exports.testDumperPrototypeDumpBinding = function(t) {
         binding.getDone(), tc[1]);
   }
 
+  // Check status of additional bindings that will be set implicitly
+  // as a side effect of the code generated above.
+  const implicit = [
+    ['Object.length', Do.SET],
+    ['Object.name', Do.SET],
+    ['f1.length', Do.SET],
+    ['f1.name', Do.SET],
+    ['f2.length', Do.SET],
+    ['f2.name', Do.SET],
+    ['f2.f3.length', Do.SET],
+    // TODO(cpcallen): enable this once code is correct.
+    // ['f2.f3.name', Do.UNSTARTED],  // N.B.: not implicitly set.
+    ['arr.length', Do.SET],
+    ['sparse.length', Do.SET],
+    // TODO(cpcallen): enable this once code is correct.
+    // ['re.lastIndex', Do.SET],
+  ];
+  for (const tc of implicit) {
+    const s = new Selector(tc[0]);
+    const binding = new BindingInfo(dumper, s);
+    t.expect(util.format('Binding status of %s', s),
+        binding.getDone(), tc[1]);
+  }
 };
 
 /**

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -153,7 +153,9 @@ exports.testDumperPrototypeDumpBinding = function(t) {
       var sparse = [0, , 2];
       sparse.length = 4;
       var date = new Date('1975-07-27');
-      var re = /foo/ig;
+      var re1 = /foo/ig;
+      var re2 = /bar/g;
+      re2.lastIndex = 42;
   `);
   intrp.run();
   const func = intrp.global.get('foo');
@@ -179,7 +181,8 @@ exports.testDumperPrototypeDumpBinding = function(t) {
     ['sparse', Do.RECURSE, 'var sparse = [];\n' +
         'sparse[0] = 0;\nsparse[2] = 2;\nsparse.length = 4;\n'],
     ['date', Do.SET, "var date = new Date('1975-07-27T00:00:00.000Z');\n"],
-    ['re', Do.SET, 'var re = /foo/gi;\n'],
+    ['re1', Do.SET, 'var re1 = /foo/gi;\n'],
+    ['re2', Do.RECURSE, 'var re2 = /bar/g;\nre2.lastIndex = 42;\n'],
   ];
   for (const tc of cases) {
     const s = new Selector(tc[0]);
@@ -193,8 +196,8 @@ exports.testDumperPrototypeDumpBinding = function(t) {
         binding.getDone(), tc[1]);
   }
 
-  // Check status of additional bindings that will be set implicitly
-  // as a side effect of the code generated above.
+  // Check status of (some of the) additional bindings that will be
+  // set implicitly as a side effect of the code generated above.
   const implicit = [
     ['Object.length', Do.SET],
     ['Object.name', Do.SET],
@@ -207,8 +210,11 @@ exports.testDumperPrototypeDumpBinding = function(t) {
     // ['f2.f3.name', Do.UNSTARTED],  // N.B.: not implicitly set.
     ['arr.length', Do.SET],
     ['sparse.length', Do.SET],
-    // TODO(cpcallen): enable this once code is correct.
-    // ['re.lastIndex', Do.SET],
+    ['re1.source', Do.SET],
+    ['re1.global', Do.SET],
+    ['re1.ignoreCase', Do.SET],
+    ['re1.multiline', Do.SET],
+    ['re1.lastIndex', Do.SET],
   ];
   for (const tc of implicit) {
     const s = new Selector(tc[0]);

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -127,8 +127,9 @@ exports.testDumperPrototypeToExpr = function(t) {
         "new Date('1975-07-27T00:00:00.000Z')"],
     [new intrp.RegExp(/foo/ig, intrp.ROOT), '/foo/gi'],
   ];
-  for (const tc of cases) {
-    var r = dumper.toExpr(tc[0]);
+  for (let i = 0; i < cases.length; i++) {
+    const tc = cases[i];
+    var r = dumper.toExpr(tc[0], ['tc', String(i)]);
     t.expect(util.format('Dumper.p.toExpr(%s)', tc[1]), r, tc[1]);
   }
 };
@@ -213,10 +214,10 @@ exports.testDumper = function(t) {
         'Object.setPrototypeOf',
         'Array.prototype.find',
         'Array.prototype.findIndex',
-        'String.endsWith',
-        'String.includes',
-        'String.repeat',
-        'String.startsWith',
+        'String.prototype.endsWith',
+        'String.prototype.includes',
+        'String.prototype.repeat',
+        'String.prototype.startsWith',
         'Number.isFinite',
         'Number.isNaN',
         'Number.isSafeInteger',

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -34,14 +34,16 @@ const {T} = require('./testing');
 const util = require('util');
 
 // Unpack test-only exports from dump:
-const {Dumper, primitiveToSource, toParts} = testOnly;
+const {Dumper, toParts} = testOnly;
 
 /**
- * Unit tests for the primitiveToSource function.  Leave most of the
- * string cases to testQuote, below.
+ * Unit tests for the Dumper primitiveToExpr function.
  * @param {!T} t The test runner object.
  */
-exports.testPrimitiveToSource = function(t) {
+exports.testPrimitiveToExpr = function(t) {
+  let intrp = getInterpreter();
+  let spec = [{filename: 'all', rest: true}];
+  let dumper = new Dumper(intrp, spec);
   var cases = [
     [undefined, 'undefined'],
     [null, 'null'],
@@ -55,7 +57,7 @@ exports.testPrimitiveToSource = function(t) {
     ['foo', "'foo'"],
   ];
   for (const tc of cases) {
-    var r = primitiveToSource(tc[0]);
+    var r = dumper.primitiveToExpr(tc[0]);
     t.expect(util.format('quote(%o)', tc[0]), r, tc[1]);
     t.expect(util.format('eval(quote(%o))', tc[0]), eval(r), tc[0]);
   }

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -148,7 +148,7 @@ exports.testDumperPrototypeDumpBinding = function(t) {
       var f2 = function(arg) {};
       f2.f3 = function f4(arg) {};
       var obj = {a: 1, b: 2, c:3};
-      var arr = [42, 69, 105];
+      var arr = [42, 69, 105, obj];
       var date = new Date('1975-07-27');
       var re = /foo/ig;
   `);
@@ -156,26 +156,28 @@ exports.testDumperPrototypeDumpBinding = function(t) {
   const func = intrp.global.get('foo');
 
   const cases = [  // Order matters.
-    ['Object', Do.DECL, 'var Object;'],
-    ['Object', Do.SET, "Object = new 'Object';"],
-    ['f1', Do.DECL, 'var f1;'],
-    // Actually want 'function f1(arg) {};'.
-    ['f1', Do.SET, 'f1 = function f1(arg) {};'],
-    ['f2', Do.SET, 'var f2 = function(arg) {};'],
-    ['f2.f3', Do.DECL, 'f2.f3 = undefined;'],
-    ['f2.f3', Do.SET, 'f2.f3 = function f4(arg) {};'],
-    // Actually want 'var obj = {a: 1, b:2, c: 3};'.
-    ['obj', Do.SET, 'var obj = {};'],
-    // Actually want 'var arr = [42, 69, 105];'
-    ['arr', Do.SET, 'var arr = [];'],
-    ['date', Do.SET, "var date = new Date('1975-07-27T00:00:00.000Z');"],
-    ['re', Do.SET, 'var re = /foo/gi;'],
+    ['Object', Do.DECL, 'var Object;\n'],
+    ['Object', Do.DECL, ''],
+    ['Object', Do.SET, "Object = new 'Object';\n"],
+    ['Object', Do.SET, ''],
+    ['f1', Do.DECL, 'var f1;\n'],
+    // Actually want 'function f1(arg) {};\n'.
+    ['f1', Do.SET, 'f1 = function f1(arg) {};\n'],
+    ['f2', Do.SET, 'var f2 = function(arg) {};\n'],
+    ['f2.f3', Do.DECL, 'f2.f3 = undefined;\n'],
+    ['f2.f3', Do.SET, 'f2.f3 = function f4(arg) {};\n'],
+    // Actually want 'var obj = {a: 1, b:2, c: 3};\n'.
+    ['obj', Do.SET, 'var obj = {};\n'],
+    // Actually want 'var arr = [42, 69, 105, obj];\n'
+    ['arr', Do.SET, 'var arr = [];\n'],
+    ['date', Do.SET, "var date = new Date('1975-07-27T00:00:00.000Z');\n"],
+    ['re', Do.SET, 'var re = /foo/gi;\n'],
   ];
   for (const tc of cases) {
     const parts = toParts(tc[0]);
     var r = dumper.dumpBinding(parts, tc[1]);
-    t.expect(
-        util.format('Dumper.p.dumpBinding(%o, %o)', parts, tc[1]), r, tc[2]);
+    t.expect(util.format('Dumper.p.dumpBinding(%o, %o)', parts, tc[1]),
+        r, tc[2]);
   }
 
 };

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -30,11 +30,12 @@ const {dump, Do, testOnly} = require('../dump');
 const fs = require('fs');
 const {getInterpreter} = require('./interpreter_common');
 const path = require('path');
+const Selector = require('../selector');
 const {T} = require('./testing');
 const util = require('util');
 
 // Unpack test-only exports from dump:
-const {Dumper, toParts} = testOnly;
+const {Dumper} = testOnly;
 
 /** A very simle Dumper config specification, for testing. */
 const simpleSpec = [{filename: 'all', rest: true}];
@@ -69,7 +70,7 @@ exports.testDumperPrototypePrimitiveToExpr = function(t) {
 
   function doCases(cases) {
     for (const tc of cases) {
-      var r = dumper.primitiveToExpr(tc[0]);
+      const r = dumper.primitiveToExpr(tc[0]);
       t.expect(util.format('dumper.primitiveToExpr(%o)', tc[0]), r, tc[1]);
       t.expect(util.format('eval(dumper.primitiveToExpr(%o))', tc[0]),
           eval(r), tc[0]);
@@ -129,7 +130,7 @@ exports.testDumperPrototypeToExpr = function(t) {
   ];
   for (let i = 0; i < cases.length; i++) {
     const tc = cases[i];
-    var r = dumper.toExpr(tc[0], ['tc', String(i)]);
+    const r = dumper.toExpr(tc[0], new Selector(['tc', String(i)]));
     t.expect(util.format('Dumper.p.toExpr(%s)', tc[1]), r, tc[1]);
   }
 };
@@ -174,9 +175,9 @@ exports.testDumperPrototypeDumpBinding = function(t) {
     ['re', Do.SET, 'var re = /foo/gi;\n'],
   ];
   for (const tc of cases) {
-    const parts = toParts(tc[0]);
-    var r = dumper.dumpBinding(parts, tc[1]);
-    t.expect(util.format('Dumper.p.dumpBinding(%o, %o)', parts, tc[1]),
+    const s = new Selector(tc[0]);
+    let r = dumper.dumpBinding(s, tc[1]);
+    t.expect(util.format('Dumper.p.dumpBinding(%o, %o)', s, tc[1]),
         r, tc[2]);
   }
 
@@ -199,8 +200,8 @@ exports.testDumper = function(t) {
     ['String.prototype.split.length', '2'],
   ];
   for (const tc of cases) {
-    const parts = toParts(tc[0]);
-    let r = dumper.toExpr(dumper.getValueForParts(parts));
+    const s = new Selector(tc[0]);
+    let r = dumper.toExpr(dumper.getValueForSelector(s));
     t.expect('toExpr(/* ' + tc[0] + ' */)', r, tc[1]);
   }
 
@@ -334,7 +335,7 @@ exports.testDumper = function(t) {
       contents: [
         {path: '$.www', do: Do.SET},
         {path: '$.www.ROUTER', do: Do.SET},
-        '$.www.404',  // TODO(cpcallen): support proper selectors.
+        '$.www[404]',
         '$.www.homepage',
         '$.www.robots',
       ],

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -37,14 +37,35 @@ const util = require('util');
 const {Dumper, toParts} = testOnly;
 
 /**
- * Unit tests for the Dumper primitiveToExpr function.
+ * Unit tests for the Dumper.prototype.isShadowed method.
  * @param {!T} t The test runner object.
  */
-exports.testPrimitiveToExpr = function(t) {
-  let intrp = getInterpreter();
-  let spec = [{filename: 'all', rest: true}];
-  let dumper = new Dumper(intrp, spec);
-  var cases = [
+exports.testDumperPrototypeIsShadowed = function(t) {
+  const intrp = getInterpreter();
+  const spec = [{filename: 'all', rest: true}];
+  const dumper = new Dumper(intrp, spec);
+
+  intrp.global.createMutableBinding('foo', 'foo');
+  intrp.global.createMutableBinding('bar', 'bar');
+
+  const inner = new Interpreter.Scope(Interpreter.Scope.Type.FUNCTION,
+      intrp.ROOT, intrp.global);
+  inner.createMutableBinding('foo', 'foobar!');
+  dumper.scope = inner;
+
+  t.expect("isShadowed('foo')", dumper.isShadowed('foo'), true);
+  t.expect("isShadowed('bar')", dumper.isShadowed('bar'), false);
+};
+
+/**
+ * Unit tests for the Dumper.prototype.primitiveToExpr method.
+ * @param {!T} t The test runner object.
+ */
+exports.testDumperPrototypePrimitiveToExpr = function(t) {
+  const intrp = getInterpreter();
+  const spec = [{filename: 'all', rest: true}];
+  const dumper = new Dumper(intrp, spec);
+  const cases = [
     [undefined, 'undefined'],
     [null, 'null'],
     [false, 'false'],

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -31,8 +31,34 @@ const fs = require('fs');
 const {getInterpreter} = require('./interpreter_common');
 const path = require('path');
 const {T} = require('./testing');
+const util = require('util');
 
 const {primitiveToSource} = testOnly;
+
+/**
+ * Unit tests for the primitiveToSource function.  Leave most of the
+ * string cases to testQuote, below.
+ * @param {!T} t The test runner object.
+ */
+exports.testPrimitiveToSource = function(t) {
+  var cases = [
+    [undefined, 'undefined'],
+    [null, 'null'],
+    [false, 'false'],
+    [true, 'true'],
+    [0, '0'],
+    [-0, '-0'],
+    [Infinity, 'Infinity'],
+    [-Infinity, '-Infinity'],
+    [NaN, 'NaN'],
+    ['foo', "'foo'"],
+  ];
+  for (const tc of cases) {
+    var r = primitiveToSource(tc[0]);
+    t.expect(util.format('quote(%o)', tc[0]), r, tc[1]);
+    t.expect(util.format('eval(quote(%o))', tc[0]), eval(r), tc[0]);
+  }
+};
 
 /**
  * @param {!T} t The test runner object.

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -26,7 +26,7 @@
 'use strict';
 
 const Interpreter = require('../interpreter');
-const {dump} = require('../dump');
+const {dump, Do} = require('../dump');
 const fs = require('fs');
 const {getInterpreter} = require('./interpreter_common');
 const path = require('path');
@@ -127,18 +127,18 @@ exports.testDump = function(t) {
     }, {
       filename: 'core_10_base',
       contents: [
-        {path: 'user', do: 'decl'},
-        {path: '$', do: 'set'},
+        {path: 'user', do: Do.DECL},
+        {path: '$', do: Do.SET},
         '$.system',
-        {path: '$.utils', do: 'set'},
+        {path: '$.utils', do: Do.SET},
         '$.physical',
         '$.thing',
         '$.room',
         '$.user',
         '$.execute',
-        {path: '$.userDatabase', do: 'set'},
+        {path: '$.userDatabase', do: Do.SET},
         '$.connection',
-        {path: '$.servers', do: 'set'},
+        {path: '$.servers', do: Do.SET},
         '$.servers.telnet',
       ],
     }, {
@@ -169,8 +169,8 @@ exports.testDump = function(t) {
     }, {
       filename: 'core_32_$.www',
       contents: [
-        {path: '$.www', do: 'set'},
-        {path: '$.www.ROUTER', do: 'set'},
+        {path: '$.www', do: Do.SET},
+        {path: '$.www.ROUTER', do: Do.SET},
         '$.www.404',  // TODO(cpcallen): support proper selectors.
         '$.www.homepage',
         '$.www.robots',
@@ -184,7 +184,7 @@ exports.testDump = function(t) {
     }, {
       filename: 'core_40_$.db.tempId',
       contents: [
-        {path: '$.db', do: 'set'},
+        {path: '$.db', do: Do.SET},
         '$.db.tempID',
       ],
     }, {

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -167,13 +167,16 @@ exports.testDumperPrototypeDumpBinding = function(t) {
     ['f2', Do.SET, 'var f2 = function(arg) {};\n'],
     ['f2.f3', Do.DECL, 'f2.f3 = undefined;\n'],
     ['f2.f3', Do.SET, 'f2.f3 = function f4(arg) {};\n'],
-    // Actually want 'var obj = {a: 1, b:2, c: 3};\n'.
     ['obj', Do.SET, 'var obj = {};\n'],
-    // Actually want 'var arr = [42, 69, 105, obj];\n'
-    ['arr', Do.SET, 'var arr = [];\n'],
+    ['obj', Do.RECURSE, 'obj.a = 1;\nobj.b = 2;\nobj.c = 3;\n'],
+    // Actually want 'var arr = [42, 69, 105, obj];\n'.
+    ['arr', Do.RECURSE, 'var arr = [];\narr[0] = 42;\narr[1] = 69;\n' +
+        'arr[2] = 105;\narr[3] = obj;\n'],
     ['date', Do.SET, "var date = new Date('1975-07-27T00:00:00.000Z');\n"],
     ['re', Do.SET, 'var re = /foo/gi;\n'],
   ];
+
+  
   for (const tc of cases) {
     const s = new Selector(tc[0]);
     let r = dumper.dumpBinding(s, tc[1]);

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -1,0 +1,197 @@
+/**
+ * @license
+ * Code City: serialisation to eval-able JS (tests)
+ *
+ * Copyright 2018 Google Inc.
+ * https://github.com/NeilFraser/CodeCity
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Tests for Saving the state of the interpreter as
+ *     eval-able JS.
+ * @author cpcallen@google.com (Christopher Allen)
+ */
+'use strict';
+
+const Interpreter = require('../interpreter');
+const {dump} = require('../dump');
+const fs = require('fs');
+const {getInterpreter} = require('./interpreter_common');
+const path = require('path');
+const {T} = require('./testing');
+
+
+/**
+ * @param {!T} t The test runner object.
+ */
+exports.testDump = function(t) {
+  let intrp = new Interpreter;
+
+  // Hack to install stubs for builtins found in codecity.js:
+  const builtins = ['CC.log', 'CC.checkpoint', 'CC.shutdown'];
+  for (const bi of builtins) {
+    new intrp.NativeFunction({
+      id: bi, length: 0,
+    });
+  }
+
+  // Load 
+  const coreDir = '../demo';
+  let  files = fs.readdirSync(coreDir) || [];
+  for (const file of files) {
+    if (file.match(/^(core|test).*\.js$/)) {
+      var filename = path.join(coreDir, file);
+      var contents = String(fs.readFileSync(filename, 'utf8'));
+      intrp.createThreadForSrc(contents);
+      intrp.run();
+    }
+  }
+  intrp.stop();  // Close any listening sockets, so node will exit.
+
+  const spec = [
+    {
+      filename: 'core_00_es5',
+      contents: [
+        'Object',
+        'Function',
+        'Array',
+        'String',
+        'Boolean',
+        'Number',
+        'Date',
+        'RegExp',
+        'Error',
+        'EvalError',
+        'RangeError',
+        'ReferenceError',
+        'SyntaxError',
+        'TypeError',
+        'URIError',
+        'Math',
+        'JSON',
+        'decodeURI',
+        'decodeURIComponent',
+        'encodeURI',
+        'encodeURIComponent',
+        'escape',
+        'isFinite',
+        'isNan',
+        'parseFloat',
+        'parseInt',
+        'unescape',
+      ],
+    }, {
+      filename: 'core_00_es6',
+      contents: [
+        'Object.is',
+        'Object.setPrototypeOf',
+        'Array.prototype.find',
+        'Array.prototype.findIndex',
+        'String.endsWith',
+        'String.includes',
+        'String.repeat',
+        'String.startsWith',
+        'Number.isFinite',
+        'Number.isNaN',
+        'Number.isSafeInteger',
+        'Number.EPSILON',
+        'Number.MAX_SAFE_INTEGER',
+        'Math.sign',
+        'Math.trunc',
+        'WeakMap',
+      ],
+    }, {
+      filename: 'core_00_esx',
+      contents: [
+        'Object.getOwnerOf',
+        'Object.setOwnerOf',
+        'Thread',
+        'PermissionError',
+        'Array.prototype.join',
+        'suspend',
+        'setTimeout',
+        'clearTimeout',
+      ],
+    }, {
+      filename: 'core_10_base',
+      contents: [
+        {path: 'user', do: 'decl'},
+        {path: '$', do: 'set'},
+        '$.system',
+        {path: '$.utils', do: 'set'},
+        '$.physical',
+        '$.thing',
+        '$.room',
+        '$.user',
+        '$.execute',
+        {path: '$.userDatabase', do: 'set'},
+        '$.connection',
+        {path: '$.servers', do: 'set'},
+        '$.servers.telnet',
+      ],
+    }, {
+      filename: 'core_11_$.utils.command',
+      contents: [
+        '$.utils.command',
+        '$.utils.match',
+      ],
+    }, {
+      filename: 'core_12_$.utils.selector',
+      contents: ['$.utils.selector'],
+    }, {
+      filename: 'core_13_$.utils.code',
+      contents: ['$.utils.code'],
+    }, {
+      filename: 'core_20_$.utils.acorn_pre',
+    }, {
+      filename: 'core_21_$.utils.acorn',
+      symlink: '../server/node_modules/acorn/dist/acorn.js',
+    }, {
+      filename: 'core_22_$.utils.acorn_post',
+    }, {
+      filename: 'core_30_$.servers.http',
+      contents: ['$.servers.http'],
+    }, {
+      filename: 'core_31_$.jssp',
+      contents: ['$.jssp'],
+    }, {
+      filename: 'core_32_$.www',
+      contents: [
+        {path: '$.www', do: 'set'},
+        {path: '$.www.ROUTER', do: 'set'},
+        '$.www.404',  // TODO(cpcallen): support proper selectors.
+        '$.www.homepage',
+        '$.www.robots',
+      ],
+    }, {
+      filename: 'core_33_$.www.editor',
+      contents: ['$.www.editor'],
+    }, {
+      filename: 'core_34_$.www.code',
+      contents: ['$.www.code'],
+    }, {
+      filename: 'core_40_$.db.tempId',
+      contents: [
+        {path: '$.db', do: 'set'},
+        '$.db.tempID',
+      ],
+    }, {
+      filename: 'core_90_world',
+      rest: true,
+    },
+  ];
+
+  dump(intrp, spec);
+};

--- a/server/tests/dump_test.js
+++ b/server/tests/dump_test.js
@@ -26,18 +26,19 @@
 'use strict';
 
 const Interpreter = require('../interpreter');
-const {dump, Do} = require('../dump');
+const {dump, Do, testOnly} = require('../dump');
 const fs = require('fs');
 const {getInterpreter} = require('./interpreter_common');
 const path = require('path');
 const {T} = require('./testing');
 
+const {primitiveToSource} = testOnly;
 
 /**
  * @param {!T} t The test runner object.
  */
 exports.testDump = function(t) {
-  let intrp = new Interpreter;
+  const intrp = new Interpreter;
 
   // Hack to install stubs for builtins found in codecity.js:
   const builtins = ['CC.log', 'CC.checkpoint', 'CC.shutdown'];

--- a/server/tests/registry_test.js
+++ b/server/tests/registry_test.js
@@ -43,12 +43,7 @@ exports.testRegistry = function(t) {
   } catch(e) {
     t.pass("reg.get('foo')  // 0");
   }
-  try {
-    reg.getKey(obj);
-    t.fail("reg.getKey(obj)  // 0", "Didn't throw.");
-  } catch(e) {
-    t.pass("reg.getKey(obj)  // 0");
-  }
+  t.expect("reg.getKey(obj)  // 0", reg.getKey(obj), undefined);
 
   // 1: Register obj as 'foo'.
   reg.set('foo', obj);
@@ -66,10 +61,5 @@ exports.testRegistry = function(t) {
   t.expect("reg.has('foo')  // 2", reg.has('foo'), true);
   t.expect("reg.get('foo')  // 2", reg.get('foo'), obj);
   t.expect("reg.getKey(obj)  // 2", reg.getKey(obj), 'foo');
-  try {
-    reg.getKey({});
-    t.fail("reg.getKey({})  // 2", "Didn't throw.");
-  } catch(e) {
-    t.pass("reg.getKey({})  // 2");
-  }
+  t.expect("reg.getKey({})  // 2", reg.getKey({}), undefined);
 };

--- a/server/tests/run.js
+++ b/server/tests/run.js
@@ -32,6 +32,7 @@
 const compileTargets = [
   require('../codecity'),
   require('./code_test'),
+  require('./dump_test'),
   require('./interpreter_test'),
   require('./interpreter_unit_test'),
   require('./interpreter_test'),


### PR DESCRIPTION
This is a preliminary PR to solicit input on the design and implementation (to date) of the `Dumper` class which will do checkpointing to eval-able JS.  This PR is not intended to be submitted (at least not at this time).  There is no reason to look at all the individual commits (they will probably be squashed eventually).

The main thing that is fairly complete is the implementation of the `Dumper.prototype.dumpBinding` method which outputs the source code for a single binding (variable or property value) or all bindings reachable recursively from that binding.

There is limited support for prototypes and no support for owners, `Map` or `Set` keys/values, non-global scopes, or temporary names, nor for setting any bindings not explicitly requested or actually outputting code to disk—all of which are most certainly needed—nor for desirable features like per-user output files.  (There is tentative support for a configuration mechanism, but it is not connected to anything yet.)

But there's enough there that I would be happy to get some feedback about the design and implementation to date.