### PR TITLE
Add missing preposition "out of/from inside/from"

### DIFF
--- a/static/code/editor.js
+++ b/static/code/editor.js
@@ -793,6 +793,7 @@ Code.functionEditor.createDom = function(container) {
     <option>in front of</option>
     <option>in/inside/into</option>
     <option>on top of/on/onto/upon</option>
+    <option>out of/from inside/from</option>
     <option>over</option>
     <option>through</option>
     <option>under/underneath/beneath</option>


### PR DESCRIPTION
For some reason this preposition was (mostly) missing from the core and from the function editor.