### PR TITLE
Implement time limit

### DIFF
--- a/demo/core_10_base.js
+++ b/demo/core_10_base.js
@@ -632,11 +632,9 @@ $.connection.onReceive = function(text) {
   this.buffer += text.replace(/\r/g, '');
   var lf;
   while ((lf = this.buffer.indexOf('\n')) !== -1) {
-    try {
-      this.onReceiveLine(this.buffer.substring(0, lf));
-    } finally {
-      this.buffer = this.buffer.substring(lf + 1);
-    }
+    var line = this.buffer.substring(0, lf);
+    this.buffer = this.buffer.substring(lf + 1);
+    this.onReceiveLine(line);
   }
 };
 
@@ -667,6 +665,8 @@ $.servers.telnet.onReceiveLine = function(text) {
     return;
   }
   // Remainder of function handles login.
+  // TODO(fraser): Make sure that no security issues exist due to
+  // called code suspending or timing out unexpectedly.
   var m = text.match(/identify as ([0-9a-f]+)/);
   if (!m) {
     this.write('{type: "narrate", text: "Unknown command: ' +

--- a/demo/core_90_world.js
+++ b/demo/core_90_world.js
@@ -146,6 +146,6 @@
   $.fido = fido;
   $.utils.selector.setSelector(fido, '$.fido');
 
-  $.system.connectionListen(7777, $.servers.telnet);
-  $.system.connectionListen(7780, $.servers.http.connection);
+  $.system.connectionListen(7777, $.servers.telnet, 100);
+  $.system.connectionListen(7780, $.servers.http.connection, 100);
 })();

