### PR TITLE
Fix bug in CC.xhr; improve tests

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2391,8 +2391,10 @@ Interpreter.prototype.initNetwork_ = function() {
         throw new intrp.Error(perms, intrp.SYNTAX_ERROR,
             'Unrecognized URL "' + url + '"');
       }
+      intrp.log('net', 'XHR for %s: connect', url);
       var rr = intrp.getResolveReject(thread, state);
       req.on('response', function(res) {
+        intrp.log('net', 'XHR for %s: response', url);
         if (res.statusCode !== 200) {
           var err = new intrp.Error(perms, intrp.ERROR,
               'HTTP request failed: ' + res.statusCode + ' ' +
@@ -2408,9 +2410,11 @@ Interpreter.prototype.initNetwork_ = function() {
           body += String(data);
         });
         res.on('end', function() {
+          intrp.log('net', 'XHR for %s: end', url);
           rr.resolve(body);
         });
       }).on('error', function(e) {
+        intrp.log('net', 'XHR for %s: %s', url, e);
         rr.reject(intrp.errorNativeToPseudo(e, perms), perms);
       });
       return Interpreter.FunctionResult.Block;

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2407,7 +2407,7 @@ Interpreter.prototype.initNetwork_ = function() {
         res.on('data', function(data) {
           body += String(data);
         });
-        res.on('close', function() {
+        res.on('end', function() {
           rr.resolve(body);
         });
       }).on('error', function(e) {

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -24,6 +24,7 @@
  */
 'use strict';
 
+const http = require('http');
 const net = require('net');
 const util = require('util');
 
@@ -1272,8 +1273,24 @@ exports.testNetworking = async function(t) {
    `;
   await runAsyncTest(t, name, src, 'OK');
 
-  // Run a test of the xhr() function.
-  // TODO(cpcallen): More tests.  Don't depend on external webserver.
+  // Run test of the xhr() function using HTTP.
+  name = 'testXhrHttp';
+  const httpTestServer = http.createServer(function (req, res) {
+    res.writeHead(200, {'Content-Type': 'text/plain'});
+    res.end('OK HTTP: ' + req.url);
+  }).listen(9980);
+  src = `
+      try {
+        resolve(CC.xhr('http://localhost:9980/foo'));
+      } catch (e) {
+        reject(e);
+      }
+  `;
+  await runAsyncTest(t, name, src, 'OK HTTP: /foo');
+  httpTestServer.close();
+
+  // Run test of the xhr() function using HTTPS.
+  // TODO(cpcallen): Don't depend on external webserver.
   name = 'testXhr';
   src = `
       try {

--- a/server/tests/interpreter_test.js
+++ b/server/tests/interpreter_test.js
@@ -1283,5 +1283,5 @@ exports.testNetworking = async function(t) {
         reject(e);
       }
   `;
-  await runAsyncTest(t, name, src, 'It worked!');
+  await runAsyncTest(t, name, src, 'It worked!\n');
 };


### PR DESCRIPTION
Fix bug causing `node` to terminate when a `CC.xhr` request finishes (because we were waiting fro the wrong event).

Also improve the tests for `CC.xhr` somewhat.  (Looking into doing https tests to localhost, but need to generate our own self-signed certs to get that to work…)