### PR TITLE
Fix bug causing setPrototypeOf(..., null) to crash

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -4158,7 +4158,7 @@ Interpreter.prototype.installTypes = function() {
             "An object's prototype chain can't include the object itself");
       }
     }
-    Object.setPrototypeOf(this.properties, proto.properties);
+    Object.setPrototypeOf(this.properties, proto && proto.properties);
     this.proto = proto;
     return true;
   };

--- a/server/tests/db/test_01_es6.js
+++ b/server/tests/db/test_01_es6.js
@@ -144,7 +144,16 @@ tests.ObjectSetPrototypeOf = function() {
       'Object.setPrototypeOf(q, p) inheritance');
 };
 
-tests.ObjectSetPrototypeOf = function() {
+tests.ObjectSetPrototypeOfToNull = function() {
+  var o = {parent: 'o'};
+  var q = Object.create(o);
+  console.assert(Object.setPrototypeOf(q, null) === q,
+      'Object.setPrototypeOf(q, null) return value');
+  console.assert(Object.getPrototypeOf(q) === null,
+      'Object.setPrototypeOf(q, null) new parent');
+};
+
+tests.ObjectSetPrototypeOfCircular = function() {
   var o = {};
   var p = Object.create(o);
   try {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1223,6 +1223,14 @@ module.exports = [
     `,
     expected: 'p' },
 
+  { name: 'Object.setPrototypeOf(..., null)', src: `
+    var o = {parent: 'o'};
+    var q = Object.create(o);
+    Object.setPrototypeOf(q, null) === q &&
+        Object.getPrototypeOf(q);
+    `,
+    expected: null },
+
   { name: 'Object.setPrototypeOf circular', src: `
     var o = {};
     var p = Object.create(o);

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -1226,8 +1226,7 @@ module.exports = [
   { name: 'Object.setPrototypeOf(..., null)', src: `
     var o = {parent: 'o'};
     var q = Object.create(o);
-    Object.setPrototypeOf(q, null) === q &&
-        Object.getPrototypeOf(q);
+    Object.setPrototypeOf(q, null) === q && Object.getPrototypeOf(q);
     `,
     expected: null },
 


### PR DESCRIPTION
If new prototype is null then setPrototype woudl fail because null has no .properties property.  Fix this, and a separate typo bug which was causing some DB tests to be silently skipped.