### PR TITLE
Production updates

### DIFF
--- a/demo/demo.cfg
+++ b/demo/demo.cfg
@@ -3,5 +3,5 @@
   "checkpointInterval": 600,
   "checkpointAtShutdown": true,
   "checkpointMinFiles": 10,
-  "checkpointMaxDirectorySize": 1
+  "checkpointMaxDirectorySize": 2048
 }

--- a/etc/codecity.service
+++ b/etc/codecity.service
@@ -9,7 +9,7 @@ SyslogIdentifier=codecity
 WorkingDirectory=/home/cc/CodeCity/demo
 User=cc
 Group=cc
-ExecStart=@/usr/bin/nodejs codecity /home/cc/CodeCity/server/codecity.js .
+ExecStart=@/usr/bin/nodejs codecity /home/cc/CodeCity/server/codecity.js ./demo.cfg
 Restart=on-failure
 
 [Install]

--- a/server/codecity.js
+++ b/server/codecity.js
@@ -60,7 +60,7 @@ CodeCity.startup = function(configFile) {
     process.exit(1);
   }
   // Find the most recent database file.
-  var checkpoint = CodeCity.allCheckpoints().pop();
+  var checkpoint = CodeCity.allCheckpoints()[0];
   // Load the interpreter.
   CodeCity.interpreter = new Interpreter({
     trimEval: true,
@@ -142,7 +142,8 @@ CodeCity.parseJson = function(text) {
 };
 
 /**
- * Return an ordered list of all currently saved checkpoints.
+ * Return a list of all currently saved checkpoints, ordered from most
+ * to least recent.
  * @return {!Array<string>} Array of filenames for checkpoints.
  */
 CodeCity.allCheckpoints = function() {

--- a/server/codecity.js
+++ b/server/codecity.js
@@ -148,7 +148,7 @@ CodeCity.parseJson = function(text) {
 CodeCity.allCheckpoints = function() {
   var files = fs.readdirSync(CodeCity.databaseDirectory);
   files = files.filter((file) => CodeCity.allCheckpoints.regexp_.test(file));
-  files.sort();
+  files.sort().reverse();
   return files;
 };
 
@@ -172,7 +172,7 @@ CodeCity.deleteCheckpointsIfNeeded = function() {
       sum + CodeCity.fileSize(fileName), 0);
   // Budget for a possible 10% growth.
   var estimateNext = directorySize + lastCheckpointSize * 1.1;
-  var maxSize = CodeCity.config.checkpointMaxDirectorySize;
+  var maxSize = CodeCity.config.checkpointMaxDirectorySize * 1024 * 1024;
   if (typeof maxSize !== 'number') {
     maxSize = Infinity;
   }


### PR DESCRIPTION
* Config files changes for running 'demo' core in prod with logarithmic deletion of backups and max 2GB of space for checkpoints.

* Treat checkpointMaxDirectorySize as specified in megabytes instead of bytes.

* Fix bug in computation of ideal times, where they would be spaced out between present time and most recent backup (rather than between present time and oldest backup).
