### PR TITLE
Impement stack size limit

### DIFF
--- a/server/codecity.js
+++ b/server/codecity.js
@@ -66,6 +66,7 @@ CodeCity.startup = function(configFile) {
     trimEval: true,
     trimProgram: true,
     methodNames: true,
+    stackLimit: 10000,
   });
   CodeCity.initSystemFunctions();
   if (checkpoint) {

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -3093,6 +3093,7 @@ Interpreter.FunctionResult.Sleep = new Interpreter.FunctionResult;
  *     noLog: (!Array<string>|undefined),
  *     trimEval: (boolean|undefined),
  *     trimProgram: (boolean|undefined),
+ *     stackLimit: (number|undefined),
  * }}
  */
 Interpreter.Options;
@@ -5959,6 +5960,10 @@ stepFuncs_['Call'] = function (thread, stack, state, node) {
    */
   if (state.step_ === 0) {  // Done evaluating arguments; do function call.
     state.step_ = 1;
+    if (this.options.stackLimit && stack.length > this.options.stackLimit) {
+      throw new this.Error(state.scope.perms, this.RANGE_ERROR,
+          'Maximum call stack size exceeded');
+    }
     var func = state.info_.func;
     var args = state.info_.arguments;
     var r =

--- a/server/tests/interpreter_common.js
+++ b/server/tests/interpreter_common.js
@@ -47,6 +47,7 @@ exports.getInterpreter = function(options, init) {
     noLog: ['net', 'unhandled'],
     trimEval: true,
     trimProgram: true,
+    stackLimit: 1000,  // Fairly small to speed stack-overflow tests.
   };
   var intrp = new Interpreter(options);
   if (init || init === undefined) {

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2820,4 +2820,27 @@ module.exports = [
     `,
     expected: 'pass' },
 
+  { name: 'Stack overflow errors', src: `
+    try {
+      (function f() {f();})();
+    } catch (e) {
+      e.name;
+    }
+    `,
+    expected: 'RangeError'
+  },
+
+  { name: 'Minimum stack depth limit', src: `
+    function f() {
+      try {
+        return f() + 1;
+      } catch (e) {
+        return 1;
+      }
+    }
+    var limit = f();
+    limit > 100 ? 'OK' : limit;
+    `,
+    expected: 'OK'
+  },
 ];


### PR DESCRIPTION
This limit is enforced only when a (native or user) Function is called, because we don't want to pester user with stack errors just because nested statements/expressions have taken them slightly over the limit.

RangeError is throw, for compatibility with Node.js - though we may want to implement a custom subclass of RangeError to make it easier for user code to detect this particular kind of error.