### PR TITLE
Support {proto} and {owner} in Selector

### DIFF
--- a/server/selector.js
+++ b/server/selector.js
@@ -177,7 +177,7 @@ Selector.prototype.toString = function(specialHandler) {
 /**
  * A Selector fundamentally an array of Parts, and Parts are either
  * strings (representing variable or property names) or SpecialParts
- * (representing everything else, like ^ for prottype.
+ * (representing everything else, like {proto} or {owner}).
  * @typedef {string|!SpecialPart}
  */
 Selector.Part;

--- a/server/selector.js
+++ b/server/selector.js
@@ -43,7 +43,7 @@ var Selector = function(s) {
     if (typeof s.length < 1) throw new RangeError('Zero-length parts list??');
     if (s.length < 1) throw new RangeError('Zero-length parts list??');
     for (var i = 0; i < s.length; i++) {
-      if (typeof s[i] !== 'string') {
+      if (typeof s[i] !== 'string' && !(s[i] instanceof SpecialPart)) {
         throw new TypeError('Invalid part in parts array');
       }
       parts[i] = s[i];
@@ -75,19 +75,14 @@ Selector.prototype.isVar = function() {
  * @return {string} The selector as a string.
  */
 Selector.prototype.toExpr = function() {
-  var /** !Array<string> */ out = [this[0]];
-  for (var i = 1; i < this.length; i++) {
-    var part = this[i];
-    if (identifierRE.test(part)) {
-      out.push('.', part);
-    } else if (String(Number(part)) === part) {
-      // String represents a number with same string representation.
-      out.push('[', part, ']');
+  return this.toString(function(part, out) {
+    if (part === Selector.PROTOTYPE) {
+      out.unshift('Object.getPrototypeOf(');
+      out.push(')');
     } else {
-      out.push('[', code.quote(part), ']');
+      throw new TypeError('Invalid part in parts array');
     }
-  }
- return out.join('');
+  });
 };
 
 /**
@@ -100,22 +95,68 @@ Selector.prototype.toExpr = function() {
  * @return {string} The selector as a string.
  */
 Selector.prototype.toSetExpr = function(valueExpr) {
-  // TODO(cpcallen): rewrite when support for __proto__  / owner is added.
-  return this.toExpr() + ' = ' + valueExpr;
+  var lastPart = this[this.length - 1];
+  if (!(lastPart instanceof SpecialPart)) {
+    return this.toExpr() + ' = ' + valueExpr;
+  } else if (lastPart === Selector.PROTOTYPE) {
+    var objExpr = new Selector(this.slice(0, -1)).toExpr();
+    return 'Object.setPrototypeOf(' + objExpr + ', ' + valueExpr + ')';
+  } else {
+    throw new TypeError('Invalid part in parts array');
+  }
 };
 
 /**
  * Return the selector string corresponding to this selector.
+ * @param {function(!SpecialPart, !Array<string>)=} specialHandler
+ *     Optional function to handle stringifying SpecialParts.
  * @return {string} The selector as a string.
  */
-Selector.prototype.toString = function() {
-  // TODO(cpcallen): rewrite when support for __proto__  / owner is added.
-  return this.toExpr();
+Selector.prototype.toString = function(specialHandler) {
+  var /** !Array<string> */ out = [this[0]];
+  for (var i = 1; i < this.length; i++) {
+    var part = this[i];
+    if (part instanceof SpecialPart) {
+      if (specialHandler) {
+        specialHandler(part, out);
+      } else if (part === Selector.PROTOTYPE) {
+        out.push('^');
+      } else {
+        throw new TypeError('Invalid SpecialPart');
+      }
+    } else if (identifierRE.test(part)) {
+      out.push('.', part);
+    } else if (String(Number(part)) === part) {
+      // String represents a number with same string representation.
+      out.push('[', part, ']');
+    } else {
+      out.push('[', code.quote(part), ']');
+    }
+  }
+  return out.join('');
 };
 
-/** @typedef {string} */
+/**
+ * A Selector fundamentally an array of Parts, and Parts are either
+ * strings (representing variable or property names) or SpecialParts
+ * (representing everything else, like ^ for prottype.
+ * @typedef {string|!SpecialPart}
+ */
 Selector.Part;
 
+/**
+ * Type for all "special" selector parts (ones which do not represent
+ * named variables / properties).
+ * @constructor
+ */
+var SpecialPart = function(type) {
+  this.type = type;
+};
+
+/**
+ * Special singleton Part for refering to an object's prototype.
+ */
+Selector.PROTOTYPE = new SpecialPart('^');
 
 /**
  * Parse a selector into an array of Parts.
@@ -144,6 +185,9 @@ var parse = function(selector) {
           state = State.DOT;
         } else if (token.type === '[') {
           state = State.BRACKET;
+        } else if (token.type === '^') {
+          // state remains unchanged.
+          parts.push(Selector.PROTOTYPE);
         } else {
           throw new SyntaxError(
               'Invalid token ' + code.quote(token.raw)  + ' in selector');
@@ -211,6 +255,7 @@ var tokenize = function(selector) {
     number: /\d+/y,
     '[': /\[/y,
     ']': /\]/y,
+    '^': /\^/y,
     str: new RegExp(code.regexps.string, 'y'),
   };
   

--- a/server/selector.js
+++ b/server/selector.js
@@ -42,7 +42,11 @@ var Selector = function(s) {
     // Validate & copy parts list.
     if (typeof s.length < 1) throw new RangeError('Zero-length parts list??');
     if (s.length < 1) throw new RangeError('Zero-length parts list??');
-    for (var i = 0; i < s.length; i++) {
+    if (typeof s[0] !== 'string' || !identifierRE.test(s[0])) {
+      throw new TypeError('Parts array must begin with an identifier');
+    }
+    parts[0] = s[0];
+    for (var i = 1; i < s.length; i++) {
       if (typeof s[i] !== 'string' && !(s[i] instanceof SpecialPart)) {
         throw new TypeError('Invalid part in parts array');
       }

--- a/server/selector.js
+++ b/server/selector.js
@@ -160,7 +160,7 @@ Selector.prototype.toString = function(specialHandler) {
       if (specialHandler) {
         specialHandler(part, out);
       } else {
-        out.push('{', part.type, '}');
+        out.push(String(part));
       }
     } else if (identifierRE.test(part)) {
       out.push('.', part);
@@ -189,6 +189,11 @@ Selector.Part;
  */
 var SpecialPart = function(type) {
   this.type = type;
+};
+
+/** @override */
+SpecialPart.prototype.toString = function() {
+  return '{' + this.type + '}';
 };
 
 /**

--- a/server/selector.js
+++ b/server/selector.js
@@ -74,6 +74,24 @@ Selector.prototype.isVar = function() {
 };
 
 /**
+ * Returns true iff the selector represents an object property
+ * binding.
+ * @return {boolean} Is selector for a property?
+ */
+Selector.prototype.isProp = function() {
+  return this.length > 1 && typeof this[this.length - 1] === 'string';
+};
+
+/**
+ * Returns true iff the selector represents an object prototype
+ * binding.
+ * @return {boolean} Is selector for prototype?
+ */
+Selector.prototype.isProto = function() {
+  return this.length > 1 && this[this.length - 1] === Selector.PROTOTYPE;
+};
+
+/**
  * Return the selector as an evaluable expression yeilding the
  * selected value.
  * @return {string} The selector as a string.

--- a/server/tests/selector_test.js
+++ b/server/tests/selector_test.js
@@ -58,9 +58,9 @@ exports.testSelector = function(t) {
     ['foo["\'\\"\'"]', ['foo', "'\"'"], 'foo["\'\\"\'"]'],
     ['foo.bar.baz', ['foo', 'bar', 'baz'], 'foo.bar.baz'],
     ['$._.__.$$', ['$', '_', '__', '$$'], '$._.__.$$'],
-    ['foo^', ['foo', Selector.PROTOTYPE], 'foo^',
+    ['foo^', ['foo', Selector.PROTOTYPE], 'foo{proto}',
         'Object.getPrototypeOf(foo)', 'Object.setPrototypeOf(foo, NEW)'],
-    ['foo^.bar', ['foo', Selector.PROTOTYPE, 'bar'], 'foo^.bar',
+    ['foo{proto}.bar', ['foo', Selector.PROTOTYPE, 'bar'], 'foo{proto}.bar',
         'Object.getPrototypeOf(foo).bar',
         'Object.getPrototypeOf(foo).bar = NEW'],
   ];
@@ -97,8 +97,16 @@ exports.testSelector = function(t) {
     "foo['\"'\"']",
     'foo["\'"\'"]',
     'foo^bar',
+    '^.bar',
     ['1foo'],
+    '^',
+    '{proto}',
     [Selector.PROTOTYPE],
+    "foo['bar'}",
+    'foo{proto]',
+    'foo{proto',
+    'foo{blah}',
+    'foo{}',
   ];
   for (const input of invalidCases) {
     // Do test with selector string.

--- a/server/tests/selector_test.js
+++ b/server/tests/selector_test.js
@@ -60,6 +60,18 @@ exports.testSelector = function(t) {
 
     ['$._.__.$$', 4, '$', '$$', '$._.__.$$'],
     [['$', '_', '__', '$$'], 4, '$', '$$', '$._.__.$$'],
+
+    ['foo^', 2, 'foo', Selector.PROTOTYPE, 'foo^',
+        'Object.getPrototypeOf(foo)', 'Object.setPrototypeOf(foo, NEW)'],
+    [['foo', Selector.PROTOTYPE], 2, 'foo', Selector.PROTOTYPE, 'foo^',
+        'Object.getPrototypeOf(foo)', 'Object.setPrototypeOf(foo, NEW)'],
+
+    ['foo^.bar', 3, 'foo', 'bar', 'foo^.bar',
+        'Object.getPrototypeOf(foo).bar',
+        'Object.getPrototypeOf(foo).bar = NEW'],
+    [['foo', Selector.PROTOTYPE, 'bar'], 3, 'foo', 'bar', 'foo^.bar',
+        'Object.getPrototypeOf(foo).bar',
+        'Object.getPrototypeOf(foo).bar = NEW'],
   ];
   for (const tc of cases) {
     const s = new Selector(tc[0]);
@@ -68,7 +80,10 @@ exports.testSelector = function(t) {
     t.expect(name + '[0]', s[0], tc[2]);
     t.expect(name + '[/*last*/]', s[s.length - 1], tc[3]);
     t.expect(name + '.toString()', s.toString(), tc[4]);
-    t.expect(name + '.toExpr()', s.toExpr(), tc[4]);
+    const expr = tc[5] || tc[4];
+    t.expect(name + '.toExpr()', s.toExpr(), expr);
+    const setExpr = tc[6] || tc[4] + ' = NEW';
+    t.expect(name + '.toSetExpr()', s.toSetExpr('NEW'), setExpr);
   }
 };
 

--- a/server/tests/selector_test.js
+++ b/server/tests/selector_test.js
@@ -113,20 +113,22 @@ exports.testSelector = function(t) {
 };
 
 /**
- * Unit tests for Selector.prototype.isVar
+ * Unit tests for Selector.prototype.isVar / isProp / isProto
  * @param {!T} t The test runner object.
  */
-exports.testSelectorPrototypeIsVar = function(t) {
+exports.testSelectorPrototypeIsWhatever = function(t) {
   const cases = [
     // Test cases  of form [selector, isVar].
-    ['foo', true],
-    ['foo.bar', false],
-    ['foo^', false],
+    ['foo', true, false, false],
+    ['foo.bar', false, true, false],
+    ['foo^', false, false, true],
   ];
-  for (const [input, isVar] of cases) {
+  for (const [input, isVar, isProp, isProto] of cases) {
     const name = util.format('new Selector(%o)', input);
     const s = new Selector(input);
     t.expect(name + '.isVar()', s.isVar(), isVar);
+    t.expect(name + '.isProp()', s.isProp(), isProp);
+    t.expect(name + '.isProto()', s.isProto(), isProto);
   }
 };
 

--- a/server/tests/selector_test.js
+++ b/server/tests/selector_test.js
@@ -96,11 +96,11 @@ exports.testSelector = function(t) {
     'foo42]',
     "foo['\"'\"']",
     'foo["\'"\'"]',
-    'foo^.bar',
+    'foo^bar',
     ['1foo'],
     [Selector.PROTOTYPE],
   ];
-  for (const input of cases) {
+  for (const input of invalidCases) {
     // Do test with selector string.
     const name = util.format('new Selector(%o)', input);
     try {

--- a/server/tests/selector_test.js
+++ b/server/tests/selector_test.js
@@ -63,6 +63,11 @@ exports.testSelector = function(t) {
     ['foo{proto}.bar', ['foo', Selector.PROTOTYPE, 'bar'], 'foo{proto}.bar',
         'Object.getPrototypeOf(foo).bar',
         'Object.getPrototypeOf(foo).bar = NEW'],
+    ['foo{owner}', ['foo', Selector.OWNER], 'foo{owner}',
+        'Object.getOwnerOf(foo)', 'Object.setOwnerOf(foo, NEW)'],
+    ['foo{owner}.bar', ['foo', Selector.OWNER, 'bar'], 'foo{owner}.bar',
+        'Object.getOwnerOf(foo).bar',
+        'Object.getOwnerOf(foo).bar = NEW'],
   ];
   for (const [input, parts, str, expr, setExpr] of cases) {
     // Do test with selector string.
@@ -94,6 +99,7 @@ exports.testSelector = function(t) {
     'foo.[42]',
     'foo[42',
     'foo42]',
+    'foo[42}',
     "foo['\"'\"']",
     'foo["\'"\'"]',
     'foo^bar',
@@ -105,8 +111,11 @@ exports.testSelector = function(t) {
     "foo['bar'}",
     'foo{proto]',
     'foo{proto',
+    'foo.proto}',
     'foo{blah}',
     'foo{}',
+    '{owner}',
+    [Selector.OWNER],
   ];
   for (const input of invalidCases) {
     // Do test with selector string.
@@ -127,16 +136,19 @@ exports.testSelector = function(t) {
 exports.testSelectorPrototypeIsWhatever = function(t) {
   const cases = [
     // Test cases  of form [selector, isVar].
-    ['foo', true, false, false],
-    ['foo.bar', false, true, false],
-    ['foo^', false, false, true],
+    ['foo', true, false, false, false],
+    ['foo.bar', false, true, false, false],
+    ['foo^', false, false, true, false],
+    ['foo{proto}', false, false, true, false],
+    ['foo{owner}', false, false, false, true],
   ];
-  for (const [input, isVar, isProp, isProto] of cases) {
+  for (const [input, isVar, isProp, isProto, isOwner] of cases) {
     const name = util.format('new Selector(%o)', input);
     const s = new Selector(input);
     t.expect(name + '.isVar()', s.isVar(), isVar);
     t.expect(name + '.isProp()', s.isProp(), isProp);
     t.expect(name + '.isProto()', s.isProto(), isProto);
+    t.expect(name + '.isOwner()', s.isOwner(), isOwner);
   }
 };
 

--- a/server/tests/selector_test.js
+++ b/server/tests/selector_test.js
@@ -112,3 +112,21 @@ exports.testSelector = function(t) {
   }
 };
 
+/**
+ * Unit tests for Selector.prototype.isVar
+ * @param {!T} t The test runner object.
+ */
+exports.testSelectorPrototypeIsVar = function(t) {
+  const cases = [
+    // Test cases  of form [selector, isVar].
+    ['foo', true],
+    ['foo.bar', false],
+    ['foo^', false],
+  ];
+  for (const [input, isVar] of cases) {
+    const name = util.format('new Selector(%o)', input);
+    const s = new Selector(input);
+    t.expect(name + '.isVar()', s.isVar(), isVar);
+  }
+};
+

--- a/server/tests/selector_test.js
+++ b/server/tests/selector_test.js
@@ -97,6 +97,8 @@ exports.testSelector = function(t) {
     "foo['\"'\"']",
     'foo["\'"\'"]',
     'foo^.bar',
+    ['1foo'],
+    [Selector.PROTOTYPE],
   ];
   for (const input of cases) {
     // Do test with selector string.

--- a/server/tests/selector_test.js
+++ b/server/tests/selector_test.js
@@ -85,5 +85,28 @@ exports.testSelector = function(t) {
     t.expect(name + '.toExpr()', s.toExpr(), expectedExpr);
     t.expect(name + '.toSetExpr()', s.toSetExpr('NEW'), expectedSetExpr);
   }
+
+  const invalidCases = [
+    '1foo',
+    'foo.',
+    'foo["bar]',
+    "foo[bar']",
+    'foo.[42]',
+    'foo[42',
+    'foo42]',
+    "foo['\"'\"']",
+    'foo["\'"\'"]',
+    'foo^.bar',
+  ];
+  for (const input of cases) {
+    // Do test with selector string.
+    const name = util.format('new Selector(%o)', input);
+    try {
+      new Selector(input);
+      t.fail(name, "didn't throw");
+    } catch (e) {
+      t.pass(name);
+    }
+  }
 };
 


### PR DESCRIPTION
Also supports `^` as a synonym for `{proto}`.