### PR TITLE
Compare round-tripped data for changes.

### DIFF
--- a/static/code/editor.js
+++ b/static/code/editor.js
@@ -446,7 +446,7 @@ Code.Editor.setSourceToAllEditors = function(src) {
   for (var editor of Code.Editor.editors) {
     editor.setSource(src);
     // Round-trip version of the source.
-    editor.lastSavedSource = editor.getSource();
+    editor.unmodifiedSource = editor.getSource();
   }
 };
 
@@ -650,7 +650,7 @@ Code.GenericEditor = function(name) {
    * Plain text representation of this editor's contents as of load or last save.
    * @type {?string}
    */
-  this.lastSavedSource = null;
+  this.unmodifiedSource = null;
 
   // Register this editor.
   Code.Editor.editors.push(this);
@@ -686,7 +686,7 @@ Code.GenericEditor.prototype.setSource = function(source) {
  * @return {boolean} True if work is saved.
  */
 Code.GenericEditor.prototype.isSaved = function() {
-  return this.getSource() === this.lastSavedSource;
+  return this.getSource() === this.unmodifiedSource;
 };
 
 /**

--- a/static/code/editor.js
+++ b/static/code/editor.js
@@ -286,7 +286,7 @@ Code.Editor.tabClick = function(e) {
     editor.created = true;
   }
   container.style.display = 'block';
-  Code.Editor.setSourceToAllEditors(Code.Editor.currentSource, false);
+  Code.Editor.setSourceToAllEditors(Code.Editor.currentSource);
   // If e is an event, then this click is the result of a user's direct action.
   // If not, then it's a fake event as a result of page load.
   var userAction = e instanceof Event;
@@ -344,7 +344,7 @@ Code.Editor.receiveXhr = function() {
     // or b) the previous save was successful.
     if (Code.Editor.currentSource === null || data.saved) {
       Code.Editor.currentSource = data.src;
-      Code.Editor.setSourceToAllEditors(data.src, true);
+      Code.Editor.setSourceToAllEditors(data.src);
     }
   }
   // Remove saving mask.
@@ -440,15 +440,13 @@ Code.Editor.mostConfidentEditor = function() {
 /**
  * Set the values of all the editors.
  * @param {string} src Plain text contents.
- * @param {boolean} isSaved True if this is the saved source.
  */
-Code.Editor.setSourceToAllEditors = function(src, isSaved) {
+Code.Editor.setSourceToAllEditors = function(src) {
   Code.Editor.uncreatedEditorSource = src;
   for (var editor of Code.Editor.editors) {
     editor.setSource(src);
-    if (isSaved) {
-      editor.lastSavedSource = editor.getSource();
-    }
+    // Round-trip version of the source.
+    editor.lastSavedSource = editor.getSource();
   }
 };
 


### PR DESCRIPTION
Clicking on an incompatible editor should not nullify the data.