--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -2236,7 +2236,7 @@ Interpreter.prototype.initThread_ = function() {
    * @return {!Interpreter.NativeCallImpl} The decorated function.)
    */
   var withChecks = function(func) {
-    name = (name === undefined ? func.name : name);
+    name = (name === undefined) ? func.name : name;
     return function call(intrp, thred, state, thisVal, args) {
       // TODO(cpcallen:perms): add controls()-type and/or
       // object-readability check(s) here.
@@ -2271,7 +2271,7 @@ Interpreter.prototype.initThread_ = function() {
       var old = thisVal.thread.timeLimit || Number.MAX_VALUE;
       if (typeof limit !== 'number' || Number.isNaN(limit)) {
         throw new intrp.Error(perms, intrp.TYPE_ERROR,
-        'new limit must be a number (and not NaN)');
+            'new limit must be a number (and not NaN)');
       } else if (limit <= 0) {
         throw new intrp.Error(perms, intrp.RANGE_ERROR,
             'new limit must be > 0');
@@ -2938,6 +2938,7 @@ Interpreter.prototype.setValue = function(ref, value, perms) {
 /**
  * Check to see if the current thread has run too long.  Called at the
  * top of loops and before making function calls.
+ * @private
  * @param {!Interpreter.Owner} perms Perm to use to create Error object.
  * @param {!Array<Interpreter.State>=} stack Current State stack.  If
  *   supplied, it will be popped to remove top item (e.g.: Call state)

--- a/server/startup/esx.js
+++ b/server/startup/esx.js
@@ -70,7 +70,9 @@ var PermissionError = new 'PermissionError';
 
   var struct = [
     [Object, 'Object', ['getOwnerOf', 'setOwnerOf'], []],
-    [Thread, 'Thread', ['current', 'kill', 'suspend', 'callers'], []],
+    [Thread, 'Thread',
+     ['current', 'kill', 'suspend', 'callers'],
+     ['getTimeLimit', 'setTimeLimit']],
   ];
   for (var i = 0; i < struct.length; i++) {
     var obj = struct[i][0];

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -95,13 +95,13 @@ module.exports = [
     expected: 45 },
 
   { name: 'getPropertyOnPrimitive', src: `
-    "foo".length;
+    'foo'.length;
     `,
     expected: 3 },
 
   { name: 'setPropertyOnPrimitive', src: `
     try {
-      "foo".bar = 42;
+      'foo'.bar = 42;
     } catch (e) {
       e.name;
     }
@@ -825,7 +825,7 @@ module.exports = [
       e.name;
     }
     `,
-    expected: "TypeError" },
+    expected: 'TypeError' },
 
   { name: 'funcDecl', src: `
     var v;
@@ -1069,7 +1069,7 @@ module.exports = [
     expected: undefined },
 
   { name: 'callEvalOrder', src: `
-    var r = "";
+    var r = '';
     function log(x) {
       r += x;
       return function () {};
@@ -1640,7 +1640,7 @@ module.exports = [
   { name: 'Function.prototype.apply(..., sparse)', src: `
     (function(a, b, c) {
       if (!(1 in arguments)) {
-        throw new Error("Argument 1 missing");
+        throw new Error('Argument 1 missing');
       }
       return a + c;
     }).apply(undefined, [1, , 3]);
@@ -1688,7 +1688,7 @@ module.exports = [
   { name: 'Function.prototype.call', src: `
     (function(a, b, c) {
       if (!(1 in arguments)) {
-        throw new Error("Argument 1 missing");
+        throw new Error('Argument 1 missing');
       }
       return a + c;
     }).call(undefined, 1, 2, 3);
@@ -2734,7 +2734,7 @@ module.exports = [
   // Check invalid time limits are rejected.
   { name: 'Thread.prototype.setTimeLimit(/* invalid value */) throws', src: `
     Thread.current().setTimeLimit(1000);
-    var invalid = [0, 1001, NaN, "foo", true, {}];
+    var invalid = [0, 1001, NaN, 'foo', true, {}];
     var failures = [];
     for (var i = 0; i < invalid.length; i++) {
       try {
@@ -2761,7 +2761,7 @@ module.exports = [
     CC.root.name = 'Root';
     var bob = {};
     bob.name = 'Bob';
-    var r = "";
+    var r = '';
     r += perms().name;
     (function() {
       setPerms(bob);
@@ -2770,7 +2770,7 @@ module.exports = [
     })();
     r += perms().name;
     r;`,
-    expected: "RootBobRoot"
+    expected: 'RootBobRoot'
   },
 
   { name: 'getOwnerOf', src: `

--- a/server/tests/testcases.js
+++ b/server/tests/testcases.js
@@ -2711,6 +2711,42 @@ module.exports = [
     `,
     expected: 'user' },
 
+  // Time limit tests.  Actual enforcement is tested in
+  // interpreter_tests.js; this is just checking behaviour of get/set
+  // builtins.
+  { name: 'Thread.prototype.getTimeLimit() initially 0', src: `
+    Thread.current().getTimeLimit();
+    `,
+    expected: 0 },
+
+  { name: 'Thread.prototype.setTimeLimit()', src: `
+    Thread.current().setTimeLimit(1000);
+    Thread.current().getTimeLimit();
+    `,
+    expected: 1000 },
+
+  { name: 'Thread.prototype.setTimeLimit(...)', src: `
+    Thread.current().setTimeLimit(1000);
+    Thread.current().getTimeLimit();
+    `,
+    expected: 1000 },
+
+  // Check invalid time limits are rejected.
+  { name: 'Thread.prototype.setTimeLimit(/* invalid value */) throws', src: `
+    Thread.current().setTimeLimit(1000);
+    var invalid = [0, 1001, NaN, "foo", true, {}];
+    var failures = [];
+    for (var i = 0; i < invalid.length; i++) {
+      try {
+        Thread.current().setTimeLimit(invalid[i]);
+        failures.push(invalid[i]);
+      } catch (e) {
+      }
+    }
+    (failures.length === 0) ? 'OK' : String(failures);
+    `,
+    expected: 'OK' },
+
   /////////////////////////////////////////////////////////////////////////////
   // Permissions system:
 


### PR DESCRIPTION
It's not exactly polished, and as discussed we probably want a (more restrictive) tick limit too, but these commits implement a 100ms time limit on all code run by the web and telnet servers, which can be adjusted by un-listening and then re-listening with a different timeLimit value.

