### PR TITLE
Fix Error constructor wrong-prototype bug

### DIFF
--- a/server/interpreter.js
+++ b/server/interpreter.js
@@ -1969,7 +1969,7 @@ Interpreter.prototype.initRegExp_ = function() {
 Interpreter.prototype.initError_ = function() {
   var intrp = this;
 
-  var createErrorClass = function(name) {
+  var createErrorClass = function(name, protoKey) {
     var protoproto = name === 'Error' ? intrp.OBJECT : intrp.ERROR;
     var proto = new intrp.Error(intrp.ROOT, protoproto);
     intrp.builtins.set(name + '.prototype', proto);
@@ -1979,7 +1979,10 @@ Interpreter.prototype.initError_ = function() {
       construct: function(intrp, thread, state, args) {
         var message = (args[0] === undefined) ? undefined : String(args[0]);
         var perms = state.scope.perms;
-        var err = new intrp.Error(perms, proto, message);
+        // Use intrp[protoKey] instead of proto because
+        // deserialisation will set up intrp.ERROR et al correctly but
+        // can't modify values of variables in native closures.
+        var err = new intrp.Error(perms, intrp[protoKey], message);
         err.makeStack(thread.callers(perms).slice(1), perms);
         return err;
       },
@@ -1991,14 +1994,14 @@ Interpreter.prototype.initError_ = function() {
     return proto;
   };
 
-  this.ERROR = createErrorClass('Error');  // Must be first!
-  this.EVAL_ERROR = createErrorClass('EvalError');
-  this.RANGE_ERROR = createErrorClass('RangeError');
-  this.REFERENCE_ERROR = createErrorClass('ReferenceError');
-  this.SYNTAX_ERROR = createErrorClass('SyntaxError');
-  this.TYPE_ERROR = createErrorClass('TypeError');
-  this.URI_ERROR = createErrorClass('URIError');
-  this.PERM_ERROR = createErrorClass('PermissionError');
+  intrp.ERROR = createErrorClass('Error', 'ERROR');  // Must be first!
+  intrp.EVAL_ERROR = createErrorClass('EvalError', 'EVAL_ERROR');
+  intrp.RANGE_ERROR = createErrorClass('RangeError', 'RANGE_ERROR');
+  intrp.REFERENCE_ERROR = createErrorClass('ReferenceError', 'REFERENCE_ERROR');
+  intrp.SYNTAX_ERROR = createErrorClass('SyntaxError', 'SYNTAX_ERROR');
+  intrp.TYPE_ERROR = createErrorClass('TypeError', 'TYPE_ERROR');
+  intrp.URI_ERROR = createErrorClass('URIError', 'URI_ERROR');
+  intrp.PERM_ERROR = createErrorClass('PermissionError', 'PERM_ERROR');
 
   this.createNativeFunction('Error.prototype.toString',
                             this.Error.prototype.toString, false);


### PR DESCRIPTION
Invoking an error constructor after deserialisation caused the resulting error objects to have an incorrect prototpye chain: the prototype would be the <Foo>Error.prototype object created by the (second) Interpreter constructor rather than the object deserialised from disk (and this object and its prototypes would have no properties since the startup .js files hadn't ever been run on that Interpreter).

The root cause of this was that the constructors were using the proto object captured in a closure at the time of the constructor's construction, rather than using intrp.ERROR etc.

The solution is to use intrp.ERROR et al.  This patch does that, albeit in a sub-optimal way, mixing usage of intrp.ERROR and intrp['ERROR'], which would break if we used JS Compiler output.  Since we only use the compiler for type-checking, we can get away with it.

Better implementation suggestions welcome.

Not yet tested to verify compatibility with dogfood `.city` file, but plan is to do said test, push to `prod` branch, tag as dogfood-1.0.1 (or the like) and push to `google.codecity.world`.